### PR TITLE
feat: add common button component

### DIFF
--- a/src/components/common/button/Button.stories.tsx
+++ b/src/components/common/button/Button.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Button } from './Button'
+
+const meta = {
+  title: 'Common/Button',
+  component: Button,
+  tags: ['autodocs'],
+  args: {
+    children: '버튼',
+    variant: 'primary',
+    size: 'md',
+    rounded: 'default',
+    disabled: false,
+    fullWidth: false,
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: [
+        'primary',
+        'secondary',
+        'danger',
+        'neutral',
+        'dark',
+        'outline',
+        'textDanger',
+        'textPrimary',
+      ],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+    },
+    rounded: {
+      control: 'select',
+      options: ['default', 'pill'],
+    },
+    fullWidth: {
+      control: 'boolean',
+    },
+    leftIcon: {
+      control: false,
+    },
+    rightIcon: {
+      control: false,
+    },
+  },
+} satisfies Meta<typeof Button>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    children: '투표하기',
+    variant: 'primary',
+    size: 'md',
+  },
+}
+
+export const Secondary: Story = {
+  args: {
+    children: '수정',
+    variant: 'secondary',
+    size: 'sm',
+  },
+}
+
+export const Danger: Story = {
+  args: {
+    children: '삭제',
+    variant: 'danger',
+    size: 'sm',
+  },
+}
+
+export const Neutral: Story = {
+  args: {
+    children: '취소',
+    variant: 'neutral',
+    size: 'sm',
+  },
+}
+
+export const Dark: Story = {
+  args: {
+    children: '로그인',
+    variant: 'dark',
+    rounded: 'pill',
+    className: 'w-[450px] py-[18px]',
+  },
+}
+
+export const Outline: Story = {
+  args: {
+    children: '인증',
+    variant: 'outline',
+    size: 'sm',
+    rounded: 'pill',
+  },
+}
+
+export const TextDanger: Story = {
+  args: {
+    children: '신고',
+    variant: 'textDanger',
+    size: 'md',
+  },
+}
+
+export const TextPrimary: Story = {
+  args: {
+    children: '회원가입',
+    variant: 'textPrimary',
+    size: 'md',
+    className: 'px-0 py-0',
+  },
+}
+
+export const Pill: Story = {
+  args: {
+    children: '게시글 작성',
+    variant: 'primary',
+    size: 'md',
+    rounded: 'pill',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    children: '투표하기',
+    disabled: true,
+  },
+}

--- a/src/components/common/button/Button.stories.tsx
+++ b/src/components/common/button/Button.stories.tsx
@@ -1,18 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Button } from './Button'
+import Button from './Button'
 
-const meta = {
+const meta: Meta<typeof Button> = {
   title: 'Common/Button',
   component: Button,
+  parameters: { layout: 'centered' },
   tags: ['autodocs'],
   args: {
     children: '버튼',
     variant: 'primary',
     size: 'md',
-    rounded: 'default',
+    rounded: 'md',
     disabled: false,
-    fullWidth: false,
   },
   argTypes: {
     variant: {
@@ -22,10 +22,10 @@ const meta = {
         'secondary',
         'danger',
         'neutral',
-        'dark',
         'outline',
         'textDanger',
         'textPrimary',
+        'auth',
       ],
     },
     size: {
@@ -34,28 +34,23 @@ const meta = {
     },
     rounded: {
       control: 'select',
-      options: ['default', 'pill'],
+      options: ['md', 'full'],
     },
-    fullWidth: {
-      control: 'boolean',
-    },
-    leftIcon: {
-      control: false,
-    },
-    rightIcon: {
-      control: false,
-    },
+    leftIcon: { control: false },
+    rightIcon: { control: false },
   },
-} satisfies Meta<typeof Button>
+}
 
 export default meta
-type Story = StoryObj<typeof meta>
+
+type Story = StoryObj<typeof Button>
 
 export const Primary: Story = {
   args: {
     children: '투표하기',
     variant: 'primary',
     size: 'md',
+    rounded: 'md',
   },
 }
 
@@ -64,6 +59,7 @@ export const Secondary: Story = {
     children: '수정',
     variant: 'secondary',
     size: 'sm',
+    rounded: 'md',
   },
 }
 
@@ -72,6 +68,7 @@ export const Danger: Story = {
     children: '삭제',
     variant: 'danger',
     size: 'sm',
+    rounded: 'md',
   },
 }
 
@@ -80,15 +77,7 @@ export const Neutral: Story = {
     children: '취소',
     variant: 'neutral',
     size: 'sm',
-  },
-}
-
-export const Dark: Story = {
-  args: {
-    children: '로그인',
-    variant: 'dark',
-    rounded: 'pill',
-    className: 'w-[450px] py-[18px]',
+    rounded: 'md',
   },
 }
 
