### PR TITLE
feat: auth form layout and common field components

### DIFF
--- a/src/features/auth/components/AuthForm.tsx
+++ b/src/features/auth/components/AuthForm.tsx
@@ -1,0 +1,20 @@
+import type { ComponentProps, ReactNode } from 'react'
+
+import { cn } from '@/utils/cn'
+
+type AuthFormProps = {
+  className?: string
+  children: ReactNode
+} & ComponentProps<'form'>
+
+/**
+ * 공통 인증 폼 (로그인 / 회원가입 공통)
+ * 내부 필드는 children으로 받아서 유연하게 구성
+ */
+export function AuthForm({ className, children, ...props }: AuthFormProps) {
+  return (
+    <form className={cn('space-y-8 gap-4 w-full', className)} {...props}>
+      {children}
+    </form>
+  )
+}

--- a/src/features/auth/components/AuthPageLayout.tsx
+++ b/src/features/auth/components/AuthPageLayout.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '@/utils/cn'
+
+/*
+ * 로그인 / 회원가입 공통 레이아웃
+ */
+
+type AuthPageLayoutProps = {
+  title: string
+  subTitle: string
+  children: ReactNode
+  className?: string
+}
+
+export function AuthPageLayout({
+  title,
+  subTitle,
+  children,
+  className,
+}: AuthPageLayoutProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div
+        className={cn('w-full max-w-sm flex flex-col px-3 gap-8', className)}
+      >
+        <div className="flex flex-col items-center gap-2">
+          <h1 className="text-center text-2xl font-semibold">{title}</h1>
+          <span className="text-sm text-text-muted">{subTitle}</span>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/features/auth/components/FormField.tsx
+++ b/src/features/auth/components/FormField.tsx
@@ -1,0 +1,38 @@
+/*
+ *  회원가입 / 로그인 공통 폼필드 사용
+ */
+
+import { type ComponentProps, useId } from 'react'
+
+import { Input } from '@/components/common/ui'
+import { cn } from '@/utils/cn'
+
+type FormFieldProps = {
+  label?: string
+  id?: string
+  error?: string
+} & ComponentProps<'input'>
+
+export function FormField({ label, id, error, ...props }: FormFieldProps) {
+  const generatedId = useId()
+  const inputId = id ?? generatedId
+
+  return (
+    <div className={cn('grid w-full grid-cols-[108px_1fr] items-center')}>
+      {label && (
+        <label htmlFor={inputId} className="text-sm">
+          {label}
+        </label>
+      )}
+      <Input
+        id={inputId}
+        error={Boolean(error)}
+        errorMessage={error}
+        className={cn(
+          'placeholder:text-sm py-1 px-1.5 w-full rounded-none border-t-0 border-x-0 border-border-strong bg-transparent'
+        )}
+        {...props}
+      />
+    </div>
+  )
+}

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,0 +1,3 @@
+export { AuthForm } from './components/AuthForm'
+export { AuthPageLayout } from './components/AuthPageLayout'
+export { FormField } from './components/FormField'

--- a/src/index.css
+++ b/src/index.css
@@ -439,3 +439,17 @@ body {
     transform: translateY(-6px);
   }
 }
+
+/* =========================
+   Autofill override (Chrome/Safari)
+   ========================= */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  /* remove default autofill background */
+  -webkit-box-shadow: 0 0 0px 1000px transparent inset;
+  /* ensure text color matches theme (dark mode visible) */
+  -webkit-text-fill-color: var(--text-primary);
+  /* prevent flash of default color */
+  transition: background-color 9999s ease-out 0s;
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #65

## ✨ 변경 내용

- 인증(Auth) 관련 공통 폼 구조 구성
- AuthForm, AuthPageLayout, FormField 컴포넌트 구현
- 로그인/회원가입에서 재사용 가능한 폼 레이아웃 설계
- input 하단 border(underline) 스타일 적용
- 브라우저 autofill 배경색 제거 스타일 추가

## 📸 스크린샷(선택)

## 📚 참고사항
- AuthForm은 form 역할만 담당하고, 레이아웃(UI)은 AuthPageLayout에서 관리
- FormField는 label + input + error를 하나의 단위로 구성