### PR TITLE
chore: 36 tailwind lint plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,135 +1,184 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
-import storybook from "eslint-plugin-storybook";
+import storybook from 'eslint-plugin-storybook'
 
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
 
-import js from "@eslint/js"; // JavaScript 기본 규칙 세트
-import prettier from "eslint-config-prettier"; // Prettier와 충돌하는 ESLint 규칙 비활성화
-import react from "eslint-plugin-react"; // React 컴포넌트 관련 규칙
-import reactHooks from "eslint-plugin-react-hooks"; // React Hooks 관련 규칙
-import reactRefresh from "eslint-plugin-react-refresh"; // Vite HMR 최적화 규칙
-import simpleImportSort from "eslint-plugin-simple-import-sort"; // 자동import정렬
-import globals from "globals"; // 글로벌 변수 정의 (window, document 등)
-import tseslint from "typescript-eslint"; // TypeScript 전용 규칙 세트
+import js from '@eslint/js' // JavaScript 기본 규칙 세트
+import prettier from 'eslint-config-prettier' // Prettier와 충돌하는 ESLint 규칙 비활성화
+import betterTailwindcss from 'eslint-plugin-better-tailwindcss' // Tailwind class 품질 규칙
+import react from 'eslint-plugin-react' // React 컴포넌트 관련 규칙
+import reactHooks from 'eslint-plugin-react-hooks' // React Hooks 관련 규칙
+import reactRefresh from 'eslint-plugin-react-refresh' // Vite HMR 최적화 규칙
+import simpleImportSort from 'eslint-plugin-simple-import-sort' // 자동import정렬
+import globals from 'globals' // 글로벌 변수 정의 (window, document 등)
+import tseslint from 'typescript-eslint' // TypeScript 전용 규칙 세트
 
