### PR TITLE
docs: update common component structure

### DIFF
--- a/docs/CONVENTION.md
+++ b/docs/CONVENTION.md
@@ -12,7 +12,6 @@
 src
 ├── assets/images
 ├── components/common
-├── components/layouts
 ├── constants
 ├── features
 ├── hooks
@@ -28,7 +27,7 @@ src
 - 기능은 `features` 단위로 분리합니다.
 - `pages`는 라우트 진입점만 담당합니다.
 - 공통 UI는 `components/common`에 둡니다.
-- 레이아웃 컴포넌트는 `components/layouts`에 둡니다.
+- 레이아웃 컴포넌트는 `components/common/layout`에 둡니다.
 - `features`끼리는 직접 참조하지 않습니다.
 - 여러 곳에서 재사용되는 로직만 전역 폴더로 분리합니다.
 
@@ -37,8 +36,11 @@ src
 - `pages`: 라우트 단위 화면 컴포넌트
 - `router`: 라우팅 설정
 - `features`: 기능 단위 코드
-- `components/common`: 여러 곳에서 재사용하는 공통 UI
-- `components/layouts`: Header, Footer, RootLayout 같은 공통 레이아웃
+- `components/common`: 여러 곳에서 재사용하는 공통 UI, 오버레이, 레이아웃
+- `components/common/ui`: Badge, Input, Textarea ,Button 등 같은 기본 UI
+- `components/common/ui/field`: Input, Textarea 같은 입력 필드 UI
+- `components/common/overlay`: Modal, Dropdown 같은 화면 위에 뜨는 UI
+- `components/common/layout`: Header, Footer, RootLayout 같은 공통 레이아웃
 - `hooks`: 여러 곳에서 재사용하는 커스텀 훅
 - `hooks/queries`: 서버 상태, API 요청 관련 훅
 - `constants`: 여러 곳에서 공유하는 상수
@@ -64,6 +66,8 @@ src
 - 공통으로 필요해진 로직만 `hooks`, `utils`, `constants`로 분리합니다.
 - 프로젝트 내부 import는 `@/*` alias를 우선 사용합니다.
 - 공통 컴포넌트는 필요한 경우 같은 폴더에 `index.ts`를 두어 export합니다.
+- `Input`, `Textarea`처럼 입력 필드 성격의 UI는 `components/common/ui/field` 아래에 둡니다.
+- 공통 컴포넌트의 배럴 export는 각 영역의 `index.ts`에서만 관리합니다.
 
 ## features 작성 기준
 
@@ -94,15 +98,6 @@ src/features/post-create/
 
 - 공통 UI 컴포넌트는 가능하면 같은 폴더에 story를 작성합니다.
 - 스토리 파일명은 `*.stories.tsx` 형식을 사용합니다.
-
-예시
-
-```text
-src/components/common/badge/
-├── Badge.tsx
-├── Badge.stories.tsx
-└── index.ts
-```
 
 ## 커밋 전 체크
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -25,8 +25,7 @@ src
 ├── assets
 │   └── images
 ├── components
-│   ├── common
-│   └── layouts
+│   └── common
 ├── constants
 ├── features
 ├── hooks
@@ -42,8 +41,7 @@ src
 ## 폴더 설명
 
 - `src/assets/images`: 이미지 리소스
-- `src/components/common`: 여러 곳에서 재사용하는 공통 UI
-- `src/components/layouts`: Header, Footer, RootLayout 같은 공통 레이아웃
+- `src/components/common`: 여러 곳에서 재사용하는 공통 UI, 오버레이, 레이아웃
 - `src/constants`: 여러 곳에서 공유하는 상수
 - `src/features`: 기능 단위 코드
 - `src/hooks`: 여러 곳에서 재사용하는 커스텀 훅
@@ -66,8 +64,40 @@ src/features/post-create/
 ## 공통 컴포넌트 구조 예시
 
 ```text
-src/components/common/badge/
-├── Badge.tsx
-├── Badge.stories.tsx
-└── index.ts
+src/components/common/
+├── ui/                     # Badge, Input, Textarea 등 기본 UI
+│   ├── badge/
+│   ├── field/              # Input, Textarea
+│   └── index.ts
+├── overlay/                # Modal, Dropdown 등 화면 위에 뜨는 UI
+│   ├── modal/
+│   ├── dropdown/
+│   └── index.ts
+├── layout/                 # Header, Footer, RootLayout
+│   ├── constants/
+│   └── index.ts
+└── feedback/               # Toast, Loading 등 사용자 피드백 UI
+    ├── toast/
+    ├── loading/
+    └── index.ts
+```
+
+## 공통 컴포넌트 export
+
+- 각 영역의 `index.ts`는 해당 영역에 속한 컴포넌트만 export합니다.
+- `ui/index.ts`는 기본 UI 컴포넌트를 export합니다. 현재 `Badge`, `Input`, `Textarea` , `Button` , `TabButton` , `SearchBar` , `Card` 를 export하며, `Input`과 `Textarea`는 입력 필드 성격이므로 `field` 폴더 아래에서 가져옵니다.
+- `overlay/index.ts`는 화면 위에 뜨는 UI를 export합니다. 현재 `Dropdown`, `ActionMenu`를 직접 export하고, modal 관련 컴포넌트는 `modal/index.ts`에서 모아 다시 export합니다.
+- `overlay/modal/index.ts`는 modal에 속한 컴포넌트를 export합니다. 기본 구성 요소인 `Modal`, `ModalHeader`, `ModalContent`, `ModalFooter`와 목적별 modal인 `CharacterSelectModal`, `ConfirmModal`, `ReportFormModal`을 포함합니다.
+- `layout/index.ts`는 페이지 공통 레이아웃 컴포넌트를 export합니다. 현재 `Header`, `Footer`, `RootLayout`을 포함합니다.
+- `feedback/index.ts`는 사용자 상태나 결과를 알려주는 피드백 UI를 export합니다. `Toast`, `Loading`처럼 화면 상태를 전달하는 컴포넌트를 포함합니다.
+- 새로운 공통 컴포넌트를 추가할 때는 해당 영역의 폴더에 컴포넌트와 story를 함께 두고, 외부에서 사용할 컴포넌트만 해당 영역의 `index.ts`에 추가합니다.
+
+## 사용 예시
+
+```ts
+import { Button } from '@/components/common/button'
+import { Badge, Input, Textarea } from '@/components/common/ui'
+import { ActionMenu, Dropdown, Modal } from '@/components/common/overlay'
+import { Footer, Header } from '@/components/common/layout'
+import { Loading, Toast } from '@/components/common/feedback'
 ```


### PR DESCRIPTION
## 📌 관련 이슈

Closes #39

## ✨ 변경 내용

  - 공통 컴포넌트 폴더 구조를 현재 프로젝트 기준에 맞게 수정
  - Input, Textarea가 ui/field 하위에 위치하도록 문서 반영
  - button, ui, overlay, layout, feedback 영역별 export 설명 추가
  - 공통 컴포넌트 import 사용 예시 업데이트

## 📸 스크린샷(선택)

## 📚 참고사항
