### PR TITLE
refactor: apply Button , Textarea to overlay component

### DIFF
--- a/src/components/common/overlay/dropdown/Dropdown.stories.tsx
+++ b/src/components/common/overlay/dropdown/Dropdown.stories.tsx
@@ -30,3 +30,14 @@ export const Default: Story = {
     )
   },
 }
+
+export const DarkDefault: Story = {
+  render: () => {
+    const [value, setValue] = useState('')
+    return (
+      <div className="dark bg-surface p-6 rounded-lg w-[340px]">
+        <Dropdown options={reportOptions} value={value} onChange={setValue} />
+      </div>
+    )
+  },
+}

--- a/src/components/common/overlay/dropdown/Dropdown.tsx
+++ b/src/components/common/overlay/dropdown/Dropdown.tsx
@@ -11,7 +11,7 @@ const MAX_VISIBLE_ITEMS = 4
 const LIST_MAX_HEIGHT = ITEM_HEIGHT * MAX_VISIBLE_ITEMS
 
 const dropdownTriggerVariants = cva(
-  'flex w-full items-center justify-between border border-border-default bg-white text-sm text-text-muted transition-colors cursor-pointer',
+  'flex w-full items-center justify-between border border-border-default bg-surface text-sm text-text-muted transition-colors cursor-pointer',
   {
     variants: {
       size: {
@@ -26,7 +26,7 @@ const dropdownTriggerVariants = cva(
 )
 
 const dropdownListVariants = cva(
-  'absolute left-0 right-0 z-50 mt-2 overflow-hidden bg-white',
+  'absolute left-0 right-0 z-50 mt-2 overflow-hidden bg-surface',
   {
     variants: {
       size: {
@@ -89,7 +89,6 @@ export function Dropdown({
 
   return (
     <div ref={ref} className="relative w-full min-w-64">
-      {/* TODO: 버튼 공통 컴포넌트 만들면 적용 */}
       <button
         id={id}
         type="button"
@@ -97,7 +96,7 @@ export function Dropdown({
         className={cn(
           dropdownTriggerVariants({ size }),
           (isOpen || value) && 'border-border-active',
-          value && 'text-gray-900 cursor-pointer'
+          value && 'text-text-primary cursor-pointer'
         )}
       >
         <span>{selectedLabel ?? placeholder}</span>
@@ -105,7 +104,7 @@ export function Dropdown({
           size={16}
           strokeWidth={1.5}
           className={cn(
-            'text-gray-700 transition-transform duration-200',
+            'text-text-muted transition-transform duration-200',
             isOpen && 'rotate-180'
           )}
         />
@@ -137,7 +136,7 @@ export function Dropdown({
                     'w-full p-4 text-left text-sm rounded-sm transition-colors cursor-pointer',
                     value === opt.value
                       ? 'bg-primary-500 text-white'
-                      : 'hover:bg-primary-100/21 hover:text-primary-600 hover:font-semibold'
+                      : 'text-text-primary hover:bg-dropdown-item-hover-bg hover:text-dropdown-item-hover-text hover:font-semibold'
                   )}
                 >
                   {opt.label}

--- a/src/components/common/overlay/dropdown/action-menu/ActionMenu.stories.tsx
+++ b/src/components/common/overlay/dropdown/action-menu/ActionMenu.stories.tsx
@@ -38,6 +38,23 @@ export const MyPage: Story = {
   render: (args) => <ActionMenu {...args} trigger={<DotsIcon />} />,
 }
 
+export const DarkMyPage: Story = {
+  args: {
+    align: 'right',
+    items: [
+      { label: '마이페이지', onClick: () => {} },
+      { label: '프로필 수정', onClick: () => {} },
+      { label: '로그아웃', onClick: () => {} },
+      { label: '회원탈퇴', onClick: () => {} },
+    ],
+  },
+  render: (args) => (
+    <div className="dark bg-surface p-6 rounded-lg">
+      <ActionMenu {...args} trigger={<DotsIcon />} />
+    </div>
+  ),
+}
+
 export const PostActions: Story = {
   args: {
     align: 'right',
@@ -48,4 +65,20 @@ export const PostActions: Story = {
     ],
   },
   render: (args) => <ActionMenu {...args} trigger={<DotsIcon />} />,
+}
+
+export const DarkPostActions: Story = {
+  args: {
+    align: 'right',
+    items: [
+      { label: '수정', onClick: () => {} },
+      { label: '삭제', onClick: () => {} },
+      { label: '신고', onClick: () => {} },
+    ],
+  },
+  render: (args) => (
+    <div className="dark bg-surface p-6 rounded-lg">
+      <ActionMenu {...args} trigger={<DotsIcon />} />
+    </div>
+  ),
 }

--- a/src/components/common/overlay/dropdown/action-menu/ActionMenu.tsx
+++ b/src/components/common/overlay/dropdown/action-menu/ActionMenu.tsx
@@ -50,7 +50,7 @@ export function ActionMenu({
       {(isOpen || isClosing) && (
         <ul
           className={cn(
-            'absolute z-10 mt-1 min-w-30 rounded-xl shadow-card-main px-4 py-3.5',
+            'absolute z-10 mt-1 min-w-30 rounded-xl shadow-card-main bg-surface px-4 py-3.5',
             align === 'right' ? 'right-0' : 'left-0',
             isClosing
               ? 'animate-[dropdown-out_0.2s_ease-in_forwards]'
@@ -66,7 +66,7 @@ export function ActionMenu({
                   onClick()
                   close()
                 }}
-                className="w-full px-1.5 py-1 text-center text-sm rounded-sm cursor-pointer hover:bg-primary-100 hover:text-primary-600 hover:font-semibold"
+                className="w-full px-1.5 py-1 text-center text-sm rounded-sm cursor-pointer text-text-primary hover:bg-dropdown-item-hover-bg hover:text-dropdown-item-hover-text hover:font-semibold"
               >
                 {label}
               </button>

--- a/src/components/common/overlay/modal/base/Modal.tsx
+++ b/src/components/common/overlay/modal/base/Modal.tsx
@@ -9,7 +9,7 @@ import { ModalContent } from './ModalContent'
 import { ModalFooter } from './ModalFooter'
 import { ModalHeader } from './ModalHeader'
 
-const modalVariants = cva('w-full bg-white shadow-card-active', {
+const modalVariants = cva('w-full bg-surface shadow-card-active', {
   variants: {
     size: {
       default: 'max-w-100 text-sm p-7',
@@ -22,7 +22,7 @@ const modalVariants = cva('w-full bg-white shadow-card-active', {
     },
     border: {
       none: '',
-      default: 'border border-gray-200',
+      default: 'border border-border-default',
       // 추가 가능
     },
   },

--- a/src/components/common/overlay/modal/character/CharacterSelectModal.stories.tsx
+++ b/src/components/common/overlay/modal/character/CharacterSelectModal.stories.tsx
@@ -43,3 +43,18 @@ export const Default: Story = {
     onClose: () => {},
   },
 }
+
+export const Dark: Story = {
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => <CharacterSelectModal {...args} />,
+  args: {
+    onSelect: () => {},
+    onClose: () => {},
+  },
+}

--- a/src/components/common/overlay/modal/character/CharacterSelectModal.tsx
+++ b/src/components/common/overlay/modal/character/CharacterSelectModal.tsx
@@ -6,6 +6,7 @@ import {
   pinkCharacterImage,
   yellowCharacterImage,
 } from '@/assets/images'
+import { Button } from '@/components/common/ui'
 import { cn } from '@/utils/cn'
 
 import { Modal, type ModalProps } from '../base/Modal'
@@ -72,30 +73,31 @@ export function CharacterSelectModal({
                 className="h-full w-full object-contain"
               />
               {selectedId !== id && (
-                <div className="pointer-events-none absolute inset-0 rounded-full bg-gray-200/70" />
+                <div className="pointer-events-none absolute inset-0 rounded-full bg-gray-200/70 dark:bg-gray-950/50" />
               )}
             </button>
           ))}
         </div>
       </Modal.Content>
-      <Modal.Footer className="mt-7 gap-3 font-light text-white text-xs">
-        {/* TODO: 버튼 공통 컴포넌트 만들면 적용 */}
-        <button
-          type="button"
+      <Modal.Footer className="mt-7 gap-3">
+        <Button
+          variant="modal"
+          rounded="lg"
           onClick={onClose}
-          className="rounded-lg bg-gray-950 px-5 py-1.5 cursor-pointer"
+          className="px-5 py-1.5 text-xs font-light"
         >
           닫기
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          variant="primary"
+          rounded="lg"
           onClick={handleSelect}
           disabled={!selectedId}
           aria-disabled={!selectedId}
-          className="rounded-lg bg-primary-500 px-5 py-1.5 cursor-pointer"
+          className="px-5 py-1.5 text-xs font-light"
         >
           선택
-        </button>
+        </Button>
       </Modal.Footer>
     </Modal>
   )

--- a/src/components/common/overlay/modal/confirm/ConfirmModal.stories.tsx
+++ b/src/components/common/overlay/modal/confirm/ConfirmModal.stories.tsx
@@ -88,3 +88,40 @@ export const Register: Story = {
     cancelLabel: '취소',
   },
 }
+
+export const DarkDelete: Story = {
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => <ConfirmModal {...args} />,
+  args: {
+    description:
+      '삭제된 내용은 복구할 수 없습니다.\n게시글을 정말로 삭제하시겠습니까?',
+    confirmLabel: '삭제',
+    cancelLabel: '취소',
+    onConfirm: () => {},
+    onClose: () => {},
+  },
+}
+
+export const DarkRegister: Story = {
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => <ConfirmModal {...args} />,
+  args: {
+    description: '게시글을 등록하시겠습니까?',
+    confirmLabel: '등록',
+    cancelLabel: '취소',
+    onConfirm: () => {},
+    onClose: () => {},
+  },
+}

--- a/src/components/common/overlay/modal/confirm/ConfirmModal.tsx
+++ b/src/components/common/overlay/modal/confirm/ConfirmModal.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/common/ui'
+
 import { Modal, type ModalProps } from '../base/Modal'
 
 type ConfirmModalProps = {
@@ -27,25 +29,28 @@ export function ConfirmModal({
       className={className}
     >
       <div className="flex flex-col gap-7">
-        <Modal.Content className="text-base leading-[1.4] tracking-[-0.03em] text-gray-800">
+        <Modal.Content className="text-base leading-[1.4] tracking-[-0.03em] text-text-primary">
           {description}
         </Modal.Content>
         <Modal.Footer className="justify-end gap-3">
-          {/* TODO: 버튼 공통 컴포넌트 만들면 적용 */}
-          <button
-            type="button"
+          <Button
+            variant="modal"
+            size="lg"
+            rounded="full"
             onClick={onClose}
-            className="rounded-[100px] bg-gray-950 px-6 py-2 text-base font-semibold text-white"
+            className="px-6 font-semibold"
           >
             {cancelLabel}
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="primary"
+            size="lg"
+            rounded="full"
             onClick={onConfirm}
-            className="rounded-[100px] bg-primary-500 px-6 py-2 text-base font-semibold text-white"
+            className="px-6 font-semibold"
           >
             {confirmLabel}
-          </button>
+          </Button>
         </Modal.Footer>
       </div>
     </Modal>

--- a/src/components/common/overlay/modal/form/ReportFormModal.stories.tsx
+++ b/src/components/common/overlay/modal/form/ReportFormModal.stories.tsx
@@ -48,3 +48,19 @@ export const Report: Story = {
     options: REPORT_REASONS,
   },
 }
+
+export const Dark: Story = {
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => <ReportFormModal {...args} title="신고 선택 및 작성" />,
+  args: {
+    options: REPORT_REASONS,
+    onClose: () => {},
+    onSubmit: () => {},
+  },
+}

--- a/src/components/common/overlay/modal/form/ReportFormModal.tsx
+++ b/src/components/common/overlay/modal/form/ReportFormModal.tsx
@@ -29,6 +29,10 @@ export function ReportFormModal({
     onSubmit({ reason, content })
   }
 
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value)
+  }
+
   return (
     <Modal
       onClose={onClose}
@@ -64,7 +68,7 @@ export function ReportFormModal({
               id="content"
               size="sm"
               value={content}
-              onChange={(e) => setContent(e.target.value)}
+              onChange={handleContentChange}
             />
           </div>
         </Modal.Content>

--- a/src/components/common/overlay/modal/form/ReportFormModal.tsx
+++ b/src/components/common/overlay/modal/form/ReportFormModal.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
+
+import { Button, Textarea } from '@/components/common/ui'
 
 import { Dropdown, type DropdownOption } from '../../dropdown/Dropdown'
 import { Modal, type ModalProps } from '../base/Modal'
@@ -22,20 +24,10 @@ export function ReportFormModal({
   const [reason, setReason] = useState('')
   const [content, setContent] = useState('')
 
-  const handleContentChange = useCallback(
-    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      setContent(e.target.value)
-    },
-    []
-  )
-
-  const handleSubmit = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault()
-      onSubmit({ reason, content })
-    },
-    [onSubmit, reason, content]
-  )
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    onSubmit({ reason, content })
+  }
 
   return (
     <Modal
@@ -51,7 +43,7 @@ export function ReportFormModal({
           <div className="grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-3">
             <label
               htmlFor="reason"
-              className="whitespace-nowrap text-sm text-gray-700"
+              className="whitespace-nowrap text-sm text-text-muted"
             >
               사유 선택
             </label>
@@ -64,35 +56,35 @@ export function ReportFormModal({
             />
             <label
               htmlFor="content"
-              className="whitespace-nowrap text-sm text-gray-700"
+              className="whitespace-nowrap text-sm text-text-muted"
             >
               직접 입력
             </label>
-            {/* TODO: 텍스트 에어리어 공통 컴포넌트 만들면 적용 */}
-            <textarea
+            <Textarea
               id="content"
-              rows={3}
+              size="sm"
               value={content}
-              onChange={handleContentChange}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              onChange={(e) => setContent(e.target.value)}
             />
           </div>
         </Modal.Content>
-        <Modal.Footer className="mt-7 gap-3 font-light text-white text-xs">
-          {/* TODO: 버튼 공통 컴포넌트 만들면 적용 */}
-          <button
-            type="button"
+        <Modal.Footer className="mt-7 gap-3">
+          <Button
+            variant="modal"
+            rounded="lg"
             onClick={onClose}
-            className="rounded-lg bg-gray-950 px-5 py-1.5 cursor-pointer"
+            className="px-5 py-1.5 text-xs font-light"
           >
             닫기
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
+            rounded="lg"
             type="submit"
-            className="rounded-lg bg-primary-500 px-5 py-1.5 cursor-pointer"
+            className="px-5 py-1.5 text-xs font-light"
           >
             등록
-          </button>
+          </Button>
         </Modal.Footer>
       </form>
     </Modal>

--- a/src/components/common/ui/button/Button.style.ts
+++ b/src/components/common/ui/button/Button.style.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority'
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-1 px-4 font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:bg-gray-400 disabled:text-white',
+  'inline-flex items-center justify-center gap-1 px-4 font-medium cursor-pointer transition-colors focus:outline-none disabled:pointer-events-none disabled:bg-gray-400 disabled:text-white',
   {
     variants: {
       variant: {

--- a/src/components/common/ui/field/Input.tsx
+++ b/src/components/common/ui/field/Input.tsx
@@ -18,7 +18,7 @@ export function Input({
         ref={ref}
         {...props}
         className={cn(
-          'w-full rounded-xl border border-border-default bg-white px-4.5 py-3.5 text-text-primary outline-none placeholder:text-text-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+          'w-full rounded-xl border border-border-default bg-input-bg px-4.5 py-3.5 text-text-primary outline-none placeholder:text-text-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50',
           error
             ? 'border-status-error-border focus:border-status-error-border'
             : 'focus:border-focus-border',

--- a/src/components/common/ui/field/Textarea.tsx
+++ b/src/components/common/ui/field/Textarea.tsx
@@ -27,7 +27,7 @@ export function Textarea({
         ref={ref}
         {...props}
         className={cn(
-          'max-h-58 w-full resize-none overflow-y-auto rounded-xl border border-border-default bg-white px-4.5 text-text-primary outline-none placeholder:text-text-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+          'max-h-58 w-full resize-none overflow-y-auto rounded-xl border border-border-default bg-input-bg px-4.5 text-text-primary outline-none placeholder:text-text-muted transition-colors disabled:cursor-not-allowed disabled:opacity-50',
           textareaSizeClass[size],
           error
             ? 'border-status-error-border focus:border-status-error-border'

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,7 @@ body {
 
   --border-active: var(--color-primary-500);
 
+  --input-bg: var(--color-white);
   /* =========================
      Focus
   ========================= */
@@ -376,6 +377,8 @@ body {
 
   --color-dropdown-item-hover-bg: var(--dropdown-item-hover-bg);
   --color-dropdown-item-hover-text: var(--dropdown-item-hover-text);
+
+  --color-input-bg: var(--input-bg);
 
   --color-tab-active-bg: var(--tab-active-bg);
   --color-tab-hover-bg: var(--tab-hover-bg);


### PR DESCRIPTION
## 📌 관련 이슈

Closes #46 

## ✨ 변경 내용

- ConfirmModal, CharacterSelectModal, ReportFormModal의 취소/확인 버튼에 Button 공통 컴포넌트 적용 
  - 취소 버튼 → variant="modal" / 확인 버튼 → variant="primary"
- Modal, Dropdown, ActionMenu 하드코딩된 색상 값을 디자인 토큰으로 교체                                                                                            
    - bg-white → bg-surface 
    - text-gray-* → text-text-primary / text-text-muted                                                                                                              
    - border-gray-* → border-border-default                                                                                                                          
  - Input, Textarea 배경색 디자인 토큰 교체 
    - bg-white → bg-input-bg                                                                                                                               
- Button 공통 컴포넌트 베이스 스타일에 cursor-pointer 추가                                                                                                          
- 위 변경 사항이 반영된 다크모드 Storybook 스토리 추가 

## 📸 스크린샷(선택)

https://github.com/user-attachments/assets/6eb4c6e6-6fd2-48db-9986-9e25af15b9b5

## 📚 참고사항
- Dropdown 트리거 버튼, ActionMenu 트리거/ 모달 아이템 등에서 사용되는 버튼은 컨트롤·메뉴 아이템 성격으로 Button 공통 컴포넌트 적용 대상에서 제외 하고 <button>을 유지 하였습니다
- bg-input-bg가 적용 될수 있도록 --input-bg 도 index.css에 추가하였습니다.



