### PR TITLE
refactor: apply calendar component to vot editor

### DIFF
--- a/src/components/common/ui/vote/Vote.type.ts
+++ b/src/components/common/ui/vote/Vote.type.ts
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react'
 
+import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
+
 // 조회 모드 (enum 대신 const object 사용)
 export const VoteViewerMode = {
   GUEST: 'guest',
@@ -31,8 +33,7 @@ export type VoteDisplayOption = {
 
 // 공통 필드
 type VoteBaseProps = {
-  startDate?: string
-  endDate?: string
+  period?: DateRange
   participantCount?: number
 }
 
@@ -54,5 +55,5 @@ export type VoteEditorProps = {
   disabled?: boolean
   onChangeOption?: (index: number, value: string) => void
   onSubmit?: () => void
-  onClickPeriod?: () => void
+  onChangePeriod?: (date: DateRange | null) => void
 } & VoteBaseProps

--- a/src/components/common/ui/vote/VoteDisplay.stories.tsx
+++ b/src/components/common/ui/vote/VoteDisplay.stories.tsx
@@ -81,6 +81,10 @@ export const Closed: Story = {
     ],
     actionLabel: '투표하기',
     actionSlot: actionMenu,
+    period: {
+      start: new Date('2026-04-01'),
+      end: new Date('2026-04-06'),
+    },
   },
 }
 

--- a/src/components/common/ui/vote/VoteDisplay.tsx
+++ b/src/components/common/ui/vote/VoteDisplay.tsx
@@ -1,16 +1,11 @@
 import { CalendarDays, Users } from 'lucide-react'
 
 import { Button } from '@/components/common/ui'
+import { formatSelectedDate } from '@/components/common/ui/calendar/Calendar.util'
 import { cn } from '@/utils/cn'
 
 import { VoteOptionItem } from './components/VoteOptionItem'
 import { type VoteDisplayProps, VoteViewerMode } from './Vote.type'
