### PR TITLE
feat: add ranking component and story

### DIFF
--- a/src/features/main/ranking/Ranking.constants.ts
+++ b/src/features/main/ranking/Ranking.constants.ts
@@ -1,0 +1,42 @@
+import type { RankingType } from './Ranking.types'
+
+type RankStyleConfig = {
+  text: string
+  bg: string
+  border: string
+  shadow: string
+}
+
+export const RANK_STYLES: Record<number, RankStyleConfig> = {
+  1: {
+    text: 'text-text-ranking-gold font-bold',
+    bg: 'bg-ranking-gold-bg',
+    border: 'border-ranking-gold-border',
+    shadow: 'hover:shadow-ranking-gold',
+  },
+  2: {
+    text: 'text-text-ranking-silver font-bold',
+    bg: 'bg-ranking-silver-bg',
+    border: 'border-ranking-silver-border',
+    shadow: 'hover:shadow-ranking-silver',
+  },
+  3: {
+    text: 'text-text-ranking-bronze font-bold',
+    bg: 'bg-ranking-bronze-bg',
+    border: 'border-ranking-bronze-border',
+    shadow: 'hover:shadow-ranking-bronze',
+  },
+}
+
+export const DEFAULT_RANK_STYLE: RankStyleConfig = {
+  text: 'text-text-muted font-medium',
+  bg: 'bg-ranking-default-bg',
+  border: 'border-ranking-default-border',
+  shadow: '',
+}
+
+export const TAB_LABELS: Record<RankingType, string> = {
+  weekly: '주간',
+  monthly: '월간',
+  total: '누적',
+}

--- a/src/features/main/ranking/Ranking.stories.tsx
+++ b/src/features/main/ranking/Ranking.stories.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react'
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Ranking } from './Ranking'
+import type { RankingType, RankingUser } from './Ranking.types'
+
+const meta: Meta<typeof Ranking> = {
+  component: Ranking,
+  title: 'Features/Main/Ranking',
+}
+export default meta
+
+type Story = StoryObj<typeof Ranking>
+
+const MOCK_WEEKLY: RankingUser[] = [
+  {
+    user_id: 1,
+    nickname: '운동왕',
+    rank: 1,
+    weekly_cert_count: 20,
+    profile_img_url: null,
+  },
+  {
+    user_id: 2,
+    nickname: '헬스마니아',
+    rank: 2,
+    weekly_cert_count: 18,
+    profile_img_url: null,
+  },
+  {
+    user_id: 3,
+    nickname: '달리기선수',
+    rank: 3,
+    weekly_cert_count: 15,
+    profile_img_url: null,
+  },
+  {
+    user_id: 4,
+    nickname: '요가고수',
+    rank: 4,
+    weekly_cert_count: 12,
+    profile_img_url: null,
+  },
+  {
+    user_id: 5,
+    nickname: '수영러버',
+    rank: 5,
+    weekly_cert_count: 10,
+    profile_img_url: null,
+  },
+]
+
+const MOCK_MONTHLY: RankingUser[] = [
+  {
+    user_id: 1,
+    nickname: '운동왕',
+    rank: 1,
+    monthly_cert_count: 80,
+    profile_img_url: null,
+  },
+  {
+    user_id: 3,
+    nickname: '달리기선수',
+    rank: 2,
+    monthly_cert_count: 72,
+    profile_img_url: null,
+  },
+  {
+    user_id: 2,
+    nickname: '헬스마니아',
+    rank: 3,
+    monthly_cert_count: 65,
+    profile_img_url: null,
+  },
+  {
+    user_id: 5,
+    nickname: '수영러버',
+    rank: 4,
+    monthly_cert_count: 50,
+    profile_img_url: null,
+  },
+  {
+    user_id: 4,
+    nickname: '요가고수',
+    rank: 5,
+    monthly_cert_count: 45,
+    profile_img_url: null,
+  },
+]
+
+const MOCK_TOTAL: RankingUser[] = [
+  {
+    user_id: 3,
+    nickname: '달리기선수',
+    rank: 1,
+    total_cert_count: 520,
+    profile_img_url: null,
+  },
+  {
+    user_id: 1,
+    nickname: '운동왕',
+    rank: 2,
+    total_cert_count: 498,
+    profile_img_url: null,
+  },
+  {
+    user_id: 4,
+    nickname: '요가고수',
+    rank: 3,
+    total_cert_count: 430,
+    profile_img_url: null,
+  },
+  {
+    user_id: 2,
+    nickname: '헬스마니아',
+    rank: 4,
+    total_cert_count: 380,
+    profile_img_url: null,
+  },
+  {
+    user_id: 5,
+    nickname: '수영러버',
+    rank: 5,
+    total_cert_count: 310,
+    profile_img_url: null,
+  },
+]
+
+const MOCK_DATA: Record<RankingType, RankingUser[]> = {
+  weekly: MOCK_WEEKLY,
+  monthly: MOCK_MONTHLY,
+  total: MOCK_TOTAL,
+}
+
+export const Default: Story = {
+  render: () => {
+    const [type, setType] = useState<RankingType>('weekly')
+    return (
+      <Ranking
+        rankings={MOCK_DATA[type]}
+        activeType={type}
+        onTypeChange={setType}
+      />
+    )
+  },
+}
+
+export const Dark: Story = {
+  render: () => {
+    const [type, setType] = useState<RankingType>('weekly')
+    return (
+      <div className="dark bg-surface p-6 rounded-lg">
+        <Ranking
+          rankings={MOCK_DATA[type]}
+          activeType={type}
+          onTypeChange={setType}
+        />
+      </div>
+    )
+  },
+}

