### PR TITLE
feat: add common Card, GoalCard, GoalCardEdit, PostCard components

### DIFF
--- a/src/components/common/ui/button/Button.style.ts
+++ b/src/components/common/ui/button/Button.style.ts
@@ -19,16 +19,21 @@ export const buttonVariants = cva(
         outline: 'border border-border-subtle bg-gray-100 text-text-muted',
 
         ghost: 'bg-transparent text-text-muted hover:bg-gray-100',
+
+        modal:
+          'bg-button-modal-cancel-bg text-white hover:bg-button-modal-cancel-hover',
       },
 
       size: {
         sm: 'py-1 text-xs',
         md: 'py-1.5 text-sm',
+        lg: 'py-2 text-base',
       },
 
       rounded: {
         md: 'rounded-md',
         full: 'rounded-full',
+        lg: 'rounded-lg',
       },
     },
 

--- a/src/components/common/ui/card/Card.stories.tsx
+++ b/src/components/common/ui/card/Card.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Card } from './Card'
+
+const meta: Meta<typeof Card> = {
+  component: Card,
+  title: 'Common/Card',
+  parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj<typeof Card>
+
+export const Default: Story = {
+  render: () => <Card />,
+}
+
+export const DarkDefault: Story = {
+  render: () => (
+    <div className="dark bg-surface p-6 rounded-lg">
+      <Card />
+    </div>
+  ),
+}

--- a/src/components/common/ui/card/Card.tsx
+++ b/src/components/common/ui/card/Card.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/utils/cn'
+
+export type CardProps = React.ComponentProps<'div'>
+
+export function Card({ className, children, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'w-69 h-85 px-2.5 py-3 rounded-2xl bg-surface border border-border-default hover:shadow-card-light hover:border-border-active transition-colors',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/common/ui/card/GoalCard.stories.tsx
+++ b/src/components/common/ui/card/GoalCard.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { GoalCard } from './GoalCard'
+import { GoalCardEdit } from './GoalCardEdit'
+
+const goalCardMeta: Meta<typeof GoalCard> = {
+  component: GoalCard,
+  title: 'Common/GoalCard',
+  parameters: { layout: 'centered' },
+}
+export default goalCardMeta
+
+type GoalCardStory = StoryObj<typeof GoalCard>
+type GoalCardEditStory = StoryObj<typeof GoalCardEdit>
+
+export const Default: GoalCardStory = {
+  render: () => (
+    <GoalCard
+      title="운동하기"
+      status="진행중"
+      startDate="2026.04.01"
+      endDate="2026.08.09"
+      onDelete={() => alert('삭제')}
+    />
+  ),
+}
+
+export const TitleOverflow: GoalCardStory = {
+  render: () => (
+    <GoalCard
+      title="운동하기ddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+      status="진행중"
+      startDate="2026.04.01"
+      endDate="2026.08.09"
+      onDelete={() => alert('삭제')}
+    />
+  ),
+}
+
+export const Completed: GoalCardStory = {
+  render: () => (
+    <GoalCard
+      title="운동하기"
+      status="완료"
+      startDate="2026.04.01"
+      endDate="2026.08.09"
+      onDelete={() => alert('삭제')}
+    />
+  ),
+}
+
+export const DarkDefault: GoalCardStory = {
+  render: () => (
+    <div className="dark bg-surface p-6 rounded-lg">
+      <GoalCard
+        title="운동하기"
+        status="진행중"
+        startDate="2026.04.01"
+        endDate="2026.08.09"
+        onDelete={() => alert('삭제')}
+      />
+    </div>
+  ),
+}
+
+export const Create: GoalCardEditStory = {
+  render: () => (
+    <GoalCardEdit
+      mode="create"
+      onClose={() => alert('닫기')}
+      onSubmit={(data) => alert(JSON.stringify(data))}
+    />
+  ),
+}
+
+export const Edit: GoalCardEditStory = {
+  render: () => (
+    <GoalCardEdit
+      mode="edit"
+      initialTitle="운동하기"
+      onClose={() => alert('닫기')}
+      onSubmit={(data) => alert(JSON.stringify(data))}
+    />
+  ),
+}
+
+export const DarkCreate: GoalCardEditStory = {
+  render: () => (
+    <div className="dark bg-surface p-6 rounded-lg">
+      <GoalCardEdit
+        mode="create"
+        onClose={() => alert('닫기')}
+        onSubmit={(data) => alert(JSON.stringify(data))}
+      />
+    </div>
+  ),
+}

--- a/src/components/common/ui/card/GoalCard.stories.tsx
+++ b/src/components/common/ui/card/GoalCard.stories.tsx
@@ -49,6 +49,18 @@ export const Completed: GoalCardStory = {
   ),
 }
 
+export const NotAchieved: GoalCardStory = {
+  render: () => (
+    <GoalCard
+      title="운동하기"
+      status="미달성"
+      startDate="2026.04.01"
+      endDate="2026.08.09"
+      onDelete={() => alert('삭제')}
+    />
+  ),
+}
+
 export const DarkDefault: GoalCardStory = {
   render: () => (
     <div className="dark bg-surface p-6 rounded-lg">

--- a/src/components/common/ui/card/GoalCard.tsx
+++ b/src/components/common/ui/card/GoalCard.tsx
@@ -1,0 +1,48 @@
+import { Badge, Button } from '@/components/common/ui'
+
+import { Card } from './Card'
+import { type GoalCardProps, STATUS_BADGE_VARIANT } from './GoalCard.types'
+
+export function GoalCard({
+  label = '개별 목표',
+  title,
+  status,
+  startDate,
+  // Todo: 목표 값은 props로 받아와야 함 -> 도넛 차트 생성 시 작업
+  endDate,
+  onDelete,
+}: GoalCardProps) {
+  return (
+    <Card className="flex flex-col gap-2">
+      {/* 상단 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="size-3 rounded-xs bg-text-muted" />
+          <span className="text-text-primary font-bold text-lg">{label}</span>
+        </div>
+        <Badge variant={STATUS_BADGE_VARIANT[status]}>{status}</Badge>
+      </div>
+
+      {/* 날짜 */}
+      <p className="h-4 flex items-center pl-4 text-xs text-text-muted">
+        {startDate} - {endDate}
+      </p>
+
+      {/* 차트 영역 */}
+      <div className="flex flex-col h-55 w-64 p-3 gap-2 rounded-xl border border-border-default">
+        <span className="text-text-primary font-bold w-full text-start truncate">
+          {title}
+        </span>
+        {/* TODO: 도넛 차트 */}
+        <div className="size-39 rounded-full border-2 border-gray-200 mx-auto" />
+      </div>
+
+      {/* 하단 */}
+      <div className="mt-auto flex justify-end">
+        <Button variant="danger" size="sm" rounded="md" onClick={onDelete}>
+          삭제
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/common/ui/card/GoalCard.types.ts
+++ b/src/components/common/ui/card/GoalCard.types.ts
@@ -1,0 +1,30 @@
+import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
+
+export type GoalStatus = '완료' | '진행중' | '미달성'
+
+export type GoalCardProps = {
+  label?: string
+  title: string
+  status: GoalStatus
+  startDate: string
+  endDate: string
+  onDelete: () => void
+}
+
+export type GoalCardEditProps = {
+  label?: string
+  mode: 'create' | 'edit'
+  initialTitle?: string
+  initialDateRange?: DateRange
+  onClose: () => void
+  onSubmit: (data: { title: string; dateRange: DateRange | null }) => void
+}
+
+export const STATUS_BADGE_VARIANT: Record<
+  GoalStatus,
+  'success' | 'warning' | 'error'
+> = {
+  완료: 'success',
+  진행중: 'warning',
+  미달성: 'error',
+}

--- a/src/components/common/ui/card/GoalCardEdit.tsx
+++ b/src/components/common/ui/card/GoalCardEdit.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+
+import { Button, Calendar, Input } from '@/components/common/ui'
+import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
+
+import { Card } from './Card'
+import type { GoalCardEditProps } from './GoalCard.types'
+
+// 목표 값을 props로 받아와야할 수 있음 -> 도넛 차트 생성 시 작업
+export function GoalCardEdit({
+  label = '개별 목표',
+  mode,
+  initialTitle = '',
+  initialDateRange,
+  onClose,
+  onSubmit,
+}: GoalCardEditProps) {
+  const [title, setTitle] = useState(initialTitle)
+  const [dateRange, setDateRange] = useState<DateRange | null>(
+    initialDateRange ?? null
+  )
+
+  const handleSubmit = () => {
+    onSubmit({ title, dateRange })
+  }
+
+  return (
+    <Card className="flex flex-col gap-2">
+      {/* 상단 */}
+      <div className="flex items-center gap-2">
+        <div className="size-3 rounded-xs bg-text-muted" />
+        <span className="text-text-primary font-bold text-lg">{label}</span>
+      </div>
+
+      {/* 캘린더 */}
+      <div className="h-4 flex items-center">
+        <Calendar
+          label="날짜를 선택하세요"
+          value={dateRange ?? undefined}
+          onChange={setDateRange}
+        />
+      </div>
+
+      {/* 차트 영역 */}
+      <div className="flex flex-col h-55 w-64 p-3 gap-2 rounded-xl border border-border-default">
+        <Input
+          placeholder="제목을 입력하세요"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="h-8 py-1 px-2 text-sm"
+        />
+        {/* TODO: 도넛 차트 임시*/}
+        <div className="size-39 rounded-full border-2 border-gray-200 mx-auto" />
+      </div>
+
+      {/* 하단 */}
+      <div className="mt-auto flex justify-end gap-2">
+        <Button variant="modal" size="sm" onClick={onClose}>
+          닫기
+        </Button>
+        <Button variant="primary" size="sm" onClick={handleSubmit}>
+          {mode === 'edit' ? '수정' : '등록'}
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/common/ui/card/PostCard.stories.tsx
+++ b/src/components/common/ui/card/PostCard.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { PostCard } from './PostCard'
+
+const meta: Meta<typeof PostCard> = {
+  component: PostCard,
+  title: 'Common/PostCard',
+  parameters: { layout: 'centered' },
+}
+export default meta
+
+type Story = StoryObj<typeof PostCard>
+
+const baseProps = {
+  profileImage: 'https://picsum.photos/28/28?random=1',
+  nickname: '작심며칠',
+  createdAt: '3시간 전',
+  title: '운동 vs 공부 뭐부터 할까? 진짜 너무 고민된다 아무것도 못하겠어',
+  preview:
+    '오늘부터 마음 다시 잡으려고 합니다 운동이랑 공부 중에 뭐부터 시작하면 좋을까요. 사실 둘 다 하고 싶긴 한데 체력이 딸려서 고민이에요. 여러분은 어떻게 하시나요?',
+  tags: ['공부', '운동'],
+  likeCount: 10,
+  commentCount: 0,
+  isBookmarked: false,
+  onLike: () => {},
+  onShare: () => {},
+  onBookmark: () => {},
+}
+
+export const WithImage: Story = {
+  render: () => (
+    <PostCard {...baseProps} image="https://picsum.photos/276/128?random=10" />
+  ),
+}
+
+export const WithoutImage: Story = {
+  render: () => <PostCard {...baseProps} />,
+}
+
+export const Bookmarked: Story = {
+  render: () => <PostCard {...baseProps} isBookmarked />,
+}
+
+export const DarkWithImage: Story = {
+  render: () => (
+    <div className="dark bg-surface p-6 rounded-lg">
+      <PostCard
+        {...baseProps}
+        image="https://picsum.photos/276/128?random=10"
+      />
+    </div>
+  ),
+}
+
+export const DarkWithoutImage: Story = {
+  render: () => (
+    <div className="dark bg-surface p-6 rounded-lg">
+      <PostCard {...baseProps} />
+    </div>
+  ),
+}

--- a/src/components/common/ui/card/PostCard.tsx
+++ b/src/components/common/ui/card/PostCard.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+
+import { Bookmark, Heart, MessageCircle, Share2 } from 'lucide-react'
+
+import { Button } from '@/components/common/ui'
+
+import { Card } from './Card'
+import type { PostCardProps } from './PostCard.types'
+
+export type { PostCardProps } from './PostCard.types'
+
+// 추후 hook으로 정리 필요
+export function PostCard({
+  image,
+  profileImage,
+  nickname,
+  createdAt,
+  title,
+  tags,
+  preview,
+  likeCount,
+  commentCount,
+  isBookmarked = false,
+  isLiked = false,
+  onClick,
+  onLike,
+  onShare,
+  onBookmark,
+}: PostCardProps) {
+  const [bookmarked, setBookmarked] = useState(isBookmarked)
+  const [liked, setLiked] = useState(isLiked)
+  const [localLikeCount, setLocalLikeCount] = useState(likeCount)
+
+  // API 연결 시 낙관적 업데이트나 useEffect 등으로 동기화 처리가 필요
+  const toggleLike = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    setLocalLikeCount((prev) => (liked ? prev - 1 : prev + 1))
+    setLiked((prev) => !prev)
+    onLike()
+  }
+
+  const toggleBookmark = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    setBookmarked((prev) => !prev)
+    onBookmark()
+  }
+
+  const handleShare = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    onShare()
+  }
+
+  return (
+    <Card
+      className="p-0 h-84.5 overflow-hidden flex flex-col cursor-pointer"
+      onClick={onClick}
+    >
+      {/* 이미지 (선택) */}
+      {image && (
+        <img
+          src={image}
+          alt={`${title} 이미지`}
+          className="w-full h-32 object-cover shrink-0"
+        />
+      )}
+
+      {/* 게시글 내용 */}
+      <div className="flex flex-col flex-1 min-h-0 px-4 py-5">
+        {/* 프로필 */}
+        <div className="flex items-center gap-2 mb-2">
+          <img
+            src={profileImage}
+            alt={nickname}
+            className="size-7 rounded-full object-cover shrink-0"
+          />
+          <div className="min-w-0 text-2xs">
+            <p className="font-semibold text-text-primary truncate">
+              {nickname}
+            </p>
+            {/* TODO: 시간 포맷 변경 필요 -> 2026.04.14 12:00 로 할건지 몇시간 전, 몇일 전으로 할건지 정해지면 */}
+            <p className="text-text-muted">{createdAt}</p>
+          </div>
+        </div>
+
+        {/* 제목 */}
+        <h3 className="text-text-primary line-clamp-1 mb-0 font-semibold">
+          {title}
+        </h3>
+
+        {/* 태그 */}
+        {tags.length > 0 && (
+          <div className="flex flex-wrap text-xs text-text-muted gap-1 mb-3">
+            {tags.map((tag) => (
+              <span key={tag}>#{tag}</span>
+            ))}
+          </div>
+        )}
+
+        {/* 내용 미리보기 */}
+        <p className="text-sm text-text-muted line-clamp-2">{preview}</p>
+      </div>
+
+      {/* 하단 액션 */}
+      <div className="flex items-center border-t border-border-default px-5 py-2">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1 text-xs text-text-muted">
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label="좋아요"
+              aria-pressed={liked}
+              className="p-0 hover:bg-transparent"
+              onClick={toggleLike}
+            >
+              <Heart
+                size={16}
+                className={
+                  liked ? 'fill-current text-error-500' : 'text-text-muted'
+                }
+              />
+            </Button>
+            <span className="tabular-nums min-w-[1ch]">{localLikeCount}</span>
+          </div>
+          <span className="flex items-center gap-1 text-xs text-text-muted">
+            <MessageCircle size={16} />
+            <span className="tabular-nums min-w-[1ch]">{commentCount}</span>
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="공유하기"
+            className="p-0 hover:bg-transparent"
+            onClick={handleShare}
+          >
+            <Share2 size={16} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={bookmarked ? '스크랩 취소' : '스크랩'}
+            aria-pressed={bookmarked}
+            className="p-0 hover:bg-transparent"
+            onClick={toggleBookmark}
+          >
+            <Bookmark
+              size={16}
+              className={
+                bookmarked ? 'fill-current text-primary-600' : 'text-text-muted'
+              }
+            />
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/common/ui/card/PostCard.tsx
+++ b/src/components/common/ui/card/PostCard.tsx
@@ -20,12 +20,12 @@ export function PostCard({
   preview,
   likeCount,
   commentCount,
-  isBookmarked = false,
-  isLiked = false,
-  onClick,
-  onLike,
-  onShare,
-  onBookmark,
+  isBookmarked = false, // 스크랩 여부
+  isLiked = false, // 좋아요 여부
+  onClick, // 게시글 클릭 시 이동할 페이지로 이동
+  onLike, // 좋아요 버튼 클릭 시
+  onShare, // 공유 버튼 클릭 시
+  onBookmark, // 스크랩 버튼 클릭 시
 }: PostCardProps) {
   const [bookmarked, setBookmarked] = useState(isBookmarked)
   const [liked, setLiked] = useState(isLiked)

--- a/src/components/common/ui/card/PostCard.types.ts
+++ b/src/components/common/ui/card/PostCard.types.ts
@@ -1,0 +1,17 @@
+export type PostCardProps = {
+  image?: string
+  profileImage: string
+  nickname: string
+  createdAt: string
+  title: string
+  tags: string[]
+  preview: string
+  likeCount: number
+  commentCount: number
+  isBookmarked?: boolean
+  isLiked?: boolean
+  onClick?: () => void
+  onLike: () => void
+  onShare: () => void
+  onBookmark: () => void
+}

--- a/src/components/common/ui/field/SearchBar.tsx
+++ b/src/components/common/ui/field/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useState } from 'react'
 
 import { Search } from 'lucide-react'
 
@@ -13,27 +13,30 @@ export type SearchBarProps = {
 export function SearchBar({
   onSearch,
   className,
+  onChange,
   placeholder = '검색',
   ...props
 }: SearchBarProps) {
-  const inputRef = useRef<HTMLInputElement>(null)
+  const [value, setValue] = useState('')
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      onSearch?.(e.currentTarget.value)
-    }
+  const handleSearch = () => {
+    onSearch?.(value)
   }
 
-  const handleClickSearch = () => {
-    if (inputRef.current) {
-      onSearch?.(inputRef.current.value)
-    }
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value)
+    onChange?.(e)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') handleSearch()
   }
 
   return (
     <div className={cn('w-full', className, 'relative')}>
       <Input
-        ref={inputRef}
+        value={value}
+        onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         className="rounded-full pr-10"
@@ -42,7 +45,7 @@ export function SearchBar({
       <button
         type="button"
         aria-label="검색"
-        onClick={handleClickSearch}
+        onClick={handleSearch}
         className="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-text-muted hover:text-text-primary transition-colors cursor-pointer"
       >
         <Search size={20} />

--- a/src/components/common/ui/index.ts
+++ b/src/components/common/ui/index.ts
@@ -2,6 +2,15 @@ export type { BadgeProps } from './badge/Badge'
 export { Badge } from './badge/Badge'
 export { Button } from './button/Button'
 export { Calendar } from './calendar/Calendar'
+export { Card, type CardProps } from './card/Card'
+export { GoalCard } from './card/GoalCard'
+export {
+  type GoalCardEditProps,
+  type GoalCardProps,
+} from './card/GoalCard.types'
+export { GoalCardEdit } from './card/GoalCardEdit'
+export { PostCard } from './card/PostCard'
+export { type PostCardProps } from './card/PostCard.types'
 export { Input, type InputProps } from './field/Input'
 export { SearchBar, type SearchBarProps } from './field/SearchBar'
 export { Textarea, type TextareaProps } from './field/Textarea'

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,7 @@ body {
   ======================== */
 
   /* primary */
+  --color-primary-50: #e8f1ff;
   --color-primary-100: #e3eef7;
   --color-primary-400: #6b94ff;
   --color-primary-500: #3c7dff;
@@ -164,6 +165,15 @@ body {
   --button-danger-hover: var(--color-danger-200);
   --button-danger-text: var(--color-danger-500);
 
+  --button-modal-cancel-bg: var(--color-gray-950);
+  --button-modal-cancel-hover: var(--color-gray-700);
+
+  /* =========================
+     Dropdown
+  ========================= */
+  --dropdown-item-hover-bg: var(--color-primary-50);
+  --dropdown-item-hover-text: var(--color-primary-600);
+
   /* =========================
      Tab
   ========================= */
@@ -280,6 +290,15 @@ body {
   --button-danger-hover: rgba(255, 107, 107, 0.25);
   --button-danger-text: #ff8a8a;
 
+  --button-modal-cancel-bg: var(--color-gray-700);
+  --button-modal-cancel-hover: var(--color-gray-500);
+
+  /* =========================
+     Dropdown
+  ========================= */
+  --dropdown-item-hover-bg: transparent;
+  --dropdown-item-hover-text: var(--color-primary-400);
+
   /* =========================
      Shadow
   ========================= */
@@ -291,6 +310,8 @@ body {
 
 @theme inline {
   --font-sans: 'Pretendard', ui-sans-serif, system-ui, sans-serif;
+
+  --text-2xs: 0.625rem;
 
   --color-primary-100: var(--color-primary-100);
   --color-primary-400: var(--color-primary-400);
@@ -349,6 +370,12 @@ body {
   --color-button-danger-bg: var(--button-danger-bg);
   --color-button-danger-hover: var(--button-danger-hover);
   --color-button-danger-text: var(--button-danger-text);
+
+  --color-button-modal-cancel-bg: var(--button-modal-cancel-bg);
+  --color-button-modal-cancel-hover: var(--button-modal-cancel-hover);
+
+  --color-dropdown-item-hover-bg: var(--dropdown-item-hover-bg);
+  --color-dropdown-item-hover-text: var(--dropdown-item-hover-text);
 
   --color-tab-active-bg: var(--tab-active-bg);
   --color-tab-hover-bg: var(--tab-hover-bg);


### PR DESCRIPTION
## 📌 관련 이슈

Closes #47 

## ✨ 변경 내용

- Card — 공통 카드 레이아웃 베이스 컴포넌트 (`w-69 h-84.5`, rounded-2xl, hover 효과)
- GoalCard — 목표 조회 카드 (status Badge, 날짜, 도넛차트 플레이스홀더, 삭제 버튼)
- GoalCardEdit — 목표 생성/수정 카드 (Calendar, Input, create/edit mode으로 분기)
- PostCard — 게시글 카드 (선택 이미지, 프로필, 태그, 내용 미리보기, 좋아요/스크랩/공유 액션)
- 구현한 카드 컴포넌트 Storybook에 dark 모드와 함께 테스트
- Button.style.ts 에 'modal' variant 추가 (모달에서만 사용하는 취소 버튼 용도 -> 카드 컴포넌트에서도 쓰이지만 일단 modal 로 두었습니다.) + size: lg , rounded: lg 추가
- modal에 사용할 디자인 토큰을 추가 index.css 에 추가 + text-2xs 값 추가 (10px 글씨 용도) 

## 📸 스크린샷(선택)

https://github.com/user-attachments/assets/f726bbc9-81f0-4e81-9096-a4814ea31492


## 📚 참고사항
TODO (추후 작업)
- 도넛 차트 구현 시 실제 컴포넌트로 교체
- `createdAt` 포맷 결정 (절대 날짜 vs 상대 시간) -> Figma에는 0000.00.00 으로 되어 있는데 3시간 전, 1일전, 이런식으로 보이는건 어떨까요 
- 좋아요/스크랩 API 연동 시 낙관적 업데이트 해야함
- 공통 Button 컴포넌트에 cursor-pointer를 기본으로 두는건 어떨까요 -> 버튼 사용할 때 마다 cursor-pointer 값을 줘야하는 상황
- 공통 컴포넌트 Input에서 현재 input의 배경색이 bg-white로 구성 되어있음 -> bg-input-bg 로 변경 시 dark 모드 대응 가능 다음 PR에 제가 수정해도 괜찮을까요?