### PR TITLE
feat: add login validation and social login UI

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,24 +1,62 @@
 import { FormProvider, useForm } from 'react-hook-form'
 import { Link } from 'react-router'
 
+import { zodResolver } from '@hookform/resolvers/zod'
+
 import { Button } from '@/components/common/ui'
 import { AuthForm, AuthPageLayout } from '@/features/auth'
+import {
+  type EmailLoginRequestSchema,
+  emailLoginRequestSchema,
+} from '@/schemas/auth/login'
+import { cn } from '@/utils/cn'
 
-type LoginFormValues = {
-  email: string
-  password: string
-}
+const socialLoginButtons = [
+  {
+    provider: 'kakao',
+    label: '카카오 로그인',
+    iconLabel: 'K',
+    className: 'bg-[#FEE500] text-[#191919] hover:bg-[#F6D900]',
+  },
+  {
+    provider: 'naver',
+    label: '네이버 로그인',
+    iconLabel: 'N',
+    className: 'bg-[#03C75A] text-white hover:bg-[#02B350]',
+  },
+  {
+    provider: 'google',
+    label: '구글 로그인',
+    iconLabel: 'G',
+    className: 'bg-white text-[#4285F4]',
+  },
+] as const
 
 export function LoginPage() {
-  const methods = useForm<LoginFormValues>({
+  const methods = useForm<EmailLoginRequestSchema>({
+    mode: 'onChange',
+    resolver: zodResolver(emailLoginRequestSchema),
     defaultValues: {
       email: '',
       password: '',
     },
   })
 
+  const {
+    control,
+    formState: { isValid, isDirty },
+  } = methods
+
+  const LoginField = AuthForm.FormField<EmailLoginRequestSchema>
+
   // 로그인 API 연결 전 임시 제출 함수입니다.
   const handleLoginSubmit = () => {}
+  const handleSocialLogin = (
+    provider: (typeof socialLoginButtons)[number]['provider']
+  ) => {
+    // TODO: 소셜 로그인 시작 API 또는 OAuth URL 연결
+    void provider
+  }
 
   return (
     <AuthPageLayout
@@ -27,32 +65,68 @@ export function LoginPage() {
     >
       <FormProvider {...methods}>
         <AuthForm onSubmit={methods.handleSubmit(handleLoginSubmit)}>
-          <AuthForm.FormField<LoginFormValues>
+          <LoginField
             label="이메일"
             name="email"
-            control={methods.control}
+            control={control}
             type="email"
-            placeholder="이메일"
+            placeholder="example@email.com"
           />
-          <AuthForm.FormField<LoginFormValues>
+          <LoginField
             label="비밀번호"
-            control={methods.control}
+            control={control}
             name="password"
             type="password"
-            placeholder="비밀번호"
+            placeholder="비밀번호을 입력해주세요"
           />
 
-          <div className="flex flex-col gap-3">
-            <Button type="submit" size="lg">
-              로그인
-            </Button>
-            <Link
-              to="/signup"
-              className="inline-flex items-center justify-center rounded-md border border-border-subtle bg-gray-100 px-4 py-2 text-base font-medium text-text-muted hover:bg-gray-100"
-            >
+          <Button
+            variant={'neutral'}
+            type="submit"
+            rounded={'lg'}
+            className={cn(
+              'text-xl py-3 w-full',
+              isValid
+                ? 'bg-black hover:bg-[#121212]'
+                : 'disabled:bg-black/30 disabled:text-white/20'
+            )}
+            size="lg"
+            disabled={!isDirty || !isValid}
+          >
+            로그인
+          </Button>
+
+          <div className="flex items-center gap-3 py-1">
+            <span className="h-px flex-1 bg-border-default" />
+            <span className="text-xs text-text-muted">또는</span>
+            <span className="h-px flex-1 bg-border-default" />
+          </div>
+
+          {/* 소셜 로그인 레이아웃 */}
+          <div className="flex justify-center items-center gap-12">
+            {socialLoginButtons.map(
+              ({ provider, label, iconLabel, className }) => (
+                <Button
+                  key={provider}
+                  aria-label={label}
+                  rounded={'full'}
+                  className={cn(
+                    'flex size-14 items-center justify-center text-xl font-bold transition-colors',
+                    className
+                  )}
+                  onClick={() => handleSocialLogin(provider)}
+                >
+                  <span aria-hidden="true">{iconLabel}</span>
+                </Button>
+              )
+            )}
+          </div>
+          <p className="flex justify-center items-center gap-3 mt-2 text-sm text-text-muted">
+            계정이 없으신가요?
+            <Link to="/signup" className="font-medium text-primary-600">
               회원가입
             </Link>
-          </div>
+          </p>
         </AuthForm>
       </FormProvider>
     </AuthPageLayout>

--- a/src/schemas/auth/login.ts
+++ b/src/schemas/auth/login.ts
@@ -1,0 +1,64 @@
+import * as z from 'zod'
+
+const code = z.string().min(1, '인가 코드를 입력해주세요')
+const state = z.string().min(1, 'state 값을 입력해주세요')
+const email = z.email('이메일 형식이 올바르지 않습니다.')
+const password = z.string().min(1, '비밀번호를 입력해주세요')
+const accessToken = z.string()
+const fieldError = z.record(z.string(), z.array(z.string()))
+
+// REQ-AUTH-004: 카카오 소셜 회원가입/로그인 콜백 API 요청값
+export const kakaoLoginCallbackRequestSchema = z.object({
+  code,
+})
+
+// REQ-AUTH-005: 네이버 소셜 회원가입/로그인 콜백 API 요청값
+export const naverLoginCallbackRequestSchema = z.object({
+  code,
+  state,
+})
+
+// REQ-AUTH-006: 구글 소셜 회원가입/로그인 콜백 API 요청값
+export const googleLoginCallbackRequestSchema = z.object({
+  code,
+  state: state.optional(),
+})
+
+// REQ-AUTH-007: 이메일 로그인 API 요청값
+export const emailLoginRequestSchema = z.object({
+  email,
+  password,
+})
+
+// 로그인 성공 응답값
+export const loginResponseSchema = z.object({
+  access_token: accessToken,
+})
+
+// 이메일 로그인 인증 실패 응답값
+export const emailLoginUnauthorizedResponseSchema = z.object({
+  error_detail: z.literal('이메일 또는 비밀번호가 올바르지 않습니다.'),
+})
+
+// 로그인/소셜 로그인 필드 검증 실패 응답값
+export const loginFieldErrorResponseSchema = z.object({
+  error_detail: fieldError,
+})
+
+export type KakaoLoginCallbackRequestSchema = z.infer<
+  typeof kakaoLoginCallbackRequestSchema
+>
+export type NaverLoginCallbackRequestSchema = z.infer<
+  typeof naverLoginCallbackRequestSchema
+>
+export type GoogleLoginCallbackRequestSchema = z.infer<
+  typeof googleLoginCallbackRequestSchema
+>
+export type EmailLoginRequestSchema = z.infer<typeof emailLoginRequestSchema>
+export type LoginResponseSchema = z.infer<typeof loginResponseSchema>
+export type LoginFieldErrorResponseSchema = z.infer<
+  typeof loginFieldErrorResponseSchema
+>
+export type EmailLoginUnauthorizedResponseSchema = z.infer<
+  typeof emailLoginUnauthorizedResponseSchema
+>


### PR DESCRIPTION
## 📌 관련 이슈

Closes #87

## ✨ 변경 내용

  - 로그인 요청 Zod 스키마 추가
  - 로그인 페이지에 `react-hook-form` + `zodResolver` 기반 유효성 검사 적용
  - 이메일/비밀번호 필드 유효성 상태에 따라 로그인 버튼 활성화 처리
  - 회원가입 이동 링크를 안내 문구 형태로 변경
  - 카카오/네이버/구글 소셜 로그인 원형 버튼 UI 추가

## 📸 스크린샷(선택)
<img width="588" height="590" alt="스크린샷 2026-04-19 오후 11 40 45" src="https://github.com/user-attachments/assets/0bd16ae7-b9e7-4162-abe8-ed774c1c1bb6" />

## 📚 참고사항
  - 소셜 로그인 API 연결 전이라 버튼 클릭 핸들러는 TODO 상태입니다.
  - 로그인 API 연결 시 서버 에러는 `setError` 또는 공통 에러 영역으로 연결하면 됩니다.
  - TODO: 로그인/회원가입 스키마 구조 정리
    - 폼 검증용 스키마와 API 요청/응답용 스키마를 분리
    - 로그인/회원가입은 각각 파일을 나누지 않고 auth 단위 한 파일에서 관리 예정