### PR TITLE
chore: add build check workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project
+        run: pnpm build


### PR DESCRIPTION
## 📌 관련 이슈

Closes #38

## ✨ 변경 내용

 - PR 단계에서 빌드 체크를 수행하는 GitHub Actions CI 워크플로우 추가
 - PR 생성 및 업데이트 시 아래 작업이 순차적으로 실행됩니다.
	• pnpm install --frozen-lockfile
	• pnpm lint
	• pnpm tsc --noEmit
	• pnpm build
 - workflow_dispatch 옵션을 추가하여 수동 실행이 가능하도록 구성

## 📸 스크린샷(선택)

## 📚 참고사항
- 추후 브랜치 보호 규칙(Require status checks) 설정 시 CI 통과가 머지 조건으로 적용될 예정