--- a/src/features/main/ranking/Ranking.tsx
+++ b/src/features/main/ranking/Ranking.tsx
@@ -1,0 +1,62 @@
+import { Trophy } from 'lucide-react'
+
+import { TabButton } from '@/components/common/ui'
+import { cn } from '@/utils/cn'
+
+import { TAB_LABELS } from './Ranking.constants'
+import type { RankingProps, RankingType } from './Ranking.types'
+import { normalizeUser } from './Ranking.utils'
+import { RankingItem } from './RankingItem'
+
+const RANKING_TYPES: RankingType[] = ['weekly', 'monthly', 'total']
+
+export function Ranking({
+  rankings,
+  activeType,
+  onTypeChange,
+  className,
+}: RankingProps) {
+  const normalizedRankings = rankings.map((user) =>
+    normalizeUser(user, activeType)
+  )
+
+  return (
+    <section
+      className={cn(
+        'w-full min-w-sm rounded-2xl bg-surface border border-border-default p-4 ',
+        className
+      )}
+    >
+      {/* 헤더 */}
+      <div className="flex flex-col gap-2 mb-3">
+        <div className="flex items-center gap-2">
+          <Trophy size={30} className="text-yellow-500 shrink-0" />
+          <h2 className="text-2xl font-bold text-text-primary">랭킹 순위</h2>
+        </div>
+      </div>
+
+      {/* 탭 */}
+      <div className="flex gap-2 mb-3">
+        {RANKING_TYPES.map((type) => (
+          <TabButton
+            key={type}
+            isActive={activeType === type}
+            onClick={() => onTypeChange(type)}
+            className="cursor-pointer"
+          >
+            {TAB_LABELS[type]}
+          </TabButton>
+        ))}
+      </div>
+
+      <hr className="border-border-default mb-3" />
+
+      {/* 랭킹 목록 */}
+      <ul className="flex flex-col gap-0.5">
+        {normalizedRankings.map((user) => (
+          <RankingItem key={user.user_id} user={user} />
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/features/main/ranking/Ranking.types.ts
+++ b/src/features/main/ranking/Ranking.types.ts
@@ -1,0 +1,37 @@
+export type RankingType = 'weekly' | 'monthly' | 'total'
+
+type RankingUserBase = {
+  user_id: number
+  nickname: string
+  profile_img_url: number | string | null
+  rank: number
+}
+
+export type WeeklyRankingUser = RankingUserBase & {
+  weekly_cert_count: number
+}
+
+export type MonthlyRankingUser = RankingUserBase & {
+  monthly_cert_count: number
+}
+
+export type TotalRankingUser = RankingUserBase & {
+  total_cert_count: number
+}
+
+export type RankingUser =
+  | WeeklyRankingUser
+  | MonthlyRankingUser
+  | TotalRankingUser
+
+/** 정규화된 유저 타입을 지정 -> cert_count로 공통적으로 사용 */
+export type NormalizedRankingUser = RankingUserBase & {
+  cert_count: number
+}
+
+export type RankingProps = {
+  rankings: RankingUser[]
+  activeType: RankingType
+  onTypeChange: (type: RankingType) => void
+  className?: string
+}

--- a/src/features/main/ranking/Ranking.utils.ts
+++ b/src/features/main/ranking/Ranking.utils.ts
@@ -1,0 +1,28 @@
+import type {
+  MonthlyRankingUser,
+  NormalizedRankingUser,
+  RankingType,
+  RankingUser,
+  TotalRankingUser,
+  WeeklyRankingUser,
+} from './Ranking.types'
+
+export function normalizeUser(
+  user: RankingUser,
+  type: RankingType
+): NormalizedRankingUser {
+  switch (type) {
+    case 'weekly': {
+      const u = user as WeeklyRankingUser
+      return { ...u, cert_count: u.weekly_cert_count }
+    }
+    case 'monthly': {
+      const u = user as MonthlyRankingUser
+      return { ...u, cert_count: u.monthly_cert_count }
+    }
+    case 'total': {
+      const u = user as TotalRankingUser
+      return { ...u, cert_count: u.total_cert_count }
+    }
+  }
+}

--- a/src/features/main/ranking/RankingItem.tsx
+++ b/src/features/main/ranking/RankingItem.tsx
@@ -1,0 +1,78 @@
+import { Crown, Medal } from 'lucide-react'
+
+import { pinkCharacterImage } from '@/assets/images'
+import { cn } from '@/utils/cn'
+
+import { DEFAULT_RANK_STYLE, RANK_STYLES } from './Ranking.constants'
+import type { NormalizedRankingUser } from './Ranking.types'
+
+type RankingItemProps = {
+  user: NormalizedRankingUser
+}
+
+export function RankingItem({ user }: RankingItemProps) {
+  // profile_img_url 추후에 사용
+  const { rank, nickname, cert_count } = user
+
+  const isTop3 = rank <= 3
+  const {
+    text: rankTextStyle,
+    bg,
+    border,
+    shadow,
+  } = RANK_STYLES[rank] ?? DEFAULT_RANK_STYLE
+
+  return (
+    <li
+      className={cn(
+        'flex w-full items-center gap-2 rounded-xl border px-3 py-2.5 transition-shadow cursor-pointer',
+        bg,
+        border,
+        shadow
+      )}
+    >
+      {/* 순위 배지 */}
+      <span
+        className={cn(
+          'flex items-center justify-center size-7 text-sm shrink-0',
+          rankTextStyle
+        )}
+      >
+        {isTop3 ? <Medal size={22} className="shrink-0" /> : `${rank}위`}
+      </span>
+
+      {/* 프로필 이미지 TODO: 나중에 profile_img_url 사용 */}
+      <div className="relative shrink-0">
+        {rank === 1 && (
+          <Crown
+            size={14}
+            className="absolute text-text-ranking-gold fill-text-ranking-gold -rotate-40"
+            // 왕관 위치 미세 조정을 위한 하드 코딩
+            style={{ top: '-20%', left: '-15%' }}
+          />
+        )}
+        <div
+          className={cn('size-8 rounded-full border-2 overflow-hidden', border)}
+        >
+          <img
+            src={pinkCharacterImage}
+            alt="기본 프로필"
+            className="size-full object-cover"
+          />
+        </div>
+      </div>
+
+      {/* 닉네임 */}
+      <span className="flex-1 text-sm truncate text-text-primary">
+        {nickname}
+      </span>
+
+      {/* 인증 횟수 */}
+      <span className="text-xs text-text-muted shrink-0">
+        <span className={cn('font-semibold', isTop3 && rankTextStyle)}>
+          {cert_count} 회
+        </span>
+      </span>
+    </li>
+  )
+}

--- a/src/features/main/ranking/index.ts
+++ b/src/features/main/ranking/index.ts
@@ -1,0 +1,2 @@
+export { Ranking } from './Ranking'
+export type { RankingProps, RankingType } from './Ranking.types'

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,12 @@ body {
   --shadow-card-hover: 0px 10px 30px rgba(0, 0, 0, 0.15);
   --shadow-card-base: var(--shadow-card-light);
   --shadow-rank-light: 0 0 10px rgba(137, 137, 137, 0.5);
+  --color-rank-gold-shadow: 0 0 6px 0 rgba(232, 188, 15, 0.5);
+  --color-rank-silver-shadow: 0 0 6px 0 rgba(155, 155, 163, 0.5);
+  --color-rank-bronze-shadow: 0 0 6px 0 rgba(210, 130, 80, 0.5);
+  --color-rank-dark-gold-shadow: 0 0 6px 0 rgba(255, 215, 38, 0.5);
+  --color-rank-dark-silver-shadow: 0 0 6px 0 rgba(199, 199, 199, 0.4);
+  --color-rank-dark-bronze-shadow: 0 0 6px 0 rgba(222, 133, 98, 0.5);
 
   /* mypage stats */
   --color-mypage-stats-bg: #ffffff;
@@ -78,8 +84,9 @@ body {
   --color-rank-dark-bronze-bg: #221b15;
 
   /* ranking border color - dark */
-  --color-rank-dark-silver-border: #575757;
-  --color-rank-dark-bronze-border: #3e2b1e;
+  --color-rank-gold-border: #fff7de;
+  --color-rank-silver-border: #575757;
+  --color-rank-bronze-border: #3e2b1e;
 
   /* ranking text color - dark */
   --color-rank-dark-gold-text: #ffd726;
@@ -191,6 +198,8 @@ body {
   --ranking-default-bg: var(--color-rank-light-default-bg);
 
   --ranking-default-border: var(--color-rank-light-border);
+
+  --ranking-gold-border: var(--color-rank-light-border);
   --ranking-silver-border: var(--color-rank-light-border);
   --ranking-bronze-border: var(--color-rank-light-border);
 
@@ -199,6 +208,9 @@ body {
   --text-ranking-bronze: var(--color-rank-light-bronze-text);
 
   --ranking-shadow: var(--shadow-rank-light);
+  --ranking-gold-shadow: var(--color-rank-gold-shadow);
+  --ranking-silver-shadow: var(--color-rank-silver-shadow);
+  --ranking-bronze-shadow: var(--color-rank-bronze-shadow);
 
   /* =========================
      MyPage
@@ -247,14 +259,18 @@ body {
   --ranking-default-bg: var(--color-rank-dark-silver-bg);
 
   --ranking-default-border: var(--color-rank-dark-silver-border);
-  --ranking-silver-border: var(--color-rank-dark-silver-border);
-  --ranking-bronze-border: var(--color-rank-dark-bronze-border);
+  --ranking-gold-border: var(--color-rank-gold-border);
+  --ranking-silver-border: var(--color-rank-silver-border);
+  --ranking-bronze-border: var(--color-rank-bronze-border);
 
   --text-ranking-gold: var(--color-rank-dark-gold-text);
   --text-ranking-silver: var(--color-rank-dark-silver-text);
   --text-ranking-bronze: var(--color-rank-dark-bronze-text);
 
   --ranking-shadow: var(--shadow-rank-dark);
+  --ranking-gold-shadow: var(--color-rank-dark-gold-shadow);
+  --ranking-silver-shadow: var(--color-rank-dark-silver-shadow);
+  --ranking-bronze-shadow: var(--color-rank-dark-bronze-shadow);
 
   /* =========================
      MyPage
@@ -389,6 +405,7 @@ body {
   --color-ranking-bronze-bg: var(--ranking-bronze-bg);
   --color-ranking-default-bg: var(--ranking-default-bg);
   --color-ranking-default-border: var(--ranking-default-border);
+  --color-ranking-gold-border: var(--ranking-gold-border);
   --color-ranking-silver-border: var(--ranking-silver-border);
   --color-ranking-bronze-border: var(--ranking-bronze-border);
   --color-text-ranking-gold: var(--text-ranking-gold);
@@ -416,6 +433,9 @@ body {
   --shadow-card-active: var(--shadow-card-active);
   --shadow-modal: var(--shadow-modal);
   --shadow-ranking: var(--ranking-shadow);
+  --shadow-ranking-gold: var(--ranking-gold-shadow);
+  --shadow-ranking-silver: var(--ranking-silver-shadow);
+  --shadow-ranking-bronze: var(--ranking-bronze-shadow);
 }
 
 @keyframes dropdown-in {


### PR DESCRIPTION
## 📌 관련 이슈

Closes #62 

## ✨ 변경 내용

- `src/features/main/ranking/` 아래 Ranking 피처 컴포넌트 추가
  - `weekly` / `monthly` / `total` 탭 전환
  - 1~3위 메달 아이콘, 1위 왕관 오버레이, 랭크별 hover 그림자 디자인 토큰 새롭게 적용
  - `normalizeUser()` → `Ranking.utils.ts`, 스타일 상수 → `Ranking.constants.ts` 분리

## 📸 스크린샷(선택)


https://github.com/user-attachments/assets/a708803c-4016-473f-ab48-b46d892c0f43



## 📚 참고사항
features 폴더에 정리 해보았는데 main 페이지에 사용할 ranking 컴포넌트라 features/main/ranking 으로 두었습니다. 페이지별 구분이 없다면 features/ranking으로 관리하겠습니다.
figma 상 디자인에서 몇가지 추가 하였습니다 (container border, 메달 디자인을 lucide 아이콘을 사용)