### PR TITLE
feat: add common Dropdown component

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,7 @@
 import type { Preview } from '@storybook/react-vite'
 
+import '../src/index.css'
+
 const preview: Preview = {
   parameters: {
     controls: {

--- a/src/components/common/dropdown/Dropdown.stories.tsx
+++ b/src/components/common/dropdown/Dropdown.stories.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Dropdown } from './Dropdown'
+
+const meta: Meta<typeof Dropdown> = {
+  component: Dropdown,
+  title: 'Common/Dropdown',
+  parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj<typeof Dropdown>
+
+const reportOptions = [
+  { value: 'spam', label: '스팸' },
+  { value: 'abuse', label: '욕설/비방' },
+  { value: 'test', label: '테스트' },
+  { value: 'etc', label: '기타' },
+]
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('')
+    return (
+      <div className="w-[340px]">
+        <Dropdown options={reportOptions} value={value} onChange={setValue} />
+      </div>
+    )
+  },
+}

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useState } from 'react'
+
+import { cva } from 'class-variance-authority'
+import { ChevronDown } from 'lucide-react'
+
+import { useOutsideClick } from '@/hooks/useOutsideClick'
+import { cn } from '@/utils/cn'
+
+const ITEM_HEIGHT = 53
+const MAX_VISIBLE_ITEMS = 4
+const LIST_MAX_HEIGHT = ITEM_HEIGHT * MAX_VISIBLE_ITEMS
+
+const dropdownTriggerVariants = cva(
+  'flex w-full items-center justify-between border border-[#E2E2E2] bg-white text-[14px] text-gray-400 transition-colors cursor-pointer',
+  {
+    variants: {
+      size: {
+        md: 'rounded-[4px] px-[16px] py-[10px]',
+        // 추가 가능
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+)
+
+const dropdownListVariants = cva(
+  'absolute left-0 right-0 z-10 mt-[8px] overflow-hidden bg-white',
+  {
+    variants: {
+      size: {
+        sm: 'rounded-[6px] ',
+        md: 'rounded-[12px] p-[6px]',
+        lg: 'rounded-[9999px]',
+      },
+      shadow: {
+        sm: 'shadow-[0_2px_10px_rgba(0,0,0,0.1)]',
+        md: 'shadow-[0_4px_10px_rgba(0,0,0,0.25)]',
+        lg: 'shadow-[0_8px_24px_rgba(0,0,0,0.2)]',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+      shadow: 'md',
+    },
+  }
+)
+
+export type DropdownOption = {
+  value: string
+  label: string
+}
+
+type DropdownProps = {
+  options: DropdownOption[]
+  placeholder?: string
+  size?: 'md' // 추가 가능
+  value?: string
+  onChange?: (value: string) => void
+}
+
+export function Dropdown({
+  options,
+  placeholder = '해당되는 항목을 선택해 주세요.',
+  size = 'md',
+  value,
+  onChange,
+}: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isClosing, setIsClosing] = useState(false)
+
+  const close = useCallback(() => {
+    if (!isOpen) return
+    setIsClosing(true)
+  }, [isOpen])
+  const ref = useOutsideClick<HTMLDivElement>(close)
+
+  const handleAnimationEnd = () => {
+    if (isClosing) {
+      setIsClosing(false)
+      setIsOpen(false)
+    }
+  }
+
+  const selectedLabel = options.find((opt) => opt.value === value)?.label
+
+  return (
+    <div ref={ref} className="relative w-full min-w-[250px]">
+      {/* TODO: 버튼 공통 컴포넌트 만들면 적용 */}
+      <button
+        type="button"
+        onClick={() => (isOpen ? close() : setIsOpen(true))}
+        className={cn(
+          dropdownTriggerVariants({ size }),
+          (isOpen || value) && 'border-[#3C7DFF]',
+          value && 'text-gray-900 cursor-pointer'
+        )}
+      >
+        <span>{selectedLabel ?? placeholder}</span>
+        <ChevronDown
+          size={16}
+          stroke="#555"
+          strokeWidth={1.5}
+          className={cn(
+            'transition-transform duration-200',
+            isOpen && 'rotate-180'
+          )}
+        />
+      </button>
+
+      {(isOpen || isClosing) && (
+        <ul
+          className={cn(
+            dropdownListVariants({ size }),
+            isClosing
+              ? 'animate-[dropdown-out_0.2s_ease-in_forwards]'
+              : 'animate-[dropdown-in_0.2s_ease-out]'
+          )}
+          onAnimationEnd={handleAnimationEnd}
+        >
+          <div
+            style={{ maxHeight: LIST_MAX_HEIGHT }}
+            className="overflow-y-auto"
+          >
+            {options.map((opt) => (
+              <li key={opt.value}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onChange?.(opt.value)
+                    close()
+                  }}
+                  className={cn(
+                    'w-full p-[16px] text-left text-[14px] rounded-[4px] transition-colors cursor-pointer',
+                    value === opt.value
+                      ? 'bg-[#1675F9] text-white'
+                      : 'hover:bg-[#C3DBFF]/21 hover:text-[#1B57FF] hover:font-semibold'
+                  )}
+                >
+                  {opt.label}
+                </button>
+              </li>
+            ))}
+          </div>
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -11,7 +11,7 @@ const MAX_VISIBLE_ITEMS = 4
 const LIST_MAX_HEIGHT = ITEM_HEIGHT * MAX_VISIBLE_ITEMS
 
 const dropdownTriggerVariants = cva(
-  'flex w-full items-center justify-between border border-[#E2E2E2] bg-white text-[14px] text-gray-400 transition-colors cursor-pointer',
+  'flex w-full items-center justify-between border border-gray-200 bg-white text-[14px] text-gray-400 transition-colors cursor-pointer',
   {
     variants: {
       size: {
@@ -35,9 +35,9 @@ const dropdownListVariants = cva(
         lg: 'rounded-[9999px]',
       },
       shadow: {
-        sm: 'shadow-[0_2px_10px_rgba(0,0,0,0.1)]',
-        md: 'shadow-[0_4px_10px_rgba(0,0,0,0.25)]',
-        lg: 'shadow-[0_8px_24px_rgba(0,0,0,0.2)]',
+        sm: 'shadow-card-main',
+        md: 'shadow-card-light',
+        lg: 'shadow-card-hover',
       },
     },
     defaultVariants: {
@@ -93,17 +93,16 @@ export function Dropdown({
         onClick={() => (isOpen ? close() : setIsOpen(true))}
         className={cn(
           dropdownTriggerVariants({ size }),
-          (isOpen || value) && 'border-[#3C7DFF]',
+          (isOpen || value) && 'border-border-active',
           value && 'text-gray-900 cursor-pointer'
         )}
       >
         <span>{selectedLabel ?? placeholder}</span>
         <ChevronDown
           size={16}
-          stroke="#555"
           strokeWidth={1.5}
           className={cn(
-            'transition-transform duration-200',
+            'text-gray-700 transition-transform duration-200',
             isOpen && 'rotate-180'
           )}
         />
@@ -134,8 +133,8 @@ export function Dropdown({
                   className={cn(
                     'w-full p-[16px] text-left text-[14px] rounded-[4px] transition-colors cursor-pointer',
                     value === opt.value
-                      ? 'bg-[#1675F9] text-white'
-                      : 'hover:bg-[#C3DBFF]/21 hover:text-[#1B57FF] hover:font-semibold'
+                      ? 'bg-primary-500 text-white'
+                      : 'hover:bg-primary-100/21 hover:text-primary-600 hover:font-semibold'
                   )}
                 >
                   {opt.label}

--- a/src/components/common/dropdown/action-menu/ActionMenu.stories.tsx
+++ b/src/components/common/dropdown/action-menu/ActionMenu.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { ActionMenu } from './ActionMenu'
+
+const meta: Meta<typeof ActionMenu> = {
+  component: ActionMenu,
+  title: 'Common/ActionMenu',
+  parameters: { layout: 'centered' },
+  argTypes: {
+    align: {
+      control: 'radio',
+      options: ['left', 'right'],
+    },
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof ActionMenu>
+
+const DotsIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <circle cx="8" cy="2" r="1.5" fill="#555" />
+    <circle cx="8" cy="8" r="1.5" fill="#555" />
+    <circle cx="8" cy="14" r="1.5" fill="#555" />
+  </svg>
+)
+
+export const MyPage: Story = {
+  args: {
+    trigger: <DotsIcon />,
+    align: 'right',
+    items: [
+      { label: '마이페이지', onClick: () => {} },
+      { label: '프로필 수정', onClick: () => {} },
+      { label: '로그아웃', onClick: () => {} },
+      { label: '회원탈퇴', onClick: () => {} },
+    ],
+  },
+}
+
+export const PostActions: Story = {
+  args: {
+    trigger: <DotsIcon />,
+    align: 'right',
+    items: [
+      { label: '수정', onClick: () => {} },
+      { label: '삭제', onClick: () => {} },
+      { label: '신고', onClick: () => {} },
+    ],
+  },
+}

--- a/src/components/common/dropdown/action-menu/ActionMenu.stories.tsx
+++ b/src/components/common/dropdown/action-menu/ActionMenu.stories.tsx
@@ -27,7 +27,6 @@ const DotsIcon = () => (
 
 export const MyPage: Story = {
   args: {
-    trigger: <DotsIcon />,
     align: 'right',
     items: [
       { label: '마이페이지', onClick: () => {} },
@@ -36,11 +35,11 @@ export const MyPage: Story = {
       { label: '회원탈퇴', onClick: () => {} },
     ],
   },
+  render: (args) => <ActionMenu {...args} trigger={<DotsIcon />} />,
 }
 
 export const PostActions: Story = {
   args: {
-    trigger: <DotsIcon />,
     align: 'right',
     items: [
       { label: '수정', onClick: () => {} },
@@ -48,4 +47,5 @@ export const PostActions: Story = {
       { label: '신고', onClick: () => {} },
     ],
   },
+  render: (args) => <ActionMenu {...args} trigger={<DotsIcon />} />,
 }

--- a/src/components/common/dropdown/action-menu/ActionMenu.tsx
+++ b/src/components/common/dropdown/action-menu/ActionMenu.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useState } from 'react'
+
+import { useOutsideClick } from '../../../../hooks/useOutsideClick'
+import { cn } from '../../../../utils/cn'
+
+type ActionMenuItem = {
+  label: string
+  onClick: () => void
+}
+
+type ActionMenuProps = {
+  trigger: React.ReactNode
+  items: ActionMenuItem[]
+  align?: 'left' | 'right'
+}
+
+export function ActionMenu({
+  trigger,
+  items,
+  align = 'right',
+}: ActionMenuProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isClosing, setIsClosing] = useState(false)
+
+  const close = useCallback(() => {
+    if (!isOpen) return
+    setIsClosing(true)
+  }, [isOpen])
+
+  const ref = useOutsideClick<HTMLDivElement>(close)
+
+  const handleAnimationEnd = () => {
+    if (isClosing) {
+      setIsClosing(false)
+      setIsOpen(false)
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => (isOpen ? close() : setIsOpen(true))}
+        className="cursor-pointer"
+        aria-label="메뉴 열기"
+      >
+        {trigger}
+      </button>
+
+      {(isOpen || isClosing) && (
+        <ul
+          className={cn(
+            'absolute z-10 mt-1 min-w-[100px] rounded-[12px] shadow-card-main px-[16px] py-[14px]',
+            align === 'right' ? 'right-0' : 'left-0',
+            isClosing
+              ? 'animate-[dropdown-out_0.2s_ease-in_forwards]'
+              : 'animate-[dropdown-in_0.2s_ease-out]'
+          )}
+          onAnimationEnd={handleAnimationEnd}
+        >
+          {items.map(({ label, onClick }) => (
+            <li key={label}>
+              <button
+                type="button"
+                onClick={() => {
+                  onClick()
+                  close()
+                }}
+                className="w-full px-[6px] py-[3px] text-center text-[12px] rounded-[4px] cursor-pointer hover:bg-[#C3DBFF]/21 hover:text-[#1B57FF] hover:font-semibold"
+              >
+                {label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/common/dropdown/action-menu/index.ts
+++ b/src/components/common/dropdown/action-menu/index.ts
@@ -1,0 +1,1 @@
+export { ActionMenu } from './ActionMenu'

--- a/src/components/common/dropdown/index.ts
+++ b/src/components/common/dropdown/index.ts
@@ -1,0 +1,2 @@
+export type { DropdownOption } from './Dropdown'
+export { Dropdown } from './Dropdown'

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react'
+
+export function useOutsideClick<T extends HTMLElement>(callback: () => void) {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        callback()
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [callback])
+
+  return ref
+}

--- a/src/index.css
+++ b/src/index.css
@@ -289,3 +289,25 @@ body {
   --shadow-modal: var(--shadow-modal);
   --shadow-ranking: var(--ranking-shadow);
 }
+
+@keyframes dropdown-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes dropdown-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+/// <reference types="vite-plugin-svgr/client" />

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,7 @@
     "target": "es2023",
     "lib": ["ES2023"],
     "module": "esnext",
-    "types": ["node"],
+    "types": ["node", "vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## 📌 관련 이슈

Closes #12 

## ✨ 변경 내용

- Dropdown / ActionMenu 공통 컴포넌트 구현 — useOutsideClick 훅으로 외부 클릭 감지, 열림/닫힘 애니메이션 적용  
- 디자인 토큰 및 lucide-react 아이콘 적용 — 하드코딩된 색상값을 index.css 디자인 토큰으로 교체, 화살표 SVG를 아이콘으로 대체                            
 - Storybook 스토리 작성 — Dropdown 테스트 가능 , ActionMenu는 align prop(left / right)을 Controls 패널에서 테스트 가능   

## 📸 스크린샷(선택)


https://github.com/user-attachments/assets/48d72433-4122-4ccb-a8cc-0c019e7c0c03


## 📚 참고사항
pnpm storybook으로 테스트 가능합니다.
ActionMenu는 Props로 메뉴가 트리거될 react 요소를 추가하여야합니다. ex) 사용자 아이콘 , ... 아이콘
Button 컴포넌트가 작성이 되면 작성해두었던 button 태그에 적용 시킬 예정입니다.