### PR TITLE
feat: add Textarea component with stories

### DIFF
--- a/src/components/common/field/Textarea.stories.tsx
+++ b/src/components/common/field/Textarea.stories.tsx
@@ -1,0 +1,88 @@
+import { type ChangeEvent, useState } from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Textarea } from './Textarea'
+
+const meta: Meta<typeof Textarea> = {
+  component: Textarea,
+  title: 'Common/Field/Textarea',
+  parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj<typeof Textarea>
+
+function CommentTextarea() {
+  const maxLength = 500
+  const [value, setValue] = useState('')
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(event.currentTarget.value)
+  }
+
+  return (
+    <div className="relative">
+      <Textarea
+        value={value}
+        onChange={handleChange}
+        maxLength={maxLength}
+        placeholder="댓글로 의견을 남겨보세요"
+        className="pr-17"
+      />
+      <span className="pointer-events-none absolute right-4.5 bottom-5 text-sm text-text-muted">
+        {value.length}/{maxLength}
+      </span>
+    </div>
+  )
+}
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex w-[800px] flex-col gap-8">
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold text-text-primary">댓글</h3>
+        <CommentTextarea />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold text-text-primary">내용</h3>
+        <Textarea size="lg" placeholder="내용을 입력해 주세요." />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold text-text-primary">신고사유</h3>
+        <Textarea placeholder="신고 사유를 입력해 주세요." />
+      </section>
+    </div>
+  ),
+}
+
+export const Error: Story = {
+  render: () => (
+    <div className="flex w-[800px] flex-col gap-8">
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold text-text-primary">
+          게시글 내용 에러
+        </h3>
+        <Textarea
+          error
+          size="lg"
+          errorMessage="게시글 내용을 입력해 주세요."
+          placeholder="게시글 내용을 입력해 주세요."
+        />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold text-text-primary">
+          신고사유 에러
+        </h3>
+        <Textarea
+          error
+          errorMessage="신고 사유를 입력해 주세요."
+          placeholder="신고 사유를 입력해 주세요."
+        />
+      </section>
+    </div>
+  ),
+}

--- a/src/components/common/field/Textarea.tsx
+++ b/src/components/common/field/Textarea.tsx
@@ -1,0 +1,46 @@
+import type React from 'react'
+
+import { cn } from '@/utils/cn'
+
+export type TextareaProps = {
+  error?: boolean
+  errorMessage?: string
+  size?: 'sm' | 'lg'
+} & React.ComponentProps<'textarea'>
+
+const textareaSizeClass = {
+  sm: 'h-15 py-4',
+  lg: 'h-58 py-5',
+}
+
+export function Textarea({
+  className,
+  error,
+  errorMessage,
+  ref,
+  size = 'sm',
+  ...props
+}: TextareaProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <textarea
+        ref={ref}
+        {...props}
+        className={cn(
+          'max-h-58 w-full resize-none overflow-y-auto rounded-xl border border-border-default bg-white px-4.5 text-text-primary outline-none placeholder:text-text-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+          textareaSizeClass[size],
+          error
+            ? 'border-status-error-border focus:border-status-error-border'
+            : 'focus:border-focus-border',
+          className
+        )}
+      />
+
+      {error && errorMessage && (
+        <p className="text-sm text-status-error-text">{errorMessage}</p>
+      )}
+    </div>
+  )
+}
+
+export default Textarea

--- a/src/components/common/field/index.ts
+++ b/src/components/common/field/index.ts
@@ -1,1 +1,3 @@
 export { default as Input } from './Input'
+export { Textarea } from './Textarea'
+export type { TextareaProps } from './Textarea'


### PR DESCRIPTION
## 📌 관련 이슈

Closes #24

## ✨ 변경 내용

  - 공통 `Textarea` 컴포넌트를 추가
  - `sm`, `lg` 사이즈 옵션을 추가해 댓글/신고사유와 게시글 내용 작성 케이스를 구분
  - 에러 상태와 에러 메시지 표시를 지원하도록 구성
  - React Hook Form 등에서 사용할 수 있도록 `ref`를 실제 `textarea` DOM 요소에 전달
  - `Textarea` Storybook을 추가하고 `Default`, `Error` 케이스를 분리
  - `field/index.ts`에 `Textarea` 관련 barrel export를 추가

## 📸 스크린샷(선택)
<img width="891" height="506" alt="스크린샷 2026-04-12 오후 6 27 11" src="https://github.com/user-attachments/assets/44713553-1306-4419-ac71-de5d9e0055f3" />
<img width="864" height="551" alt="스크린샷 2026-04-12 오후 6 28 28" src="https://github.com/user-attachments/assets/755b6639-466a-4722-8f61-4543f8ef6184" />


## 📚 참고사항

  - 현재는 `Input`, `Textarea` 내부에서 각각 에러 메시지를 렌더링하도록 두었습니다.
  - 추후 로그인/회원가입 등 실제 form 페이지를 구현하면서 field 구조가 확정되면, 에러 메시지와 label 영역을 별도
  공통 컴포넌트로 분리할 예정입니다.
  - 예: `FieldErrorMessage`, `FieldLabel`, `Field` wrapper 등