-export default tseslint.config(// 1. 무시할 파일/폴더 설정
-{
-  ignores: [
-    "dist", // 빌드 결과물
-    "node_modules", // 외부 패키지
-    "*.config.js", // 설정 파일들 (vite.config.js 등)
-    "*.config.ts", // TypeScript 설정 파일들
-    "public" // 정적 자원 폴더
-  ]
-}, // 2. 기본 JavaScript 규칙 적용
-// 일반적인 JavaScript 오류 방지 규칙들
-js.configs.recommended, // 3. TypeScript 권장 규칙들 적용
-// TypeScript 기본 규칙
-...tseslint.configs.recommended, // 4. 메인 설정 블록
-{
-  // 적용할 파일 확장자 지정
-  files: ["**/*.{ts,tsx}"],
+export default tseslint.config(
+  // 1. 무시할 파일/폴더 설정
+  {
+    ignores: [
+      'dist', // 빌드 결과물
+      'node_modules', // 외부 패키지
+      '*.config.js', // 설정 파일들 (vite.config.js 등)
+      '*.config.ts', // TypeScript 설정 파일들
+      'public', // 정적 자원 폴더
+    ],
+  }, // 2. 기본 JavaScript 규칙 적용
+  // 일반적인 JavaScript 오류 방지 규칙들
+  js.configs.recommended, // 3. TypeScript 권장 규칙들 적용
+  // TypeScript 기본 규칙
+  ...tseslint.configs.recommended, // 4. 메인 설정 블록
+  {
+    // 적용할 파일 확장자 지정
+    files: ['**/*.{ts,tsx}'],
 
-  // 사용할 플러그인들 등록
-  plugins: {
-    react, // React 컴포넌트 관련
-    "react-hooks": reactHooks, // React Hooks 관련
-    "react-refresh": reactRefresh, // Vite HMR 관련
-    "simple-import-sort": simpleImportSort // import 자동정렬
-  },
-
-  // 언어 및 파싱 설정
-  languageOptions: {
-    ecmaVersion: 2023, // 최신 JavaScript 문법 지원
-    sourceType: "module", // ES6 모듈 시스템 사용
-    parserOptions: {
-      ecmaFeatures: {
-        jsx: true // JSX 문법 지원
-      },
-      project: ["./tsconfig.app.json", "./tsconfig.node.json"],
-      tsconfigRootDir: import.meta.dirname
+    // 사용할 플러그인들 등록
+    plugins: {
+      react, // React 컴포넌트 관련
+      'react-hooks': reactHooks, // React Hooks 관련
+      'react-refresh': reactRefresh, // Vite HMR 관련
+      'simple-import-sort': simpleImportSort, // import 자동정렬
     },
-    // 사용 가능한 글로벌 변수들 정의
-    globals: {
-      ...globals.browser, // window, document, console 등 브라우저 API
-      ...globals.es2023 // Promise, Array.prototype.at 등 최신 JS API
-    }
+
+    // 언어 및 파싱 설정
+    languageOptions: {
+      ecmaVersion: 2023, // 최신 JavaScript 문법 지원
+      sourceType: 'module', // ES6 모듈 시스템 사용
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true, // JSX 문법 지원
+        },
+        project: ['./tsconfig.app.json', './tsconfig.node.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+      // 사용 가능한 글로벌 변수들 정의
+      globals: {
+        ...globals.browser, // window, document, console 등 브라우저 API
+        ...globals.es2023, // Promise, Array.prototype.at 등 최신 JS API
+      },
+    },
+
+    // 플러그인별 추가 설정
+    settings: {
+      react: {
+        version: 'detect', // 설치된 React 버전 자동 감지
+      },
+    },
+
+    rules: {
+      // ===== React 관련 기본 규칙들 =====
+      ...react.configs.recommended.rules, // React 권장 규칙들
+      ...react.configs['jsx-runtime'].rules, // React 17+ JSX Transform 규칙
+      ...reactHooks.configs.recommended.rules, // React Hooks 권장 규칙들
+
+      // ===== 기본적인 JavaScript/TypeScript 품질 규칙 =====
+      'prefer-const': 'warn', // 재할당하지 않는 변수는 const 사용 권장 (경고만)
+
+      'no-var': 'error', // var 키워드 사용 금지 (let, const만 사용)
+
+      'no-unused-vars': 'off', // JavaScript 미사용 변수 규칙 비활성화 (TypeScript가 처리)
+
+      '@typescript-eslint/no-unused-vars': [
+        'warn', // 에러 대신 경고로 설정
+        {
+          argsIgnorePattern: '^_', // _로 시작하는 매개변수는 미사용 허용
+          varsIgnorePattern: '^_', // _로 시작하는 변수는 미사용 허용
+        },
+      ],
+      '@typescript-eslint/consistent-type-definitions': ['error', 'type'], // 타입정의 type 사용
+
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+          prefer: 'type-imports',
+        },
+      ],
+
+      'simple-import-sort/imports': [
+        'error',
+        {
+          groups: [['^react'], ['^@?\\w'], ['^@/'], ['^\\.']],
+        },
+      ],
+      'simple-import-sort/exports': 'error',
+
+      // ===== TypeScript 기본 규칙 =====
+      '@typescript-eslint/no-explicit-any': 'warn', // any 타입 사용시 경고만 (에러 아님)
+      '@typescript-eslint/explicit-function-return-type': 'off', // 함수 리턴 타입 명시 강제 안함
+      '@typescript-eslint/explicit-module-boundary-types': 'off', // 모듈 경계 타입 명시 강제 안함
+
+      // ===== React 기본 베스트 프랙티스 =====
+      'react/prop-types': 'off', // PropTypes 사용 강제 안함 (TypeScript 사용)
+      'react/react-in-jsx-scope': 'off', // React import 강제 안함 (React 17+)
+      'react/jsx-uses-react': 'off', // React 사용 감지 안함 (React 17+)
+
+      'react/jsx-boolean-value': 'warn', // boolean prop 축약 권장
+
+      'react/jsx-fragments': 'warn', // Fragment 단축 문법 권장
+
+      'react/jsx-no-useless-fragment': 'warn', // 불필요한 Fragment 경고
+
+      // ===== 기본적인 코드 품질 =====
+      'no-console': 'warn', // console.log 사용시 경고 (개발 중에는 필요할 수 있음)
+      'no-debugger': 'warn', // debugger 문 사용시 경고 (에러 아님)
+      'no-duplicate-imports': 'warn', // 중복 import 경고
+
+      // ===== Vite HMR 최적화 =====
+      'react-refresh/only-export-components': [
+        'warn', // 경고 레벨로 설정
+        {
+          allowConstantExport: true, // 상수 export는 허용
+        },
+      ],
+      // 설명: Vite의 Hot Module Replacement 최적화를 위한 규칙
+    },
   },
-
-  // 플러그인별 추가 설정
-  settings: {
-    react: {
-      version: "detect" // 설치된 React 버전 자동 감지
-    }
-  },
-
-  rules: {
-    // ===== React 관련 기본 규칙들 =====
-    ...react.configs.recommended.rules, // React 권장 규칙들
-    ...react.configs["jsx-runtime"].rules, // React 17+ JSX Transform 규칙
-    ...reactHooks.configs.recommended.rules, // React Hooks 권장 규칙들
-
-    // ===== 기본적인 JavaScript/TypeScript 품질 규칙 =====
-    "prefer-const": "warn", // 재할당하지 않는 변수는 const 사용 권장 (경고만)
-
-    "no-var": "error", // var 키워드 사용 금지 (let, const만 사용)
-
-    "no-unused-vars": "off", // JavaScript 미사용 변수 규칙 비활성화 (TypeScript가 처리)
-
-    "@typescript-eslint/no-unused-vars": [
-      "warn", // 에러 대신 경고로 설정
-      {
-        argsIgnorePattern: "^_", // _로 시작하는 매개변수는 미사용 허용
-        varsIgnorePattern: "^_" // _로 시작하는 변수는 미사용 허용
-      }
+  {
+    // Tailwind class 규칙
+    // - src 코드에만 적용
+    // - Storybook은 예시 화면 구성을 위해 임시 width/spacing class를 쓸 수 있어서 제외
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: [
+      '**/*.story.ts',
+      '**/*.story.tsx',
+      '**/*.stories.ts',
+      '**/*.stories.tsx',
     ],
-    "@typescript-eslint/consistent-type-definitions": ["error", "type"], // 타입정의 type 사용
-
-    "@typescript-eslint/consistent-type-imports": [
-      "error",
-      {
-        prefer: "type-imports"
-      }
-    ],
-
-    "simple-import-sort/imports": [
-      "error",
-      {
-        groups: [["^react"], ["^@?\\w"], ["^@/"], ["^\\."]]
-      }
-    ],
-    "simple-import-sort/exports": "error",
-
-    // ===== TypeScript 기본 규칙 =====
-    "@typescript-eslint/no-explicit-any": "warn", // any 타입 사용시 경고만 (에러 아님)
-    "@typescript-eslint/explicit-function-return-type": "off", // 함수 리턴 타입 명시 강제 안함
-    "@typescript-eslint/explicit-module-boundary-types": "off", // 모듈 경계 타입 명시 강제 안함
-
-    // ===== React 기본 베스트 프랙티스 =====
-    "react/prop-types": "off", // PropTypes 사용 강제 안함 (TypeScript 사용)
-    "react/react-in-jsx-scope": "off", // React import 강제 안함 (React 17+)
-    "react/jsx-uses-react": "off", // React 사용 감지 안함 (React 17+)
-
-    "react/jsx-boolean-value": "warn", // boolean prop 축약 권장
-
-    "react/jsx-fragments": "warn", // Fragment 단축 문법 권장
-
-    "react/jsx-no-useless-fragment": "warn", // 불필요한 Fragment 경고
-
-    // ===== 기본적인 코드 품질 =====
-    "no-console": "warn", // console.log 사용시 경고 (개발 중에는 필요할 수 있음)
-    "no-debugger": "warn", // debugger 문 사용시 경고 (에러 아님)
-    "no-duplicate-imports": "warn", // 중복 import 경고
-
-    // ===== Vite HMR 최적화 =====
-    "react-refresh/only-export-components": [
-      "warn", // 경고 레벨로 설정
-      {
-        allowConstantExport: true // 상수 export는 허용
-      }
-    ]
-    // 설명: Vite의 Hot Module Replacement 최적화를 위한 규칙
-  }
-}, // 5. Prettier와 충돌하는 ESLint 규칙들 비활성화
-// 포맷팅은 Prettier가 담당, ESLint는 코드 품질만 담당
-prettier, storybook.configs["flat/recommended"]);
+    settings: {
+      'better-tailwindcss': {
+        // Tailwind v4 theme token을 읽기 위한 entry 파일
+        entryPoint: './src/index.css',
+      },
+    },
+    plugins: {
+      'better-tailwindcss': betterTailwindcss,
+    },
+    rules: {
+      // spacing/size/font 관련 arbitrary value와 var(...) 직접 사용 제한
+      // 색상 hex 값(text-[#...], bg-[#...], border-[#...])은 토큰 추가 전 임시 사용을 허용
+      'better-tailwindcss/no-restricted-classes': [
+        'error',
+        {
+          restrict: [
+            '^(p|px|py|pt|pr|pb|pl|m|mx|my|mt|mr|mb|ml|gap|gap-x|gap-y)-\\[',
+            '^(w|h|min-w|min-h|max-w|max-h|size)-\\[',
+            '^rounded-\\[',
+            '^text-\\[(?!#)',
+            '^leading-\\[',
+            '^tracking-\\[',
+            '^(bg|border|outline|ring|fill|stroke)-\\[(?!#)',
+          ],
+        },
+      ],
+      // Tailwind에 존재하지 않는 class 오타 방지
+      'better-tailwindcss/no-unknown-classes': 'error',
+      // 같은 역할의 class가 중복/충돌되는 경우 방지
+      'better-tailwindcss/no-conflicting-classes': 'error',
+      // left-0 right-0 -> inset-x-0 같은 표준 class 사용 권장
+      'better-tailwindcss/enforce-canonical-classes': 'warn',
+    },
+  }, // 5. Prettier와 충돌하는 ESLint 규칙들 비활성화
+  // 포맷팅은 Prettier가 담당, ESLint는 코드 품질만 담당
+  prettier,
+  storybook.configs['flat/recommended']
+)

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@vitest/coverage-v8": "^4.1.3",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-better-tailwindcss": "^4.4.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-better-tailwindcss:
+        specifier: ^4.4.0
+        version: 4.4.0(eslint@9.39.4(jiti@2.6.1))(tailwindcss@4.2.2)(typescript@6.0.2)
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -514,6 +517,10 @@ packages:
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/css-tree@4.0.1':
+    resolution: {integrity: sha512-2fCSKRwoUHntYq9J1Lm28s2zeoCSNh1Cbk6Tg7k7ViwOnveIfZwPRFGwBglz+dzw2MHe5w5Fo9+VJfqL9nco2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -644,6 +651,10 @@ packages:
 
   '@oxc-project/types@0.123.0':
     resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1095,6 +1106,11 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.1':
     resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@valibot/to-json-schema@1.6.0':
+    resolution: {integrity: sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==}
+    peerDependencies:
+      valibot: ^1.3.0
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -1615,6 +1631,19 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-better-tailwindcss@4.4.0:
+    resolution: {integrity: sha512-OVFcRnyFOMJR7dFhlfNbIBlM7D4o1g1yBGDCWvsJWliXFE4c4U06CEZ0pcFatHa5g7PAwiDRAd57gxxJT/7EIQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+      oxlint: ^1.35.0
+      tailwindcss: ^3.3.0 || ^4.1.17
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      oxlint:
+        optional: true
 
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
@@ -2287,6 +2316,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
@@ -2790,9 +2822,22 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tailwind-csstree@0.3.1:
+    resolution: {integrity: sha512-v147gLOR+E+9H4dNaP9rBeS/S/CTQJMRItlX9jLOXjdBGfSRauLwiz7LBCViaQmn6URXIlOdN6iMzSzOaeoUUw==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      '@eslint/css': '>=1.0.0'
+    peerDependenciesMeta:
+      '@eslint/css':
+        optional: true
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -2854,6 +2899,10 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  tsconfig-paths-webpack-plugin@4.2.0:
+    resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
+    engines: {node: '>=10.13.0'}
 
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
@@ -2929,6 +2978,14 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vite@8.0.7:
     resolution: {integrity: sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==}
@@ -3491,6 +3548,11 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/css-tree@4.0.1':
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
@@ -3621,6 +3683,8 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@oxc-project/types@0.123.0': {}
+
+  '@pkgr/core@0.2.9': {}
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -4054,6 +4118,10 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
+
+  '@valibot/to-json-schema@1.6.0(valibot@1.3.1(typescript@6.0.2))':
+    dependencies:
+      valibot: 1.3.1(typescript@6.0.2)
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.7(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
@@ -4695,6 +4763,23 @@ snapshots:
   eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-plugin-better-tailwindcss@4.4.0(eslint@9.39.4(jiti@2.6.1))(tailwindcss@4.2.2)(typescript@6.0.2):
+    dependencies:
+      '@eslint/css-tree': 4.0.1
+      '@valibot/to-json-schema': 1.6.0(valibot@1.3.1(typescript@6.0.2))
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      synckit: 0.11.12
+      tailwind-csstree: 0.3.1
+      tailwindcss: 4.2.2
+      tsconfig-paths-webpack-plugin: 4.2.0
+      valibot: 1.3.1(typescript@6.0.2)
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+    transitivePeerDependencies:
+      - '@eslint/css'
+      - typescript
 
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
@@ -5348,6 +5433,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.27.1: {}
+
   meow@13.2.0: {}
 
   mime-db@1.52.0: {}
@@ -5926,7 +6013,13 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
+
   tagged-tag@1.0.0: {}
+
+  tailwind-csstree@0.3.1: {}
 
   tailwind-merge@3.5.0: {}
 
@@ -5968,6 +6061,13 @@ snapshots:
       typescript: 6.0.2
 
   ts-dedent@2.2.0: {}
+
+  tsconfig-paths-webpack-plugin@4.2.0:
+    dependencies:
+      chalk: 4.1.2
+      enhanced-resolve: 5.20.1
+      tapable: 2.3.2
+      tsconfig-paths: 4.2.0
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -6064,6 +6164,10 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
       react: 19.2.5
+
+  valibot@1.3.1(typescript@6.0.2):
+    optionalDependencies:
+      typescript: 6.0.2
 
   vite@8.0.7(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:

--- a/src/components/common/modal/character/CharacterSelectModal.tsx
+++ b/src/components/common/modal/character/CharacterSelectModal.tsx
@@ -8,8 +8,7 @@ import {
 } from '@/assets/images'
 import { cn } from '@/utils/cn'
 
-import type { ModalProps } from '../base/Modal'
-import { Modal } from '../base/Modal'
+import { Modal, type ModalProps } from '../base/Modal'
 
 // 상수로 뺄지 일단 보류
 const CHARACTERS = [
@@ -47,7 +46,7 @@ export function CharacterSelectModal({
     >
       <Modal.Header
         description={
-          <p className="text-[10px] text-red-400">
+          <p className="text-2xs text-red-400">
             프로필 캐릭터는 한 번 선택하면 변경할 수 없습니다.
           </p>
         }
@@ -63,15 +62,11 @@ export function CharacterSelectModal({
               aria-label={label}
               onClick={() => setSelectedId(id)}
               className={cn(
-                'relative flex size-[70px] cursor-pointer transition-transform duration-300',
+                'relative flex size-17.5 cursor-pointer transition-transform duration-300',
                 selectedId === id && 'scale-110'
               )}
             >
-              <img
-                src={src}
-                alt={label}
-                className="h-full w-full object-contain"
-              />
+              <img src={src} alt={label} className="size-full object-contain" />
               {selectedId !== id && (
                 <div className="pointer-events-none absolute inset-0 rounded-full bg-gray-200/70" />
               )}

--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -24,7 +24,7 @@ export default function Footer() {
                 className="flex items-center gap-2 rounded-full bg-white/5 px-4 py-2 text-sm text-gray-400 transition-all duration-200 hover:bg-white/10 hover:text-white hover:scale-105"
               >
                 <svg
-                  className="h-4 w-4"
+                  className="size-4 "
                   viewBox="0 0 19 19"
                   aria-hidden="true"
                   fill="none"

--- a/src/index.css
+++ b/src/index.css
@@ -279,6 +279,8 @@ body {
     --border-mypage-stats-card-yellow
   );
 
+  --text-2xs: 0.625rem;
+
   --shadow-card-light: var(--shadow-card-light);
   --shadow-card-main: var(--shadow-card-main);
   --shadow-card-hover: var(--shadow-card-hover);


### PR DESCRIPTION
## 📌 관련 이슈

Closes #36

## ✨ 변경 내용

  - `eslint-plugin-better-tailwindcss` 설정 추가
  - Tailwind arbitrary value 제한 규칙 추가
  - Storybook 파일은 예시 화면 구성을 위해 Tailwind lint 대상에서 제외
  - `10px` 텍스트 사용을 위해 `text-2xs` theme token 추가
  - 캐릭터 모달의 `text-[10px]`를 `text-2xs`로 변경
  - Footer 아이콘 크기 class를 `h-4 w-4`에서 `size-4`로 변경

## 📸 스크린샷(선택)

## 📚 참고사항

  - `text-[#979797]`, `bg-[#EAFBF3]` 같은 hex 색상 arbitrary value는 임시 허용했습니다.
  - `text-[var(--...)]`, `bg-[var(--...)]`처럼 CSS variable을 class에서 직접 사용하는 방식은 제한했습니다.
  - `px-[18px]`, `text-[12px]`, `rounded-[100px]` 같은 spacing / size / font 관련arbitrary value는 Tailwind scale 또는 theme token 사용을 유도하도록 설정했습니다.
  - 반복 사용되는 색상은 추후 `src/index.css`의 primitive / semantic token으로 추가해서 사용하는 방향이 좋습니다.
  - `pnpm install --frozen-lockfile` 설치