-
-function formatDate(date: Date | null) {
-  if (!date) return ''
-
-  return date.toLocaleDateString('ko-KR')
-}
 
 export function VoteDisplay({
   mode,
@@ -44,8 +39,7 @@ export function VoteDisplay({
           <>
             <CalendarDays className="h-4 w-4 text-text-muted" />
             <span className="text-text-primary">
-              {formatDate(period?.start ?? null)} ~{' '}
-              {formatDate(period?.end ?? null)}
+              {formatSelectedDate(period ?? { start: null, end: null }, '')}
             </span>
           </>
         )}

--- a/src/components/common/ui/vote/VoteDisplay.tsx
+++ b/src/components/common/ui/vote/VoteDisplay.tsx
@@ -6,12 +6,17 @@ import { cn } from '@/utils/cn'
 import { VoteOptionItem } from './components/VoteOptionItem'
 import { type VoteDisplayProps, VoteViewerMode } from './Vote.type'
 
+function formatDate(date: Date | null) {
+  if (!date) return ''
+
+  return date.toLocaleDateString('ko-KR')
+}
+
 export function VoteDisplay({
   mode,
   options,
   participantCount = 0,
-  startDate,
-  endDate,
+  period,
   actionLabel,
   showMoreButton = false,
   actionSlot,
@@ -28,7 +33,7 @@ export function VoteDisplay({
 
   const buttonLabel = isClosed ? '투표 마감' : (actionLabel ?? '투표하기')
   const statusLabel = isClosed ? '투표 마감' : '투표 진행중'
-  const hasPeriod = Boolean(startDate && endDate)
+  const hasPeriod = Boolean(period?.start && period?.end)
 
   return (
     <>
@@ -39,7 +44,8 @@ export function VoteDisplay({
           <>
             <CalendarDays className="h-4 w-4 text-text-muted" />
             <span className="text-text-primary">
-              {startDate} ~ {endDate}
+              {formatDate(period?.start ?? null)} ~{' '}
+              {formatDate(period?.end ?? null)}
             </span>
           </>
         )}
@@ -74,6 +80,7 @@ export function VoteDisplay({
             variant="primary"
             onClick={onActionClick}
             disabled={isActionDisabled}
+            className="h-10 w-full max-w-md text-md"
           >
             {buttonLabel}
           </Button>

--- a/src/components/common/ui/vote/VoteEditor.stories.tsx
+++ b/src/components/common/ui/vote/VoteEditor.stories.tsx
@@ -23,8 +23,10 @@ export const Create: Story = {
 export const CreateWithPeriod: Story = {
   args: {
     mode: VoteEditorMode.CREATE,
-    startDate: '2026.04.01',
-    endDate: '2026.04.06',
+    period: {
+      start: new Date('2026-04-01'),
+      end: new Date('2026-04-06'),
+    },
     options: ['운동하기', '공부하기'],
   },
 }
@@ -32,8 +34,10 @@ export const CreateWithPeriod: Story = {
 export const Edit: Story = {
   args: {
     mode: VoteEditorMode.EDIT,
-    startDate: '2026.04.01',
-    endDate: '2026.04.06',
+    period: {
+      start: new Date('2026-04-01'),
+      end: new Date('2026-04-06'),
+    },
     options: ['운동하기', '공부하기'],
   },
 }

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -1,6 +1,6 @@
-import { CalendarDays, Users } from 'lucide-react'
+import { Users } from 'lucide-react'
 
-import { Button } from '@/components/common/ui'
+import { Button, Calendar } from '@/components/common/ui'
 import { cn } from '@/utils/cn'
 
 import { VoteEditorMode, type VoteEditorProps } from './Vote.type'
@@ -22,38 +22,28 @@ const inputVariants = {
 
 export function VoteEditor({
   mode,
-  startDate,
-  endDate,
+  period,
   options,
   participantCount = 0,
   disabled = false,
   onChangeOption,
   onSubmit,
-  onClickPeriod,
+  onChangePeriod,
 }: VoteEditorProps) {
-  const hasPeriod = Boolean(startDate && endDate)
+  const hasPeriod = Boolean(period?.start && period?.end)
   const hasValidOptions = options.every((option) => option.trim() !== '')
   const isSubmitDisabled = disabled || !hasPeriod || !hasValidOptions
   const submitLabel = getSubmitLabel(mode)
 
   return (
     <>
-      <Button
-        type="button"
-        variant="ghost"
-        onClick={onClickPeriod}
-        className="mb-4 flex items-center gap-2 p-0"
-      >
-        <CalendarDays className="h-4 w-4 text-text-muted" />
-        <span
-          className={cn(
-            'text-sm',
-            hasPeriod ? 'text-text-primary' : 'text-text-muted'
-          )}
-        >
-          {hasPeriod ? `${startDate} ~ ${endDate}` : '투표 기간을 선택하세요'}
-        </span>
-      </Button>
+      <div className="mb-4">
+        <Calendar
+          value={period}
+          onChange={onChangePeriod}
+          label="투표 기간을 선택하세요"
+        />
+      </div>
 
       <section className="w-full rounded-2xl border border-border-default bg-gray-100 px-6 py-6">
         <div className="flex flex-col gap-4">


### PR DESCRIPTION
## 📌 관련 이슈
Closes #75

## ✨ 변경 내용
- VoteEditor에서 직접 구현한 기간 선택 버튼 제거
- 공통 Calendar 컴포넌트로 교체
- 날짜 구조를 startDate/endDate → DateRange(period)로 변경
- VoteDisplay도 period 구조로 통일
- 버튼 사이즈를 Tailwind scale 기준으로 정리

## 📸 스크린샷(선택)
<img width="839" height="463" alt="스크린샷 2026-04-18 오전 1 40 19" src="https://github.com/user-attachments/assets/520d4786-ea90-4e6c-972e-6abda9b61aaf" />


## 📚 참고사항
- 공통 Calendar 컴포넌트를 재사용하는 방향으로 구조 개선
- 기존 UI 구조는 유지하면서 날짜 선택 로직만 변경