@@ -97,7 +86,7 @@ export const Outline: Story = {
     children: '인증',
     variant: 'outline',
     size: 'sm',
-    rounded: 'pill',
+    rounded: 'full',
   },
 }
 
@@ -106,6 +95,7 @@ export const TextDanger: Story = {
     children: '신고',
     variant: 'textDanger',
     size: 'md',
+    rounded: 'md',
   },
 }
 
@@ -114,6 +104,7 @@ export const TextPrimary: Story = {
     children: '회원가입',
     variant: 'textPrimary',
     size: 'md',
+    rounded: 'md',
     className: 'px-0 py-0',
   },
 }
@@ -123,13 +114,34 @@ export const Pill: Story = {
     children: '게시글 작성',
     variant: 'primary',
     size: 'md',
-    rounded: 'pill',
+    rounded: 'full',
   },
 }
 
 export const Disabled: Story = {
   args: {
     children: '투표하기',
+    variant: 'primary',
+    size: 'md',
+    rounded: 'md',
     disabled: true,
+  },
+}
+
+export const LoginButton: Story = {
+  args: {
+    children: '로그인',
+    variant: 'auth',
+    rounded: 'full',
+    className: 'w-[450px] py-[18px]',
+  },
+}
+
+export const SignupButton: Story = {
+  args: {
+    children: '회원가입',
+    variant: 'auth',
+    rounded: 'full',
+    className: 'w-[492px] py-[18px]',
   },
 }

--- a/src/components/common/button/Button.stories.tsx
+++ b/src/components/common/button/Button.stories.tsx
@@ -17,16 +17,7 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: [
-        'primary',
-        'secondary',
-        'danger',
-        'neutral',
-        'outline',
-        'textDanger',
-        'textPrimary',
-        'auth',
-      ],
+      options: ['primary', 'secondary', 'danger', 'neutral', 'outline'],
     },
     size: {
       control: 'select',
@@ -90,25 +81,6 @@ export const Outline: Story = {
   },
 }
 
