### PR TITLE
feat: add post create/edit layout

### DIFF
--- a/src/features/post/components/PostFormLayout.tsx
+++ b/src/features/post/components/PostFormLayout.tsx
@@ -1,0 +1,229 @@
+import { useRef, useState } from 'react'
+
+import { ImagePlus, X } from 'lucide-react'
+
+import { Button, Input, Textarea } from '@/components/common/ui'
+import { cn } from '@/utils/cn'
+
+import { usePostForm } from '../hooks/usePostForm'
+import { MAX_CONTENT, MAX_IMAGES, MAX_TITLE } from '../post.constants'
+import type { PostFormData, PostFormMode } from '../post.types'
+import { PostGoalSection } from './PostGoalSection'
+import { PostTagSection } from './PostTagSection'
+import { PostVoteSection } from './PostVoteSection'
+import { SectionLabel } from './SectionLabel'
+
+type PostFormLayoutProps = {
+  mode: PostFormMode
+  defaultValues?: Partial<PostFormData>
+  onSubmit: (data: PostFormData) => void
+  onCancel?: () => void
+  isPending?: boolean
+}
+
+export function PostFormLayout({
+  mode,
+  defaultValues,
+  onSubmit,
+  onCancel,
+  isPending = false,
+}: PostFormLayoutProps) {
+  const form = usePostForm(mode, defaultValues)
+
+  // 드래그 시각 피드백
+  const [isDragging, setIsDragging] = useState(false)
+  const imageInputRef = useRef<HTMLInputElement>(null)
+
+  function handleImageSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    form.addImages(Array.from(e.target.files ?? []))
+    e.target.value = ''
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault()
+    setIsDragging(false)
+    const files = Array.from(e.dataTransfer.files).filter((f) =>
+      f.type.startsWith('image/')
+    )
+    form.addImages(files)
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (form.isSubmitDisabled || isPending) return
+    onSubmit(form.buildFormData())
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+      {/* 제목 */}
+      <div className="flex flex-col gap-2">
+        <SectionLabel label="제목" required />
+        <Input
+          placeholder="제목을 입력하세요"
+          value={form.title}
+          onChange={(e) => form.changeTitle(e.target.value)}
+        />
+        <p
+          className={cn(
+            'self-end text-xs',
+            form.titleLen >= MAX_TITLE
+              ? 'text-status-error-text'
+              : 'text-text-muted'
+          )}
+        >
+          {form.titleLen}/{MAX_TITLE}
+        </p>
+      </div>
+
+      {/* 이미지 업로드 (hidden input) */}
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={handleImageSelect}
+      />
+
+      {/* 이미지 업로드 */}
+      <div className="flex flex-col gap-2">
+        <SectionLabel label="이미지 선택" />
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label={`이미지 업로드 (최대 ${MAX_IMAGES}장)`}
+          onClick={() => form.canAddImage && imageInputRef.current?.click()}
+          onKeyDown={(e) =>
+            (e.key === 'Enter' || e.key === ' ') &&
+            imageInputRef.current?.click()
+          }
+          onDrop={handleDrop}
+          onDragOver={(e) => {
+            e.preventDefault()
+            setIsDragging(true)
+          }}
+          onDragLeave={() => setIsDragging(false)}
+          className={cn(
+            'flex min-h-40 w-full flex-col rounded-2xl border-2 border-dashed p-4 transition-colors',
+            isDragging
+              ? 'border-focus-border bg-primary-100/30 dark:bg-primary-100/10'
+              : 'border-border-default bg-gray-50 dark:bg-gray-800',
+            form.canAddImage &&
+              'cursor-pointer hover:border-focus-border hover:bg-gray-100 dark:hover:bg-gray-750'
+          )}
+        >
+          {form.images.length === 0 ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-2 text-text-muted">
+              <ImagePlus className="size-8" />
+              <span className="text-sm">
+                클릭 또는 드래그하여 이미지를 추가하세요
+              </span>
+              <span className="text-xs text-text-disabled">
+                최대 {MAX_IMAGES}장
+              </span>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-wrap gap-3">
+                {form.images.map((src, i) => (
+                  <div key={i} className="relative size-32 shrink-0">
+                    <img
+                      src={src}
+                      alt={`첨부한 이미지 ${i + 1} 번째`}
+                      className="size-full rounded-xl object-cover"
+                    />
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        form.removeImage(i)
+                      }}
+                      className="absolute -right-1.5 -top-1.5 flex size-6 cursor-pointer items-center justify-center rounded-full bg-gray-700 text-white shadow dark:bg-gray-600"
+                    >
+                      <X className="size-3.5" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+              {form.canAddImage && (
+                <p className="text-text-muted">
+                  {form.images.length}/{MAX_IMAGES}장 · 클릭하거나 드래그하여
+                  추가
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 내용 */}
+      <div className="flex flex-col gap-2">
+        <SectionLabel label="내용" required />
+        <Textarea
+          size="lg"
+          placeholder="내용을 입력하세요"
+          value={form.content}
+          onChange={(e) => form.changeContent(e.target.value)}
+        />
+        <p
+          className={cn(
+            'self-end text-xs',
+            form.contentLen >= MAX_CONTENT
+              ? 'text-status-error-text'
+              : 'text-text-muted'
+          )}
+        >
+          {form.contentLen}/{MAX_CONTENT}
+        </p>
+      </div>
+
+      {/* 태그 선택 */}
+      <div className="flex flex-wrap items-center gap-2">
+        <SectionLabel label="태그 선택" />
+        <PostTagSection
+          selectedTagIds={form.selectedTagIds}
+          onToggle={form.toggleTag}
+        />
+      </div>
+
+      {/* 투표 생성 */}
+      <PostVoteSection
+        mode={mode}
+        question={form.voteQuestion}
+        options={form.voteOptions}
+        period={form.votePeriod}
+        onChangeQuestion={form.changeVoteQuestion}
+        onChangeOption={form.changeVoteOption}
+        onChangePeriod={form.changeVotePeriod}
+        onConfirm={form.confirmVote}
+      />
+
+      {/* 목표 선택 */}
+      <div className="flex flex-col gap-3">
+        <SectionLabel label="목표 선택" />
+        <PostGoalSection
+          mode={mode}
+          selectedGoalId={form.selectedGoalId}
+          onChange={form.changeGoal}
+        />
+      </div>
+
+      {/* 등록 or 수정 버튼 */}
+      <div className="flex justify-end gap-2 pt-2">
+        <Button variant="modal" size="md" rounded="md" onClick={onCancel}>
+          취소
+        </Button>
+        <Button
+          type="submit"
+          variant="secondary"
+          size="md"
+          rounded="md"
+          disabled={form.isSubmitDisabled || isPending}
+        >
+          {isPending ? '처리 중...' : mode === 'edit' ? '수정' : '등록'}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/features/post/components/PostFormLayout.tsx
+++ b/src/features/post/components/PostFormLayout.tsx
@@ -55,7 +55,7 @@ export function PostFormLayout({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-6 p-6">
       {/* 제목 */}
       <div className="flex flex-col gap-2">
         <SectionLabel label="제목" required />

--- a/src/features/post/components/PostGoalSection.tsx
+++ b/src/features/post/components/PostGoalSection.tsx
@@ -1,0 +1,90 @@
+import { Dropdown } from '@/components/common/overlay'
+import { DonutChart } from '@/components/common/ui/chart/DonutChart'
+
+import type { GoalOption, PostFormMode } from '../post.types'
+
+// TODO: 레이아웃 테스트용 mock 데이터 -> MSW 연동 필요
+// 실제 데이터는 GET lazy fetch 예정
+const MOCK_GOALS: GoalOption[] = [
+  {
+    id: 1,
+    title: '매일 1시간 운동',
+    startDate: '2026.04.01',
+    endDate: '2026.06.30',
+    progressRate: 48,
+    status: 'IN_PROGRESS',
+  },
+  {
+    id: 2,
+    title: '매일 독서 30분',
+    startDate: '2026.04.01',
+    endDate: '2026.04.30',
+    progressRate: 70,
+    status: 'IN_PROGRESS',
+  },
+  {
+    id: 3,
+    title: '코딩 스터디',
+    startDate: '2026.03.01',
+    endDate: '2026.05.31',
+    progressRate: 30,
+    status: 'IN_PROGRESS',
+  },
+]
+
+type PostGoalSectionProps = {
+  mode: PostFormMode
+  selectedGoalId?: number
+  onChange: (goalId: number | undefined) => void
+}
+
+export function PostGoalSection({
+  mode,
+  selectedGoalId,
+  onChange,
+}: PostGoalSectionProps) {
+  // TODO: API 연동 시 MOCK_GOALS를 useQuery 또는 fetch 결과로 교체
+  // GET /api/v1/goals?status=IN_PROGRESS
+  const goals = MOCK_GOALS
+
+  const selectedGoal = goals.find((g) => g.id === selectedGoalId)
+  const placeholder =
+    mode === 'create'
+      ? '목표를 선택해주세요.'
+      : '해당되는 항목을 선택해 주세요.'
+
+  return (
+    <div className="flex flex-col gap-4 rounded-2xl border border-border-default bg-surface p-4">
+      <Dropdown
+        options={goals.map((g) => ({ value: String(g.id), label: g.title }))}
+        value={
+          selectedGoalId !== undefined ? String(selectedGoalId) : undefined
+        }
+        onChange={(val) =>
+          onChange(val !== undefined ? Number(val) : undefined)
+        }
+        placeholder={placeholder}
+      />
+
+      {selectedGoal && (
+        <div className="flex flex-col gap-3 rounded-xl border border-border-default bg-surface p-4">
+          <span className="text-sm font-bold text-text-primary">개별 목표</span>
+
+          <div className="flex flex-col gap-1">
+            <p className="font-bold text-text-primary">{selectedGoal.title}</p>
+            <p className="text-xs text-text-muted">
+              {selectedGoal.startDate} - {selectedGoal.endDate}
+            </p>
+          </div>
+
+          <div className="flex justify-center">
+            <DonutChart
+              progressRate={selectedGoal.progressRate}
+              status="progress"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/post/components/PostTagSection.tsx
+++ b/src/features/post/components/PostTagSection.tsx
@@ -1,0 +1,60 @@
+import { Button } from '@/components/common/ui'
+import { cn } from '@/utils/cn'
+
+import { MAX_TAGS } from '../post.constants'
+import type { TagOption } from '../post.types'
+
+// TODO: 레이아웃 테스트용 mock 데이터 — API 연동 시 제거
+// 실제 데이터는 GET /api/v1/tags 로 fetch
+const MOCK_TAGS: TagOption[] = [
+  { id: 1, name: '운동' },
+  { id: 2, name: '독서' },
+  { id: 3, name: '공부' },
+  { id: 4, name: '식단' },
+  { id: 5, name: '취미' },
+  { id: 6, name: '자기계발' },
+]
+
+type PostTagSectionProps = {
+  selectedTagIds: number[]
+  onToggle: (id: number) => void
+}
+
+export function PostTagSection({
+  selectedTagIds,
+  onToggle,
+}: PostTagSectionProps) {
+  // TODO: API 연동 시 MOCK_TAGS를 useQuery 또는 fetch 결과로 교체
+  // GET /api/v1/tags
+  const tags = MOCK_TAGS
+  const isMaxReached = selectedTagIds.length >= MAX_TAGS
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag) => {
+        const isSelected = selectedTagIds.includes(tag.id)
+        const isDisabled = isMaxReached && !isSelected
+
+        return (
+          <Button
+            key={tag.id}
+            onClick={() => onToggle(tag.id)}
+            size="md"
+            rounded="full"
+            disabled={isDisabled}
+            className={cn(
+              'font-medium transition-colors',
+              isSelected
+                ? 'bg-primary-500 text-white'
+                : isDisabled
+                  ? 'cursor-not-allowed bg-gray-100 text-text-disabled'
+                  : 'bg-gray-100 text-text-muted hover:bg-gray-200'
+            )}
+          >
+            #{tag.name}
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/post/components/PostVoteSection.tsx
+++ b/src/features/post/components/PostVoteSection.tsx
@@ -1,0 +1,52 @@
+import type { VoteEditorMode } from '@/components/common/ui'
+import { Input, VoteEditor } from '@/components/common/ui'
+import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
+
+import type { PostFormMode } from '../post.types'
+import { SectionLabel } from './SectionLabel'
+
+type PostVoteSectionProps = {
+  mode: PostFormMode
+  question: string
+  options: string[]
+  period?: DateRange
+  onChangeQuestion: (question: string) => void
+  onChangeOption: (index: number, value: string) => void
+  onChangePeriod: (date: DateRange | null) => void
+  onConfirm: () => void
+}
+
+export function PostVoteSection({
+  mode,
+  question,
+  options,
+  period,
+  onChangeQuestion,
+  onChangeOption,
+  onChangePeriod,
+  onConfirm,
+}: PostVoteSectionProps) {
+  // PostFormMode('create'|'edit')와 VoteEditorMode('create'|'edit')는 값이 동일하므로 안전하게 캐스팅
+  const voteEditorMode = mode as VoteEditorMode
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-border-default bg-surface p-4">
+      <SectionLabel label="투표 생성" />
+
+      <Input
+        placeholder="투표 제목을 입력하세요"
+        value={question}
+        onChange={(e) => onChangeQuestion(e.target.value)}
+      />
+
+      <VoteEditor
+        mode={voteEditorMode}
+        options={options}
+        period={period}
+        onChangeOption={onChangeOption}
+        onChangePeriod={onChangePeriod}
+        onSubmit={onConfirm}
+      />
+    </div>
+  )
+}

--- a/src/features/post/components/PostVoteSection.tsx
+++ b/src/features/post/components/PostVoteSection.tsx
@@ -26,7 +26,7 @@ export function PostVoteSection({
   onChangePeriod,
   onConfirm,
 }: PostVoteSectionProps) {
-  // PostFormMode('create'|'edit')와 VoteEditorMode('create'|'edit')는 값이 동일하므로 안전하게 캐스팅
+  // 일단 생성 페이지에서 투표 생성 , 수정 페이지에선 투표 수정 한다는 가정
   const voteEditorMode = mode as VoteEditorMode
 
   return (

--- a/src/features/post/components/SectionLabel.tsx
+++ b/src/features/post/components/SectionLabel.tsx
@@ -1,0 +1,13 @@
+type SectionLabelProps = {
+  label: string
+  required?: boolean
+}
+
+export function SectionLabel({ label, required = false }: SectionLabelProps) {
+  return (
+    <span className="flex items-center gap-0.5 text-sm font-semibold text-text-primary">
+      {label}
+      {required && <span className="text-status-error-text">*</span>}
+    </span>
+  )
+}

--- a/src/features/post/hooks/usePostForm.ts
+++ b/src/features/post/hooks/usePostForm.ts
@@ -1,0 +1,186 @@
+import { useState } from 'react'
+
+import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
+
+import {
+  MAX_CONTENT,
+  MAX_IMAGES,
+  MAX_TAGS,
+  MAX_TITLE,
+  MAX_VOTE_OPTION,
+  MAX_VOTE_QUESTION,
+} from '../post.constants'
+import type { PostFormData, PostFormMode } from '../post.types'
+
+function charLen(str: string) {
+  return Array.from(str).length
+}
+
+export function usePostForm(
+  mode: PostFormMode,
+  defaultValues?: Partial<PostFormData>
+) {
+  // ── 기본 필드 ─────────────────────────────────────────────
+  const [title, setTitle] = useState(defaultValues?.title ?? '')
+  const [content, setContent] = useState(defaultValues?.content ?? '')
+  const [images, setImages] = useState<string[]>(defaultValues?.images ?? [])
+
+  // ── 태그 ─────────────────────────────────────────────────
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>(
+    defaultValues?.tagIds ?? []
+  )
+
+  // ── 투표 ─────────────────────────────────────────────────
+  const [voteQuestion, setVoteQuestion] = useState(
+    defaultValues?.vote?.question ?? ''
+  )
+  const [voteOptions, setVoteOptions] = useState<string[]>(
+    defaultValues?.vote?.options.map((o) => o.content) ?? ['', '']
+  )
+  // TODO: 투표 선생성 플로우 확정 시 votePeriod를 PostFormData.vote에 포함시켜야 함
+  // 현재는 VoteEditor UI 표시 전용으로만 사용되며 buildFormData()에 포함되지 않음
+  // → post.types.ts의 VoteFormData에 startAt/endAt 추가 및 buildFormData() 수정 필요
+  const [votePeriod, setVotePeriod] = useState<DateRange | undefined>()
+  const [voteConfirmed, setVoteConfirmed] = useState(
+    mode === 'edit' && !!defaultValues?.vote
+  )
+
+  // ── 목표 ─────────────────────────────────────────────────
+  const [selectedGoalId, setSelectedGoalId] = useState<number | undefined>(
+    mode === 'edit' ? defaultValues?.goalId : undefined
+  )
+
+  // ── 기타 — 마운트 시 확정되는 값이므로 상태가 아닌 상수로 관리 ──
+  const postId = defaultValues?.postId
+
+  // ── 파생 값 ──────────────────────────────────────────────
+  const titleLen = charLen(title)
+  const contentLen = charLen(content)
+  const isSubmitDisabled = title.trim() === '' || content.trim() === ''
+  const canAddImage = images.length < MAX_IMAGES
+
+  // ── 액션: 제목 / 내용 ─────────────────────────────────────
+  function changeTitle(val: string) {
+    if (charLen(val) <= MAX_TITLE) setTitle(val)
+  }
+
+  function changeContent(val: string) {
+    if (charLen(val) <= MAX_CONTENT) setContent(val)
+  }
+
+  // ── 액션: 이미지 ──────────────────────────────────────────
+  function addImages(files: File[]) {
+    const remaining = MAX_IMAGES - images.length
+    const urls = files.slice(0, remaining).map(URL.createObjectURL)
+    setImages((prev) => [...prev, ...urls])
+  }
+
+  function removeImage(index: number) {
+    setImages((prev) => {
+      const url = prev[index]
+      // blob URL인 경우에만 revoke (서버 URL은 no-op 방지)
+      if (url.startsWith('blob:')) URL.revokeObjectURL(url)
+      return prev.filter((_, i) => i !== index)
+    })
+  }
+
+  // ── 액션: 태그 ────────────────────────────────────────────
+  function toggleTag(id: number) {
+    setSelectedTagIds((prev) => {
+      if (prev.includes(id)) return prev.filter((t) => t !== id)
+      if (prev.length >= MAX_TAGS) return prev
+      return [...prev, id]
+    })
+  }
+
+  // ── 액션: 투표 ────────────────────────────────────────────
+  function changeVoteQuestion(question: string) {
+    if (charLen(question) <= MAX_VOTE_QUESTION) {
+      setVoteQuestion(question)
+      setVoteConfirmed(false)
+    }
+  }
+
+  function changeVoteOption(index: number, value: string) {
+    if (charLen(value) <= MAX_VOTE_OPTION) {
+      setVoteOptions((prev) => prev.map((o, i) => (i === index ? value : o)))
+      setVoteConfirmed(false)
+    }
+  }
+
+  function changeVotePeriod(date: DateRange | null) {
+    setVotePeriod(date ?? undefined)
+    setVoteConfirmed(false)
+  }
+
+  function confirmVote() {
+    setVoteConfirmed(true)
+  }
+
+  // ── 액션: 목표 ────────────────────────────────────────────
+  function changeGoal(goalId: number | undefined) {
+    setSelectedGoalId(goalId)
+  }
+
+  // ── 최종 payload 빌드 ─────────────────────────────────────
+  function buildFormData(): PostFormData {
+    const base: Omit<PostFormData, 'postId' | 'vote'> = {
+      title: title.trim(),
+      content: content.trim(),
+      images,
+      hasGoal: selectedGoalId !== undefined,
+      goalId: selectedGoalId,
+      hasVote: voteConfirmed,
+      tagIds: selectedTagIds,
+    }
+
+    if (mode === 'edit') {
+      // edit 모드에서 postId가 없는 것은 프로그래밍 오류
+      if (postId === undefined) {
+        throw new Error('[usePostForm] edit 모드에서 postId는 필수입니다.')
+      }
+      // PATCH 스펙: vote 필드 미포함. API 변환(post_id 등)은 호출부(Page)에서 처리
+      return { postId, ...base }
+    }
+
+    // POST 스펙: vote 포함
+    return {
+      ...base,
+      vote: voteConfirmed
+        ? {
+            question: voteQuestion,
+            options: voteOptions.map((c, i) => ({ content: c, sortOrder: i })),
+          }
+        : undefined,
+    }
+  }
+
+  return {
+    // state
+    title,
+    content,
+    images,
+    selectedTagIds,
+    voteQuestion,
+    voteOptions,
+    votePeriod,
+    selectedGoalId,
+    // 파생
+    titleLen,
+    contentLen,
+    isSubmitDisabled,
+    canAddImage,
+    // 액션
+    changeTitle,
+    changeContent,
+    addImages,
+    removeImage,
+    toggleTag,
+    changeVoteQuestion,
+    changeVoteOption,
+    changeVotePeriod,
+    confirmVote,
+    changeGoal,
+    buildFormData,
+  }
+}

--- a/src/features/post/hooks/usePostForm.ts
+++ b/src/features/post/hooks/usePostForm.ts
@@ -20,46 +20,43 @@ export function usePostForm(
   mode: PostFormMode,
   defaultValues?: Partial<PostFormData>
 ) {
-  // ── 기본 필드 ─────────────────────────────────────────────
+  // 기본 필드
   const [title, setTitle] = useState(defaultValues?.title ?? '')
   const [content, setContent] = useState(defaultValues?.content ?? '')
   const [images, setImages] = useState<string[]>(defaultValues?.images ?? [])
 
-  // ── 태그 ─────────────────────────────────────────────────
+  // 태그
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>(
     defaultValues?.tagIds ?? []
   )
 
-  // ── 투표 ─────────────────────────────────────────────────
+  // 투표
   const [voteQuestion, setVoteQuestion] = useState(
     defaultValues?.vote?.question ?? ''
   )
   const [voteOptions, setVoteOptions] = useState<string[]>(
     defaultValues?.vote?.options.map((o) => o.content) ?? ['', '']
   )
-  // TODO: 투표 선생성 플로우 확정 시 votePeriod를 PostFormData.vote에 포함시켜야 함
-  // 현재는 VoteEditor UI 표시 전용으로만 사용되며 buildFormData()에 포함되지 않음
-  // → post.types.ts의 VoteFormData에 startAt/endAt 추가 및 buildFormData() 수정 필요
   const [votePeriod, setVotePeriod] = useState<DateRange | undefined>()
   const [voteConfirmed, setVoteConfirmed] = useState(
     mode === 'edit' && !!defaultValues?.vote
   )
 
-  // ── 목표 ─────────────────────────────────────────────────
+  // 목표
   const [selectedGoalId, setSelectedGoalId] = useState<number | undefined>(
     mode === 'edit' ? defaultValues?.goalId : undefined
   )
 
-  // ── 기타 — 마운트 시 확정되는 값이므로 상태가 아닌 상수로 관리 ──
+  // 기타 — 마운트 시 확정되는 값이므로 상태가 아닌 상수로 관리
   const postId = defaultValues?.postId
 
-  // ── 파생 값 ──────────────────────────────────────────────
+  // 파생 값
   const titleLen = charLen(title)
   const contentLen = charLen(content)
   const isSubmitDisabled = title.trim() === '' || content.trim() === ''
   const canAddImage = images.length < MAX_IMAGES
 
-  // ── 액션: 제목 / 내용 ─────────────────────────────────────
+  // 제목 / 내용
   function changeTitle(val: string) {
     if (charLen(val) <= MAX_TITLE) setTitle(val)
   }
@@ -68,7 +65,7 @@ export function usePostForm(
     if (charLen(val) <= MAX_CONTENT) setContent(val)
   }
 
-  // ── 액션: 이미지 ──────────────────────────────────────────
+  // 이미지
   function addImages(files: File[]) {
     const remaining = MAX_IMAGES - images.length
     const urls = files.slice(0, remaining).map(URL.createObjectURL)
@@ -84,7 +81,7 @@ export function usePostForm(
     })
   }
 
-  // ── 액션: 태그 ────────────────────────────────────────────
+  // 태그
   function toggleTag(id: number) {
     setSelectedTagIds((prev) => {
       if (prev.includes(id)) return prev.filter((t) => t !== id)
@@ -93,7 +90,7 @@ export function usePostForm(
     })
   }
 
-  // ── 액션: 투표 ────────────────────────────────────────────
+  // 투표
   function changeVoteQuestion(question: string) {
     if (charLen(question) <= MAX_VOTE_QUESTION) {
       setVoteQuestion(question)
@@ -117,12 +114,12 @@ export function usePostForm(
     setVoteConfirmed(true)
   }
 
-  // ── 액션: 목표 ────────────────────────────────────────────
+  // 목표
   function changeGoal(goalId: number | undefined) {
     setSelectedGoalId(goalId)
   }
 
-  // ── 최종 payload 빌드 ─────────────────────────────────────
+  // 최종 payload 빌드
   function buildFormData(): PostFormData {
     const base: Omit<PostFormData, 'postId' | 'vote'> = {
       title: title.trim(),

--- a/src/features/post/index.ts
+++ b/src/features/post/index.ts
@@ -1,0 +1,27 @@
+export { PostFormLayout } from './components/PostFormLayout'
+
+// 프론트 전용 타입
+export type {
+  GoalOption,
+  GoalStatus,
+  PostFormData,
+  PostFormMode,
+  TagOption,
+  VoteFormData,
+  VoteOptionFormData,
+} from './post.types'
+
+// API 요청/응답 타입 (서버 스펙 그대로)
+export type {
+  ApiGoalResponse,
+  ApiPostCreateRequest,
+  ApiPostUpdateRequest,
+  ApiTagResponse,
+} from './post.api.types'
+
+// API ↔ 프론트 변환 함수
+export {
+  toApiCreateRequest,
+  toApiUpdateRequest,
+  toGoalOption,
+} from './post.mappers'

--- a/src/features/post/post.api.types.ts
+++ b/src/features/post/post.api.types.ts
@@ -1,0 +1,70 @@
+import type { GoalStatus } from './post.types'
+
+// GET /api/v1/goals 응답
+export type ApiGoalResponse = {
+  goal_id: number
+  title: string
+  startDate: string
+  endDate: string
+  status: GoalStatus
+  created_at: string
+  progressRate: number
+  isCheckedToday: boolean
+}
+
+// GET /api/v1/tags 응답
+export type ApiTagResponse = {
+  id: number
+  name: string
+}
+
+// POST /api/v1/posts 요청
+export type ApiPostCreateRequest = {
+  title: string
+  content: string
+  images: string[]
+  hasGoal: boolean
+  goalId?: number
+  hasVote: boolean
+  vote?: {
+    question: string
+    options: Array<{ content: string; sortOrder: number }>
+  }
+  tagIds: number[]
+}
+
+// ── POST /api/v1/posts/votes 요청 ────────────────────────────
+// TODO: 백엔드 엔드포인트 확정 후 타입 추가
+// 투표는 게시글 생성 전에 먼저 독립적으로 생성됨 (post_id 없이 요청)
+// 요청 body 예시: { question, options: string[], start_at: datetime, end_at: datetime }
+// export type ApiVoteCreateRequest = {
+//   question: string
+//   options: string[]
+//   start_at: string  // ISO datetime
+//   end_at: string    // ISO datetime
+// }
+
+// ── POST /api/v1/posts/votes 응답 ────────────────────────────
+// TODO: 백엔드 응답 확정 후 타입 추가
+// 생성된 vote_id와 options를 게시글 생성 요청(vote 필드)에 활용
+// export type ApiVoteCreateResponse = {
+//   vote_id: number
+//   post_id: number
+//   question: string
+//   start_at: string
+//   end_at: string
+//   status: string
+//   options: Array<{ vote_option_id: number; content: string }>
+// }
+
+// PATCH /api/v1/posts/:postId 요청
+export type ApiPostUpdateRequest = {
+  post_id: number
+  title: string
+  content: string
+  images: string[]
+  hasGoal: boolean
+  goalId?: number
+  hasVote: boolean
+  tagIds: number[]
+}

--- a/src/features/post/post.api.types.ts
+++ b/src/features/post/post.api.types.ts
@@ -33,7 +33,7 @@ export type ApiPostCreateRequest = {
   tagIds: number[]
 }
 
-// ── POST /api/v1/posts/votes 요청 ────────────────────────────
+// POST /api/v1/posts/votes 요청
 // TODO: 백엔드 엔드포인트 확정 후 타입 추가
 // 투표는 게시글 생성 전에 먼저 독립적으로 생성됨 (post_id 없이 요청)
 // 요청 body 예시: { question, options: string[], start_at: datetime, end_at: datetime }
@@ -44,7 +44,7 @@ export type ApiPostCreateRequest = {
 //   end_at: string    // ISO datetime
 // }
 
-// ── POST /api/v1/posts/votes 응답 ────────────────────────────
+// POST /api/v1/posts/votes 응답
 // TODO: 백엔드 응답 확정 후 타입 추가
 // 생성된 vote_id와 options를 게시글 생성 요청(vote 필드)에 활용
 // export type ApiVoteCreateResponse = {

--- a/src/features/post/post.constants.ts
+++ b/src/features/post/post.constants.ts
@@ -1,0 +1,6 @@
+export const MAX_TITLE = 100
+export const MAX_CONTENT = 500
+export const MAX_IMAGES = 3
+export const MAX_TAGS = 3
+export const MAX_VOTE_QUESTION = 100
+export const MAX_VOTE_OPTION = 100

--- a/src/features/post/post.mappers.ts
+++ b/src/features/post/post.mappers.ts
@@ -1,0 +1,67 @@
+import type {
+  ApiGoalResponse,
+  ApiPostCreateRequest,
+  ApiPostUpdateRequest,
+} from './post.api.types'
+import type { GoalOption, PostFormData } from './post.types'
+
+// API 응답 → 프론트 타입
+
+export function toGoalOption(api: ApiGoalResponse): GoalOption {
+  return {
+    id: api.goal_id,
+    title: api.title,
+    startDate: api.startDate,
+    endDate: api.endDate,
+    progressRate: api.progressRate,
+    status: api.status,
+  }
+}
+
+// 투표 관련 매퍼 (TODO: 백엔드 엔드포인트 확정 후 구현)
+// [1] PostFormData + votePeriod → ApiVoteCreateRequest
+//   - usePostForm의 votePeriod(DateRange)를 ISO datetime 문자열로 변환
+//   - vote options는 string[] 형태로 전달 (sortOrder 없이)
+// [2] ApiVoteCreateResponse → PostFormData.vote 병합용 객체
+//   - 응답의 options(vote_option_id, content)를 { content, sortOrder } 형태로 변환
+//   - 게시글 생성 요청의 vote 필드에 주입
+
+// 프론트 타입 → API 요청
+
+export function toApiCreateRequest(data: PostFormData): ApiPostCreateRequest {
+  return {
+    title: data.title,
+    content: data.content,
+    images: data.images,
+    hasGoal: data.hasGoal,
+    ...(data.goalId !== undefined && { goalId: data.goalId }),
+    hasVote: data.hasVote,
+    ...(data.vote !== undefined && {
+      vote: {
+        question: data.vote.question,
+        options: data.vote.options.map((o) => ({
+          content: o.content,
+          sortOrder: o.sortOrder,
+        })),
+      },
+    }),
+    tagIds: data.tagIds,
+  }
+}
+
+export function toApiUpdateRequest(data: PostFormData): ApiPostUpdateRequest {
+  if (data.postId === undefined) {
+    throw new Error('postId는 필수')
+  }
+
+  return {
+    post_id: data.postId,
+    title: data.title,
+    content: data.content,
+    images: data.images,
+    hasGoal: data.hasGoal,
+    ...(data.goalId !== undefined && { goalId: data.goalId }),
+    hasVote: data.hasVote,
+    tagIds: data.tagIds,
+  }
+}

--- a/src/features/post/post.types.ts
+++ b/src/features/post/post.types.ts
@@ -1,0 +1,46 @@
+// 프론트에서 사용하는 모든 타입은 camelCase로 통일
+// API 요청/응답 타입은 post.api.types.ts 참고
+// API ↔ 프론트 변환은 post.mappers.ts 참고
+
+export type PostFormMode = 'create' | 'edit'
+
+export type GoalStatus = 'IN_PROGRESS' | 'FAILED' | 'COMPLETED'
+
+export type VoteOptionFormData = {
+  content: string
+  sortOrder: number
+}
+
+export type VoteFormData = {
+  question: string
+  options: VoteOptionFormData[]
+}
+
+// 폼 상태 및 컴포넌트 간 전달에 사용
+export type PostFormData = {
+  postId?: number
+  title: string
+  content: string
+  images: string[]
+  hasGoal: boolean
+  goalId?: number
+  hasVote: boolean
+  vote?: VoteFormData
+  tagIds: number[]
+}
+
+// 목표 드롭다운에서 사용하는 프론트 전용 타입
+export type GoalOption = {
+  id: number
+  title: string
+  startDate: string
+  endDate: string
+  progressRate: number
+  status: GoalStatus
+}
+
+// 태그 선택에서 사용하는 프론트 전용 타입
+export type TagOption = {
+  id: number
+  name: string
+}

--- a/src/pages/PostCreatePage.tsx
+++ b/src/pages/PostCreatePage.tsx
@@ -1,0 +1,40 @@
+import { useNavigate } from 'react-router'
+
+import type { PostFormData } from '@/features/post'
+import { PostFormLayout, toApiCreateRequest } from '@/features/post'
+
+export function PostCreatePage() {
+  const navigate = useNavigate()
+
+  async function handleSubmit(data: PostFormData) {
+    // TODO: [투표 선생성 → 게시글 생성] 2단계 순차 API 호출 구현 필요
+    //
+    // [1단계] 투표가 있는 경우 먼저 투표를 생성
+    //   - POST /api/v1/posts/votes
+    //   - 요청 body: { question, options: string[], start_at, end_at }
+    //   - 응답(200): ApiVoteCreateResponse (vote_id, question, options 등)
+    //   ※ start_at / end_at 은 현재 usePostForm의 votePeriod 상태에서 가져와야 함
+    //   ※ votePeriod가 PostFormData에 포함되지 않으므로, PostFormData.vote 또는
+    //      별도 필드로 추가하는 타입 변경이 선행되어야 함 (post.types.ts, usePostForm.ts 수정 필요)
+    //
+    // [2단계] 1단계 응답값을 이용해 게시글 생성
+    //   - POST /api/v1/posts
+    //   - hasVote: true, vote: { question, options: [{ content, sortOrder }] } 포함
+    //   - vote 데이터는 1단계 응답(ApiVoteCreateResponse)을 toApiCreateRequest mapper로 변환하여 사용
+    //
+    // [타입/매퍼 추가 필요]
+    //   - post.api.types.ts: ApiVoteCreateRequest, ApiVoteCreateResponse 타입 추가
+    //   - post.mappers.ts: toApiVoteCreateRequest, fromApiVoteCreateResponse 매퍼 추가
+
+    const body = toApiCreateRequest(data)
+    console.log('create post:', body)
+  }
+
+  return (
+    <PostFormLayout
+      mode="create"
+      onSubmit={handleSubmit}
+      onCancel={() => navigate(-1)}
+    />
+  )
+}

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -1,0 +1,25 @@
+import { useNavigate, useParams } from 'react-router'
+
+import type { PostFormData } from '@/features/post'
+import { PostFormLayout, toApiUpdateRequest } from '@/features/post'
+
+export function PostEditPage() {
+  const navigate = useNavigate()
+  const { id } = useParams<{ id: string }>()
+
+  function handleSubmit(data: PostFormData) {
+    if (data.postId === undefined) return
+    const body = toApiUpdateRequest(data)
+    // TODO: PATCH /api/v1/posts/:id 연동
+    // defaultValues는 GET /api/v1/posts/:id 응답 후 PostFormLayout에 전달 (로딩 중 렌더링 보류)
+    console.log(`edit post ${id}:`, body)
+  }
+
+  return (
+    <PostFormLayout
+      mode="edit"
+      onSubmit={handleSubmit}
+      onCancel={() => navigate(-1)}
+    />
+  )
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,6 @@
 export { LoginPage } from './LoginPage'
 export { default as Main } from './Main'
 export { NotFoundPage } from './not-found'
+export { PostCreatePage } from './PostCreatePage'
+export { PostEditPage } from './PostEditPage'
 export { SignupPage } from './SignupPage'

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,7 +1,14 @@
 import { createBrowserRouter } from 'react-router'
 
 import { RootLayout } from '@/components/common/layout'
-import { LoginPage, Main, NotFoundPage, SignupPage } from '@/pages'
+import {
+  LoginPage,
+  Main,
+  NotFoundPage,
+  PostCreatePage,
+  PostEditPage,
+  SignupPage,
+} from '@/pages'
 
 /*
  * 라우터 설정 파일
@@ -18,6 +25,14 @@ export const router = createBrowserRouter([
       {
         index: true,
         element: <Main />,
+      },
+      {
+        path: 'posts/create',
+        element: <PostCreatePage />,
+      },
+      {
+        path: 'posts/:id/edit',
+        element: <PostEditPage />,
       },
     ],
   },

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -27,11 +27,11 @@ export const router = createBrowserRouter([
         element: <Main />,
       },
       {
-        path: 'posts/create',
+        path: 'post/create',
         element: <PostCreatePage />,
       },
       {
-        path: 'posts/:id/edit',
+        path: 'post/:id/edit',
         element: <PostEditPage />,
       },
     ],


### PR DESCRIPTION
## 📌 관련 이슈

Closes #85 

## ✨ 변경 내용

- PostFormLayout: 게시글 생성/수정 공통 폼 레이아웃
- usePostForm: 게시글 폼 상태 및 액션 훅 (제목, 내용, 이미지, 태그, 투표, 목표)
- PostTagSection: 태그 다중 선택 (최대 3개, 초과 시 비활성화)
- PostVoteSection: VoteEditor 공통 컴포넌트 연동
- PostGoalSection: 목표 드롭다운 (선택 시 DonutChart 미리보기)
- SectionLabel: 필수 항목 표시(*)를 위한 공통 섹션 레이블
- 3-layer 타입: 프론트 camelCase로 props 타입 지정하여 사용 / API 스펙 타입에 맞게 사용할 수 있도록 mapper 함수로 분리하여 실제 데이터 타입과 맞춤

## 📸 스크린샷(선택)

/post/create


https://github.com/user-attachments/assets/4648619e-5d02-4ae9-b7a1-46274c5be6d1




## 📚 참고사항
--> 게시글 관련 백엔드 협의가 필요한 사항
- 투표 생성 플로우 문제 : 현재 게시글 생성 API(POST /api/v1/posts) 에 vote 데이터가 포함되어 있으나, (REQ-VOTE-001)투표 실제 생성은 POST /api/v1/posts/votes 으로 진행 -> 의도된 부분인지 파악 필요
- (REQ-VOTE-001) 에는 post_id 값 필요 -> 게시글 생성 중에는 post_id를 받을 수 없음 -> 엔드포인트 협의 진행 필요
- 게시글 생성 요청의 vote 상세 데이터 대신 vote_id만 전달하는 방향으로 제안 예정
- 위 협의 결과에 따라 post.types.ts, usePostForm.ts, post.mappers.ts, PostCreatePage.tsx 수정 예정
- 실제 API 연동, 유효성 검증, 에러 처리는 기획/API 확정 후 별도 작업