### PR TITLE
feat: add common badge component

### DIFF
--- a/src/components/common/badge/Badge.stories.tsx
+++ b/src/components/common/badge/Badge.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Badge } from './Badge'
+
+const meta: Meta<typeof Badge> = {
+  title: 'Common/Badge',
+  component: Badge,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof Badge>
+
+export const Success: Story = {
+  args: {
+    children: '완료',
+    variant: 'success',
+  },
+}
+
+export const Warning: Story = {
+  args: {
+    children: '진행중',
+    variant: 'warning',
+  },
+}
+
+export const Error: Story = {
+  args: {
+    children: '미달성',
+    variant: 'error',
+  },
+}

--- a/src/components/common/badge/Badge.tsx
+++ b/src/components/common/badge/Badge.tsx
@@ -1,0 +1,27 @@
+import type { HTMLAttributes } from 'react'
+
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/utils/cn'
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center min-w-[68px] rounded-[9999px] px-[18px] py-[8px] text-[12px] font-semibold whitespace-nowrap',
+  {
+    variants: {
+      variant: {
+        success: 'bg-[#EAFBF3] text-[#75B965]',
+        warning: 'bg-[#FFEEE2] text-[#FF5550]',
+        error: 'bg-[#F1F0FF] text-[#845FFF]',
+      },
+    },
+  }
+)
+
+export type BadgeProps = HTMLAttributes<HTMLSpanElement> &
+  VariantProps<typeof badgeVariants>
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}

--- a/src/components/common/badge/index.ts
+++ b/src/components/common/badge/index.ts
@@ -1,0 +1,2 @@
+export type { BadgeProps } from './Badge'
+export { Badge } from './Badge'


### PR DESCRIPTION
## 📌 관련 이슈

Closes #15

---

## ✨ 변경 내용

* 공통 Badge 컴포넌트 구현
* variant 기반 스타일 분기 (success / warning / error)
* 디자인 스펙에 맞게 색상, padding, radius 적용
* `class-variance-authority(cva)` 활용하여 스타일 관리
* Storybook 스토리 추가 및 autodocs 적용

---

## 📸 스크린샷 (선택)

<img width="830" height="500" alt="스크린샷 2026-04-10 오후 6 58 23" src="https://github.com/user-attachments/assets/b5d247e6-c8b5-4bfd-932a-ba327cb53d81" />


---

## 📚 참고사항

* 공통 컴포넌트로 재사용 가능하도록 설계됨