-export const TextDanger: Story = {
-  args: {
-    children: '신고',
-    variant: 'textDanger',
-    size: 'md',
-    rounded: 'md',
-  },
-}
-
-export const TextPrimary: Story = {
-  args: {
-    children: '회원가입',
-    variant: 'textPrimary',
-    size: 'md',
-    rounded: 'md',
-    className: 'px-0 py-0',
-  },
-}
-
 export const Pill: Story = {
   args: {
     children: '게시글 작성',
@@ -125,23 +97,5 @@ export const Disabled: Story = {
     size: 'md',
     rounded: 'md',
     disabled: true,
-  },
-}
-
-export const LoginButton: Story = {
-  args: {
-    children: '로그인',
-    variant: 'auth',
-    rounded: 'full',
-    className: 'w-[450px] py-[18px]',
-  },
-}
-
-export const SignupButton: Story = {
-  args: {
-    children: '회원가입',
-    variant: 'auth',
-    rounded: 'full',
-    className: 'w-[492px] py-[18px]',
   },
 }

--- a/src/components/common/button/Button.style.ts
+++ b/src/components/common/button/Button.style.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority'
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-1 px-4 font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:bg-gray-400',
+  'inline-flex items-center justify-center gap-1 px-4 font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:bg-gray-400 disabled:text-white',
   {
     variants: {
       variant: {
@@ -16,13 +16,7 @@ export const buttonVariants = cva(
 
         neutral: 'bg-gray-200 text-text-primary hover:bg-gray-300',
 
-        outline: 'border border-border-subtle bg-white text-text-muted',
-
-        textDanger: 'bg-transparent text-danger-500 hover:bg-danger-100',
-
-        textPrimary: 'bg-transparent text-primary-500 hover:text-primary-600',
-
-        auth: 'bg-gray-900 text-white hover:bg-gray-950',
+        outline: 'border border-border-subtle bg-gray-100 text-text-muted',
       },
 
       size: {

--- a/src/components/common/button/Button.style.ts
+++ b/src/components/common/button/Button.style.ts
@@ -1,0 +1,45 @@
+import { cva } from 'class-variance-authority'
+
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-1 px-4 font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:bg-gray-400',
+  {
+    variants: {
+      variant: {
+        primary:
+          'bg-button-primary-bg text-button-primary-text hover:bg-button-primary-hover',
+
+        secondary:
+          'bg-button-secondary-bg text-button-secondary-text hover:bg-button-secondary-hover',
+
+        danger:
+          'bg-button-danger-bg text-button-danger-text hover:bg-button-danger-hover',
+
+        neutral: 'bg-gray-200 text-text-primary hover:bg-gray-300',
+
+        outline: 'border border-border-subtle bg-white text-text-muted',
+
+        textDanger: 'bg-transparent text-danger-500 hover:bg-danger-100',
+
+        textPrimary: 'bg-transparent text-primary-500 hover:text-primary-600',
+
+        auth: 'bg-gray-900 text-white hover:bg-gray-950',
+      },
+
+      size: {
+        sm: 'py-1 text-xs',
+        md: 'py-1.5 text-sm',
+      },
+
+      rounded: {
+        md: 'rounded-md',
+        full: 'rounded-full',
+      },
+    },
+
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+      rounded: 'md',
+    },
+  }
+)

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,103 +1,37 @@
 import * as React from 'react'
 
-import { cva, type VariantProps } from 'class-variance-authority'
+import type { VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/utils/cn'
 
-const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-1 font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:bg-[var(--color-gray-400)]',
-  {
-    variants: {
-      variant: {
-        primary:
-          'bg-[var(--color-button-primary-bg)] text-[var(--color-button-primary-text)] hover:bg-[var(--color-button-primary-hover)]',
+import { buttonVariants } from './Button.style'
 
-        secondary:
-          'bg-[var(--color-button-secondary-bg)] text-[var(--color-button-secondary-text)] hover:bg-[var(--color-button-secondary-hover)]',
-
-        danger:
-          'bg-[var(--color-button-danger-bg)] text-[var(--color-button-danger-text)] hover:bg-[var(--color-button-danger-hover)]',
-
-        neutral:
-          'bg-[var(--color-gray-200)] text-[var(--color-text-primary)] hover:bg-[var(--color-gray-300)]',
-
-        dark: 'bg-[var(--color-gray-900)] text-[var(--color-white)] hover:bg-[var(--color-gray-950)]',
-
-        outline:
-          'border border-[var(--color-border-subtle)] bg-[var(--color-white)] text-[var(--color-text-muted)]',
-
-        textDanger:
-          'bg-transparent text-[var(--color-danger-500)] hover:bg-[var(--color-danger-100)]',
-
-        textPrimary:
-          'bg-transparent text-[var(--color-primary-500)] hover:text-[var(--color-primary-600)]',
-      },
-
-      size: {
-        sm: 'px-4 py-1 text-xs',
-        md: 'px-4 py-1.5 text-sm',
-      },
-
-      rounded: {
-        default: 'rounded-lg',
-        pill: 'rounded-full',
-      },
-
-      fullWidth: {
-        true: 'w-full',
-        false: '',
-      },
-    },
-
-    defaultVariants: {
-      variant: 'primary',
-      size: 'md',
-      rounded: 'default',
-      fullWidth: false,
-    },
-  }
-)
-
-export type ButtonProps = {
+type ButtonProps = {
   leftIcon?: React.ReactNode
   rightIcon?: React.ReactNode
-} & React.ButtonHTMLAttributes<HTMLButtonElement> &
+} & React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants>
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      className,
-      variant,
-      size,
-      rounded,
-      fullWidth,
-      leftIcon,
-      rightIcon,
-      children,
-      type = 'button',
-      ...props
-    },
-    ref
-  ) => {
-    return (
-      <button
-        ref={ref}
-        type={type}
-        className={cn(
-          buttonVariants({ variant, size, rounded, fullWidth }),
-          className
-        )}
-        {...props}
-      >
-        {leftIcon ? <span className="shrink-0">{leftIcon}</span> : null}
-        {children}
-        {rightIcon ? <span className="shrink-0">{rightIcon}</span> : null}
-      </button>
-    )
-  }
-)
-
-Button.displayName = 'Button'
-
-export { Button, buttonVariants }
+export default function Button({
+  className,
+  variant,
+  size,
+  rounded,
+  leftIcon,
+  rightIcon,
+  children,
+  type = 'button',
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(buttonVariants({ variant, size, rounded }), className)}
+      {...props}
+    >
+      {leftIcon ? <span className="shrink-0">{leftIcon}</span> : null}
+      {children}
+      {rightIcon ? <span className="shrink-0">{rightIcon}</span> : null}
+    </button>
+  )
+}

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react'
+
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/utils/cn'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-1 font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:bg-[var(--color-gray-400)]',
+  {
+    variants: {
+      variant: {
+        primary:
+          'bg-[var(--color-button-primary-bg)] text-[var(--color-button-primary-text)] hover:bg-[var(--color-button-primary-hover)]',
+
+        secondary:
+          'bg-[var(--color-button-secondary-bg)] text-[var(--color-button-secondary-text)] hover:bg-[var(--color-button-secondary-hover)]',
+
+        danger:
+          'bg-[var(--color-button-danger-bg)] text-[var(--color-button-danger-text)] hover:bg-[var(--color-button-danger-hover)]',
+
+        neutral:
+          'bg-[var(--color-gray-200)] text-[var(--color-text-primary)] hover:bg-[var(--color-gray-300)]',
+
+        dark: 'bg-[var(--color-gray-900)] text-[var(--color-white)] hover:bg-[var(--color-gray-950)]',
+
+        outline:
+          'border border-[var(--color-border-subtle)] bg-[var(--color-white)] text-[var(--color-text-muted)]',
+
+        textDanger:
+          'bg-transparent text-[var(--color-danger-500)] hover:bg-[var(--color-danger-100)]',
+
+        textPrimary:
+          'bg-transparent text-[var(--color-primary-500)] hover:text-[var(--color-primary-600)]',
+      },
+
+      size: {
+        sm: 'px-4 py-1 text-xs',
+        md: 'px-4 py-1.5 text-sm',
+      },
+
+      rounded: {
+        default: 'rounded-lg',
+        pill: 'rounded-full',
+      },
+
+      fullWidth: {
+        true: 'w-full',
+        false: '',
+      },
+    },
+
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+      rounded: 'default',
+      fullWidth: false,
+    },
+  }
+)
+
+export type ButtonProps = {
+  leftIcon?: React.ReactNode
+  rightIcon?: React.ReactNode
+} & React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants>
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant,
+      size,
+      rounded,
+      fullWidth,
+      leftIcon,
+      rightIcon,
+      children,
+      type = 'button',
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={cn(
+          buttonVariants({ variant, size, rounded, fullWidth }),
+          className
+        )}
+        {...props}
+      >
+        {leftIcon ? <span className="shrink-0">{leftIcon}</span> : null}
+        {children}
+        {rightIcon ? <span className="shrink-0">{rightIcon}</span> : null}
+      </button>
+    )
+  }
+)
+
+Button.displayName = 'Button'
+
+export { Button, buttonVariants }

