### PR TITLE
feat: common icon button

### DIFF
--- a/src/components/common/dropdown/index.ts
+++ b/src/components/common/dropdown/index.ts
@@ -1,2 +1,0 @@
-export type { DropdownOption } from './Dropdown'
-export { Dropdown } from './Dropdown'

--- a/src/components/common/dropdown/index.ts
+++ b/src/components/common/dropdown/index.ts
@@ -1,0 +1,2 @@
+export type { DropdownOption } from './Dropdown'
+export { Dropdown } from './Dropdown'

--- a/src/components/common/ui/button/IconButton.stories.tsx
+++ b/src/components/common/ui/button/IconButton.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ChevronLeft, MoreVertical, Plus } from 'lucide-react'
+
+import IconButton from './IconButton'
+
+const meta: Meta<typeof IconButton> = {
+  title: 'Common/Button/IconButton',
+  component: IconButton,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof IconButton>
+
+export const Back: Story = {
+  args: {
+    icon: <ChevronLeft size={14} />,
+    'aria-label': '뒤로가기',
+  },
+}
+
+export const More: Story = {
+  args: {
+    icon: <MoreVertical size={14} />,
+    'aria-label': '더보기',
+  },
+}
+
+export const Add: Story = {
+  args: {
+    icon: <Plus size={14} />,
+    'aria-label': '추가',
+  },
+}

--- a/src/components/common/ui/button/IconButton.tsx
+++ b/src/components/common/ui/button/IconButton.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+type IconButtonProps = {
+  icon: React.ReactNode
+  'aria-label': string
+} & Omit<React.ComponentProps<'button'>, 'children'>
+
+export default function IconButton({
+  icon,
+  className,
+  type = 'button',
+  ...props
+}: IconButtonProps) {
+  return (
+    <button type={type} className={className} {...props}>
+      {icon}
+    </button>
+  )
+}

--- a/src/components/common/ui/button/index.ts
+++ b/src/components/common/ui/button/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './Button'
+export { default as IconButton } from './IconButton'


### PR DESCRIPTION
## 📌 관련 이슈

Closes #30

## ✨ 변경 내용

* IconButton 컴포넌트 추가
* lucide-react 아이콘 기반 버튼 구현
* 버튼 내 아이콘 단일 사용 구조로 구성
* 기존 Button 컴포넌트와 분리하여 독립적으로 사용 가능하도록 설계
* 공통 버튼 폴더 구조 변경에 맞춰 위치 이동 및 index export 추가
* 불필요한 dropdown 폴더 제거

## 📸 스크린샷(선택)

<img width="785" height="512" alt="스크린샷 2026-04-14 오후 2 16 11" src="https://github.com/user-attachments/assets/90d9e77f-a44f-4baa-8965-0bd37d0895a5" />

## 📚 참고사항

* IconButton은 상태를 가지지 않는 기본 아이콘 버튼으로 사용
* ToggleButton, ProfileButton은 별도 컴포넌트로 분리 예정
* MoreButton, NavigationButton은 BaseButton variant로 처리 예정
