### PR TITLE
feat: add theme provider and dark mode tokens 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,14 @@
 import { RouterProvider } from 'react-router'
 
-import { router } from './router/Router'
+import { ThemeProvider } from '@/lib/theme/ThemeProvider'
+import { router } from '@/router/Router'
 
 function App() {
-  return <RouterProvider router={router} />
+  return (
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <RouterProvider router={router} />
+    </ThemeProvider>
+  )
 }
 
 export default App

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -8,7 +8,7 @@ import { FOOTER } from '@/constants/footer'
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-950 py-14">
+    <footer className="bg-gray-950 py-14 border-t border-t-[#202020]">
       <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-4">
         <img src={DarklogoImage} className="w-14" alt="OZ Union 로고" />
         <div className="flex flex-col gap-2">

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -31,10 +31,14 @@ export default function Header() {
   return (
     <header className="max-w-7xl mx-auto w-full">
       <div className="flex items-center justify-between py-3 px-4">
-        <img src={logoImage} className="w-12 dark:hidden" alt="OZ Union 로고" />
+        <img
+          src={logoImage}
+          className="w-12 h-11 dark:hidden"
+          alt="OZ Union 로고"
+        />
         <img
           src={DarklogoImage}
-          className="hidden w-12 dark:block"
+          className="hidden w-12 h-11 dark:block"
           alt="OZ Union 로고"
         />
         <div className="flex items-center gap-2">

--- a/src/components/layouts/Header.tsx
+++ b/src/components/layouts/Header.tsx
@@ -1,12 +1,53 @@
-import { logoImage } from '@/assets/images'
+import { Laptop, Moon, Sun } from 'lucide-react'
+
+import { DarklogoImage, logoImage } from '@/assets/images'
+import { useTheme } from '@/lib/theme/ThemeProvider'
+
+const THEME_ICON = {
+  light: Sun,
+  dark: Moon,
+  system: Laptop,
+} as const
 
 export default function Header() {
+  const { theme, setTheme } = useTheme()
+
+  const ThemeIcon = THEME_ICON[theme]
+
+  const handleClickTheme = () => {
+    if (theme === 'light') {
+      setTheme('dark')
+      return
+    }
+
+    if (theme === 'dark') {
+      setTheme('system')
+      return
+    }
+
+    setTheme('light')
+  }
+
   return (
     <header className="max-w-7xl mx-auto w-full">
       <div className="flex items-center justify-between py-3 px-4">
-        <img src={logoImage} className="w-12" alt="OZ Union 로고" />
-        <div>
+        <img src={logoImage} className="w-12 dark:hidden" alt="OZ Union 로고" />
+        <img
+          src={DarklogoImage}
+          className="hidden w-12 dark:block"
+          alt="OZ Union 로고"
+        />
+        <div className="flex items-center gap-2">
           {/* TODO: 레이아웃 확정 후 로그인 상태와 공통 버튼 컴포넌트에 맞춰 헤더 props 분리 */}
+          <button
+            type="button"
+            className="relative flex size-9 items-center justify-center"
+            onClick={handleClickTheme}
+            aria-label={`현재 테마: ${theme}`}
+          >
+            <ThemeIcon className="text-text-primary" />
+          </button>
+
           <button className="text-lg">로그인</button>
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,11 @@
 @import 'tailwindcss';
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 body {
   font-family: 'Pretendard', ui-sans-serif, system-ui, sans-serif;
+  color: var(--text-primary);
+  background-color: var(--bg-surface);
 }
 
 :root {
@@ -56,6 +60,7 @@ body {
   --shadow-card-light: 0px 2px 10px rgba(0, 0, 0, 0.25);
   --shadow-card-main: 0px 4px 10px rgba(0, 0, 0, 0.11);
   --shadow-card-hover: 0px 10px 30px rgba(0, 0, 0, 0.15);
+  --shadow-card-base: var(--shadow-card-light);
   --shadow-rank-light: 0 0 10px rgba(137, 137, 137, 0.5);
 
   /* mypage stats */
@@ -65,6 +70,25 @@ body {
   --color-mypage-stats-card-blue-bg: #eaf3ff;
   --color-mypage-stats-card-mint-bg: #eafbf3;
   --color-mypage-stats-card-yellow-bg: #fff9e5;
+
+  /* ranking background color - dark */
+  --color-rank-dark-gold-bg: #4d452e;
+  --color-rank-dark-silver-bg: #1f1f20;
+  --color-rank-dark-bronze-bg: #221b15;
+
+  /* ranking border color - dark */
+  --color-rank-dark-silver-border: #575757;
+  --color-rank-dark-bronze-border: #3e2b1e;
+
+  /* ranking text color - dark */
+  --color-rank-dark-gold-text: #ffd726;
+  --color-rank-dark-silver-text: #c7c7c7;
+  --color-rank-dark-bronze-text: #de8562;
+
+  /* mypage dark */
+  --color-mypage-stats-card-blue-border: #0194fc;
+  --color-mypage-stats-card-mint-border: #6fcf97;
+  --color-mypage-stats-card-yellow-border: #f1d26b;
 
   /* =========================
    Semantic Token
@@ -132,6 +156,10 @@ body {
   --button-secondary-hover: var(--color-primary-500);
   --button-secondary-text: var(--color-white);
 
+  --button-neutral-bg: var(--color-gray-200);
+  --button-neutral-hover: var(--color-gray-300);
+  --button-neutral-text: var(--color-gray-950);
+
   --button-danger-bg: var(--color-danger-100);
   --button-danger-hover: var(--color-danger-200);
   --button-danger-text: var(--color-danger-500);
@@ -174,6 +202,91 @@ body {
   --border-mypage-stats-card-blue: transparent;
   --border-mypage-stats-card-mint: transparent;
   --border-mypage-stats-card-yellow: transparent;
+}
+
+/* =========================
+   Dark Mode
+========================= */
+.dark {
+  /* =========================
+     Background / Text
+  ========================= */
+  --bg-surface: var(--color-gray-950);
+  --text-primary: var(--color-gray-100);
+
+  /* =========================
+     Border
+  ========================= */
+  --border-subtle: var(--color-gray-750);
+  --border-default: var(--color-gray-750);
+  --border-strong: var(--color-gray-750);
+
+  /* =========================
+     Input
+  ========================= */
+  --input-bg: var(--color-gray-800);
+  --input-border: var(--color-gray-750);
+
+  /* =========================
+     Ranking
+  ========================= */
+  --ranking-gold-bg: var(--color-rank-dark-gold-bg);
+  --ranking-silver-bg: var(--color-rank-dark-silver-bg);
+  --ranking-bronze-bg: var(--color-rank-dark-bronze-bg);
+  --ranking-default-bg: var(--color-rank-dark-silver-bg);
+
+  --ranking-default-border: var(--color-rank-dark-silver-border);
+  --ranking-silver-border: var(--color-rank-dark-silver-border);
+  --ranking-bronze-border: var(--color-rank-dark-bronze-border);
+
+  --text-ranking-gold: var(--color-rank-dark-gold-text);
+  --text-ranking-silver: var(--color-rank-dark-silver-text);
+  --text-ranking-bronze: var(--color-rank-dark-bronze-text);
+
+  --ranking-shadow: var(--shadow-rank-dark);
+
+  /* =========================
+     MyPage
+  ========================= */
+  --color-mypage-stats-bg: rgba(217, 217, 217, 0.05);
+  --color-mypage-stats-border: #454545;
+
+  --bg-mypage-stats-card-blue: transparent;
+  --bg-mypage-stats-card-mint: transparent;
+  --bg-mypage-stats-card-yellow: transparent;
+
+  --border-mypage-stats-card-blue: var(--color-mypage-stats-card-blue-border);
+  --border-mypage-stats-card-mint: var(--color-mypage-stats-card-mint-border);
+  --border-mypage-stats-card-yellow: var(
+    --color-mypage-stats-card-yellow-border
+  );
+
+  /* =========================
+     Button
+  ========================= */
+  --button-primary-bg: #4c6fb3;
+  --button-primary-hover: #5a7fcf;
+  --button-primary-text: #ffffff;
+
+  --button-secondary-bg: #4c6fb3;
+  --button-secondary-hover: #5a7fcf;
+  --button-secondary-text: #ffffff;
+
+  --button-neutral-bg: #2a2d34;
+  --button-neutral-hover: #3a3f4a;
+  --button-neutral-text: #e6eaf0;
+
+  --button-danger-bg: rgba(255, 107, 107, 0.15);
+  --button-danger-hover: rgba(255, 107, 107, 0.25);
+  --button-danger-text: #ff8a8a;
+
+  /* =========================
+     Shadow
+  ========================= */
+  --shadow-card-base: 0px 0px 10px rgba(255, 255, 255, 0.2);
+  --shadow-card-hover: var(--shadow-card-base);
+  --shadow-card-active: var(--shadow-card-base);
+  --shadow-rank-dark: 2px 1px 12px rgba(153, 127, 26, 0.5);
 }
 
 @theme inline {
@@ -230,6 +343,9 @@ body {
   --color-button-secondary-bg: var(--button-secondary-bg);
   --color-button-secondary-hover: var(--button-secondary-hover);
   --color-button-secondary-text: var(--button-secondary-text);
+  --color-button-neutral-bg: var(--button-neutral-bg);
+  --color-button-neutral-hover: var(--button-neutral-hover);
+  --color-button-neutral-text: var(--button-neutral-text);
   --color-button-danger-bg: var(--button-danger-bg);
   --color-button-danger-hover: var(--button-danger-hover);
   --color-button-danger-text: var(--button-danger-text);
@@ -262,6 +378,7 @@ body {
 
   --shadow-card-light: var(--shadow-card-light);
   --shadow-card-main: var(--shadow-card-main);
+  --shadow-card-base: var(--shadow-card-base);
   --shadow-card-hover: var(--shadow-card-hover);
   --shadow-rank-light: var(--shadow-rank-light);
   --shadow-input: var(--input-shadow);

--- a/src/lib/theme/ThemeProvider.tsx
+++ b/src/lib/theme/ThemeProvider.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type Theme = 'dark' | 'light' | 'system'
+
+type ThemeProviderProps = {
+  children: React.ReactNode
+  defaultTheme?: Theme
+  storageKey?: string
+}
+
+type ThemeProviderState = {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+}
+
+const initialState: ThemeProviderState = {
+  theme: 'system',
+  setTheme: () => null,
+}
+
+const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
+
+export function ThemeProvider({
+  children,
+  defaultTheme = 'system',
+  storageKey = 'vite-ui-theme',
+  ...props
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  )
+
+  useEffect(() => {
+    const root = window.document.documentElement
+
+    root.classList.remove('light', 'dark')
+
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
+        .matches
+        ? 'dark'
+        : 'light'
+
+      root.classList.add(systemTheme)
+      return
+    }
+
+    root.classList.add(theme)
+  }, [theme])
+
+  const value = {
+    theme,
+    setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme)
+      setTheme(theme)
+    },
+  }
+
+  return (
+    <ThemeProviderContext.Provider {...props} value={value}>
+      {children}
+    </ThemeProviderContext.Provider>
+  )
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeProviderContext)
+
+  if (context === undefined)
+    throw new Error('useTheme must be used within a ThemeProvider')
+
+  return context
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #25

## ✨ 변경 내용

  - ThemeProvider를 추가해 light, dark, system 테마 전환을 지원
  - 선택한 테마를 localStorage에 저장해 새로고침 후에도 유지되도록 처리
  - system 테마 선택 시 OS 다크모드 설정을 따라가도록 구현
  - Header에 테마 전환 버튼을 추가하고 현재 테마에 맞는 아이콘 표시
  - 다크모드에서 Header 로고가 다크 로고 이미지로 변경되도록 처리
  - index.css에 다크모드 semantic token과 Tailwind theme mapping 추가
  - body 기본 텍스트 색상과 배경색을 테마 토큰에 연결
  - 카드 기본 shadow 토큰을 라이트/다크 모드에 맞게 설정

## 📸 스크린샷(선택)

https://github.com/user-attachments/assets/4fc942a8-b9e0-405c-b357-42c9c560b10a

## 📚 참고사항