--- a/src/components/common/button/index.ts
+++ b/src/components/common/button/index.ts
@@ -1,0 +1,1 @@
+export * from './Button'

--- a/src/components/common/button/index.ts
+++ b/src/components/common/button/index.ts
@@ -1,1 +1,1 @@
-export * from './Button'
+export { default as Button } from './Button'


### PR DESCRIPTION
## 📌 관련 이슈

Closes # 21

## ✨ 변경 내용

- 공통 Button 컴포넌트 구현 (src/components/common/button/)
- cva + cn 패턴을 활용한 버튼 variant 구조 설계
- Storybook을 통해 버튼 상태 및 형태 확인 가능하도록 구성

* 버튼 variant 구성
- primary
- secondary
- danger
- neutral
- outline
- dark (검정 계열 버튼)
- textDanger (신고 버튼)
-textPrimary (회원가입 텍스트 버튼)

* 옵션
- size (sm, md)
- rounded (default, pill)
- fullWidth
- disabled

* Storybook
- Primary
- Secondary
- Danger
- Neutral
- Dark
- Outline
- TextDanger
- TextPrimary
- Pill
- Disabled

## 📸 스크린샷(선택)
<img width="824" height="875" alt="스크린샷 2026-04-12 오전 2 46 03" src="https://github.com/user-attachments/assets/2644ef12-a8e5-4ba2-9478-0b6864d2fc42" />

<img width="834" height="1056" alt="스크린샷 2026-04-12 오전 2 47 18" src="https://github.com/user-attachments/assets/d4045e1c-347a-4322-89a3-963b039301a7" />

## 📚 참고사항

1. Button.tsx에서 buttonVariants를 함께 export하여 Fast Refresh warning이 1건 존재합니다.
기능상 문제는 없으며, 추후 variants 분리 리팩토링으로 개선 예정입니다.

2. 로그인 / 회원가입 버튼은 동일한 variant(dark)를 사용하고, width는 사용처에서 className으로 조정하도록 구성했습니다.

3.회원가입 텍스트 버튼(textPrimary)은 현재 사용 사례 기준으로 포함했으며, 추후 필요 시 별도 TextButton 컴포넌트로 분리할 수 있습니다.

4. disabled 상태는 배경 색상만 디자인 기준으로 반영했으며, 텍스트 색상은 임의로 변경하지 않았습니다.

5. IconButton, TabButton, DropdownButton 등은 다음 PR에서 분리하여 구현 예정입니다.