### PR TITLE
feat: auth msw signup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,21 @@
 import { RouterProvider } from 'react-router'
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { GlobalToast } from '@/components/common/ui'
 import { ThemeProvider } from '@/lib/theme/ThemeProvider'
 import { router } from '@/router/Router'
 
+const queryClient = new QueryClient()
+
 function App() {
   return (
-    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-      <RouterProvider router={router} />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+        <RouterProvider router={router} />
+        <GlobalToast />
+      </ThemeProvider>
+    </QueryClientProvider>
   )
 }
 

--- a/src/apis/apiPath.ts
+++ b/src/apis/apiPath.ts
@@ -1,5 +1,6 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
-export const MSW_BASE_URL = 'https://msw.local/api/v1'
+export const MSW_BASE_URL = '/api/v1'
 
-// MSW handler에서 절대 경로를 일관되게 만들기 위한 헬퍼
-export const toMswApiUrl = (path: string) => `${MSW_BASE_URL}${path}`
+// .env의 API_BASE_URL이 있으면 요청 도메인이 달라질 수 있어서,
+// MSW handler는 어떤 도메인이든 /api/v1 경로만 맞으면 잡도록 wildcard를 씁니다.
+export const toMswApiUrl = (path: string) => `*${MSW_BASE_URL}${path}`

--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -1,2 +1,55 @@
-// TODO: auth API 연결 시 로그인/회원가입/이메일 인증 호출 함수를 추가
-export const authApi = {} as const
+import { apiClient } from '@/apis/apiClient'
+
+import type {
+  CheckNicknameRequest,
+  CheckNicknameResponse,
+  SendEmailVerificationRequest,
+  SendEmailVerificationResponse,
+  SignupRequest,
+  SignupResponse,
+  VerifyEmailRequest,
+  VerifyEmailResponse,
+} from './auth.schema'
+import { AUTH_ENDPOINTS } from './endpoints'
+
+export const authApi = {
+  signup: async (payload: SignupRequest) => {
+    const { data } = await apiClient.post<SignupResponse>(
+      AUTH_ENDPOINTS.signup,
+      payload
+    )
+
+    return data
+  },
+
+  sendEmailVerification: async ({ email }: SendEmailVerificationRequest) => {
+    const { data } = await apiClient.post<SendEmailVerificationResponse>(
+      AUTH_ENDPOINTS.sendEmailVerification,
+      { email }
+    )
+
+    return data
+  },
+
+  verifyEmail: async ({ email, code }: VerifyEmailRequest) => {
+    const { data } = await apiClient.get<VerifyEmailResponse>(
+      AUTH_ENDPOINTS.verifyEmail,
+      {
+        params: { email, code },
+      }
+    )
+
+    return data
+  },
+
+  checkNickname: async ({ nickname }: CheckNicknameRequest) => {
+    const { data } = await apiClient.get<CheckNicknameResponse>(
+      AUTH_ENDPOINTS.checkNickname,
+      {
+        params: { nickname },
+      }
+    )
+
+    return data
+  },
+} as const

--- a/src/apis/auth/auth.schema.ts
+++ b/src/apis/auth/auth.schema.ts
@@ -13,6 +13,7 @@ const accessToken = z.string()
 const fieldError = z.record(z.string(), z.array(z.string()))
 
 // REQ-AUTH-001: 이메일 회원가입
+// POST /api/v1/accounts/signup
 export const signupRequestSchema = z.object({
   password,
   nickname,
@@ -25,6 +26,7 @@ export const signupResponseSchema = z.object({
 })
 
 // REQ-AUTH-002: 이메일 인증 발송
+// POST /api/v1/accounts/verification/send-email
 export const sendEmailVerificationRequestSchema = z.object({
   email,
 })
@@ -34,6 +36,7 @@ export const sendEmailVerificationResponseSchema = z.object({
 })
 
 // REQ-AUTH-003: 이메일 인증 확인
+// GET /api/v1/accounts/verification/verify-email
 export const verifyEmailRequestSchema = z.object({
   email,
   code,
@@ -45,21 +48,29 @@ export const verifyEmailResponseSchema = z.object({
 })
 
 // REQ-AUTH-004~006: 소셜 로그인 콜백
+// POST /api/v1/accounts/social-login/kakao/callback
 export const kakaoLoginCallbackRequestSchema = z.object({
   code,
 })
 
+// POST /api/v1/accounts/social-login/naver/callback
 export const naverLoginCallbackRequestSchema = z.object({
   code,
   state,
 })
 
+// POST /api/v1/accounts/social-login/google/callback
 export const googleLoginCallbackRequestSchema = z.object({
   code,
   state: state.optional(),
 })
 
+export const socialLoginResponseSchema = z.object({
+  access_token: accessToken,
+})
+
 // REQ-AUTH-007: 이메일 로그인
+// POST /api/v1/accounts/login
 export const loginRequestSchema = z.object({
   email,
   password,
@@ -78,11 +89,13 @@ export const loginUnauthorizedResponseSchema = z.object({
 })
 
 // REQ-AUTH-008: 로그아웃
+// POST /api/v1/accounts/logout
 export const logoutResponseSchema = z.object({
   detail,
 })
 
 // REQ-AUTH-009: JWT 토큰 재발급
+// POST /api/v1/accounts/token/refresh
 export const refreshTokenRequestSchema = z.object({
   refresh_token: refreshToken,
 })
@@ -98,6 +111,7 @@ export const sessionExpiredResponseSchema = z.object({
 })
 
 // REQ-AUTH-010: 닉네임 중복 확인
+// GET /api/v1/accounts/check-nickname
 export const checkNicknameRequestSchema = z.object({
   nickname,
 })
@@ -105,6 +119,15 @@ export const checkNicknameRequestSchema = z.object({
 export const checkNicknameResponseSchema = z.object({
   detail,
 })
+
+// Zod 스키마 기반 타입 추론
+// z.infer<typeof schema>를 사용하면,
+// Zod로 정의한 스키마를 기준으로 TypeScript 타입을 자동 생성
+// 목적:
+// 1. 타입을 따로 정의하지 않아도 됨 (중복 제거)
+// 2. API 스펙 변경 시 스키마만 수정하면 타입도 자동 반영됨
+// 3. 폼/응답/요청 구조를 하나의 기준(Zod)으로 통일 가능
+// 즉, "타입 정의 + 런타임 검증"을 동시에 가져가기 위한 구조
 
 export type SignupRequest = z.infer<typeof signupRequestSchema>
 export type SignupResponse = z.infer<typeof signupResponseSchema>
@@ -114,6 +137,7 @@ export type SendEmailVerificationRequest = z.infer<
 export type SendEmailVerificationResponse = z.infer<
   typeof sendEmailVerificationResponseSchema
 >
+
 export type VerifyEmailRequest = z.infer<typeof verifyEmailRequestSchema>
 export type VerifyEmailResponse = z.infer<typeof verifyEmailResponseSchema>
 export type KakaoLoginCallbackRequest = z.infer<
@@ -125,6 +149,7 @@ export type NaverLoginCallbackRequest = z.infer<
 export type GoogleLoginCallbackRequest = z.infer<
   typeof googleLoginCallbackRequestSchema
 >
+export type SocialLoginResponse = z.infer<typeof socialLoginResponseSchema>
 export type LoginRequest = z.infer<typeof loginRequestSchema>
 export type LoginResponse = z.infer<typeof loginResponseSchema>
 export type FieldErrorResponse = z.infer<typeof fieldErrorResponseSchema>

--- a/src/apis/auth/endpoints.ts
+++ b/src/apis/auth/endpoints.ts
@@ -7,7 +7,6 @@ export const AUTH_ENDPOINTS = {
   verifyEmail: '/accounts/verification/verify-email',
   checkNickname: '/accounts/check-nickname',
   refreshToken: '/accounts/token/refresh',
-  changePassword: '/accounts/change-password',
   socialLoginCallback: (provider: SocialLoginProvider) =>
     `/accounts/social-login/${provider}/callback`,
 } as const

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -17,6 +17,7 @@ export type {
   SessionExpiredResponse,
   SignupRequest,
   SignupResponse,
+  SocialLoginResponse,
   VerifyEmailRequest,
   VerifyEmailResponse,
 } from './auth.schema'

--- a/src/components/common/layout/RootLayout.tsx
+++ b/src/components/common/layout/RootLayout.tsx
@@ -5,7 +5,6 @@
 import { Outlet } from 'react-router'
 
 import { Footer, Header } from '@/components/common/layout'
-import { GlobalToast } from '@/components/common/ui'
 
 export function RootLayout() {
   return (
@@ -16,7 +15,6 @@ export function RootLayout() {
         <Outlet />
       </div>
       <Footer />
-      <GlobalToast />
     </div>
   )
 }

--- a/src/features/auth/AuthForm.tsx
+++ b/src/features/auth/AuthForm.tsx
@@ -55,7 +55,7 @@ function FormField<TFieldValues extends FieldValues = FieldValues>({
   return (
     <div
       className={cn(
-        label ? 'grid grid-cols-[108px_1fr] items-center' : 'block',
+        label ? 'grid grid-cols-[120px_1fr] items-center' : 'block',
         'w-full'
       )}
     >
@@ -78,13 +78,13 @@ function FormField<TFieldValues extends FieldValues = FieldValues>({
             {...props}
           />
           {children && (
-            <div className="absolute right-2 top-1/2 -translate-y-1/2">
+            <div className="absolute right-0 pb-3 top-1/2 -translate-y-1/2">
               {children}
             </div>
           )}
         </div>
         {fieldState.error?.message && (
-          <p className="text-xs text-red-500">{fieldState.error?.message}</p>
+          <p className="text-xs text-red-500">{fieldState.error.message}</p>
         )}
       </div>
     </div>

--- a/src/features/auth/signup/ProfileImageSelectField.tsx
+++ b/src/features/auth/signup/ProfileImageSelectField.tsx
@@ -7,7 +7,7 @@ import {
   yellowCharacterImage,
 } from '@/assets/images'
 import { CharacterSelectModal } from '@/components/common/overlay'
-import { Button } from '@/components/common/ui'
+import { cn } from '@/utils/cn'
 
 // API 연결 전 임시 캐릭터 목록입니다. 추후 백엔드에서 받은 이미지 URL 목록으로 교체합니다.
 const CHARACTER_IMAGES = [
@@ -27,6 +27,7 @@ export function ProfileImageSelectField({
   onChange,
 }: ProfileImageSelectFieldProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const [isActive, setIsActive] = useState(false)
 
   // 선택값이 없으면 기본 캐릭터를 보여줍니다.
   const selectedCharacter = useMemo(
@@ -41,22 +42,33 @@ export function ProfileImageSelectField({
     if (!character) return
 
     onChange(character.src)
+    setIsActive(true)
     setIsOpen(false)
   }
 
   return (
-    <div className="grid w-full grid-cols-[108px_1fr] items-center">
-      <span className="text-sm">프로필 이미지</span>
-      <Button
-        className="w-fit bg-transparent p-0"
+    <div className="grid w-full grid-cols-[120px_1fr] items-center">
+      <span className="text-sm leading-tight">프로필 캐릭터 선택</span>
+      <button
+        type="button"
+        aria-label="프로필 캐릭터 선택"
+        className="group relative size-16 cursor-pointer rounded-full transition-transform duration-200 ease-out hover:scale-110"
         onClick={() => setIsOpen(true)}
       >
         <img
           src={selectedCharacter.src}
           alt={selectedCharacter.label}
-          className="size-16 rounded-full object-contain"
+          className="size-16 rounded-full object-contain shrink-0"
         />
-      </Button>
+        <span
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute inset-0 rounded-full bg-gray-200/70 transition-opacity duration-200 dark:bg-gray-950/50',
+            'group-hover:opacity-0 group-focus-visible:opacity-0',
+            (isOpen || isActive) && 'opacity-0'
+          )}
+        />
+      </button>
 
       {isOpen ? (
         <CharacterSelectModal

--- a/src/features/auth/signup/hook/useEmailVerification.ts
+++ b/src/features/auth/signup/hook/useEmailVerification.ts
@@ -1,0 +1,177 @@
+import { useEffect, useRef, useState } from 'react'
+import { type UseFormReturn, useWatch } from 'react-hook-form'
+
+import {
+  useSendEmailVerificationMutation,
+  useVerifyEmailMutation,
+} from '@/query/auth'
+import type { SignupFormSchema } from '@/schemas/auth/authForm.schema'
+
+const EMAIL_VERIFICATION_SECONDS = 5 * 60
+const EMPTY_EMAIL_AUTH = {
+  emailToken: '',
+  sentEmail: '',
+  verifiedEmail: '',
+}
+
+const formatTimer = (seconds: number) => {
+  const minutes = Math.floor(seconds / 60)
+  const remainSeconds = seconds % 60
+
+  return `${minutes}:${String(remainSeconds).padStart(2, '0')}`
+}
+
+export function useEmailVerification(methods: UseFormReturn<SignupFormSchema>) {
+  const [timer, setTimer] = useState(0)
+  const [emailAuth, setEmailAuth] = useState(EMPTY_EMAIL_AUTH)
+  const isFirstEmailRender = useRef(true)
+
+  const { clearErrors, control, getValues, setError, setValue, trigger } =
+    methods
+  const email = useWatch({ control, name: 'email' })
+  const sendMutation = useSendEmailVerificationMutation()
+  const verifyMutation = useVerifyEmailMutation()
+
+  const isSent = sendMutation.isSuccess && emailAuth.sentEmail === email
+  const isVerified =
+    verifyMutation.isSuccess && emailAuth.verifiedEmail === email
+  const isCodeFieldOpen = isSent && !isVerified && timer > 0
+
+  // 이메일을 수정하면 기존 인증 상태와 입력된 인증번호를 초기화합니다.
+  useEffect(() => {
+    if (isFirstEmailRender.current) {
+      isFirstEmailRender.current = false
+      return
+    }
+
+    clearErrors('email')
+    clearErrors('code')
+    setValue('code', '')
+    setValue('email_token', '', { shouldValidate: true })
+    // 이전 이메일로 받은 인증 토큰이 새 이메일에 재사용되지 않도록 지웁니다.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setEmailAuth(EMPTY_EMAIL_AUTH)
+  }, [clearErrors, email, setValue])
+
+  // 인증번호 발송 후 남은 시간을 1초마다 줄입니다.
+  useEffect(() => {
+    if (!isSent || timer <= 0 || isVerified) return
+
+    const timerId = window.setInterval(() => {
+      setTimer((seconds) => {
+        const nextSeconds = seconds - 1
+
+        if (nextSeconds <= 0) {
+          // 인증 시간이 끝나면 코드 입력 필드를 닫고 인증 버튼 상태로 되돌립니다.
+          sendMutation.reset()
+          verifyMutation.reset()
+          setValue('code', '')
+          setValue('email_token', '', { shouldValidate: true })
+          setEmailAuth(EMPTY_EMAIL_AUTH)
+          return 0
+        }
+
+        return nextSeconds
+      })
+    }, 1000)
+
+    return () => window.clearInterval(timerId)
+  }, [isSent, isVerified, sendMutation, setValue, timer, verifyMutation])
+
+  const send = async () => {
+    if (isVerified) return
+
+    // 이메일 형식이 유효할 때만 인증번호 발송 API를 호출합니다.
+    const isEmailValid = await trigger('email')
+
+    if (!isEmailValid) return
+
+    sendMutation.mutate(
+      { email: getValues('email') },
+      {
+        onSuccess: () => {
+          clearErrors('email')
+          clearErrors('code')
+          verifyMutation.reset()
+          setValue('code', '')
+          setValue('email_token', '', { shouldValidate: true })
+          setEmailAuth({
+            ...EMPTY_EMAIL_AUTH,
+            sentEmail: getValues('email'),
+          })
+          setTimer(EMAIL_VERIFICATION_SECONDS)
+        },
+        onError: (error) => {
+          setError('email', {
+            type: 'server',
+            message:
+              error.response?.data?.error_detail.email?.[0] ??
+              '인증번호 발송에 실패했습니다.',
+          })
+        },
+      }
+    )
+  }
+
+  const verify = async () => {
+    // 제한 시간이 지나면 확인 요청을 보내지 않고 재전송을 유도합니다.
+    if (timer <= 0) {
+      setError('code', {
+        type: 'manual',
+        message: '인증 시간이 만료되었습니다. 다시 보내주세요.',
+      })
+      return
+    }
+
+    const code = getValues('code')?.trim()
+
+    if (!code) {
+      setError('code', {
+        type: 'manual',
+        message: '인증번호를 입력해주세요',
+      })
+      return
+    }
+
+    const isCodeValid = await trigger('code')
+
+    if (!isCodeValid) return
+
+    verifyMutation.mutate(
+      { email: getValues('email'), code },
+      {
+        onSuccess: (data) => {
+          clearErrors('code')
+          // 인증 성공 후 회원가입 요청에 사용할 1회용 이메일 토큰을 보관합니다.
+          setValue('email_token', data.email_token, { shouldValidate: true })
+          setEmailAuth({
+            emailToken: data.email_token,
+            sentEmail: getValues('email'),
+            verifiedEmail: getValues('email'),
+          })
+          setTimer(0)
+        },
+        onError: (error) => {
+          setError('code', {
+            type: 'server',
+            message:
+              error.response?.data?.error_detail.code?.[0] ??
+              '인증번호를 다시 확인해주세요.',
+          })
+        },
+      }
+    )
+  }
+
+  return {
+    emailToken: isVerified ? emailAuth.emailToken : '',
+    isCodeFieldOpen,
+    isSending: sendMutation.isPending,
+    isSent,
+    isVerified,
+    isVerifying: verifyMutation.isPending,
+    send,
+    timerText: formatTimer(isSent ? timer : 0),
+    verify,
+  }
+}

--- a/src/features/auth/signup/hook/useNicknameCheck.ts
+++ b/src/features/auth/signup/hook/useNicknameCheck.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react'
+import { type UseFormReturn, useWatch } from 'react-hook-form'
+
+import { useCheckNicknameMutation } from '@/query/auth'
+import type { SignupFormSchema } from '@/schemas/auth/authForm.schema'
+
+export function useNicknameCheck(methods: UseFormReturn<SignupFormSchema>) {
+  const { clearErrors, control, getValues, setError, setValue } = methods
+  const nickname = useWatch({ control, name: 'nickname' })
+  const mutation = useCheckNicknameMutation()
+  const isFirstNicknameRender = useRef(true)
+
+  const isChecked =
+    mutation.isSuccess && mutation.variables?.nickname === nickname
+
+  // 닉네임을 수정하면 이전 서버 에러 메시지만 지웁니다.
+  useEffect(() => {
+    if (isFirstNicknameRender.current) {
+      isFirstNicknameRender.current = false
+      return
+    }
+
+    clearErrors('nickname')
+
+    if (mutation.isSuccess && mutation.variables?.nickname !== nickname) {
+      // 사용가능 확인을 받은 뒤 닉네임을 다시 바꾸면 재확인이 필요합니다.
+      setError('nickname', {
+        type: 'manual',
+        message: '중복확인을 해주세요',
+      })
+    }
+  }, [
+    clearErrors,
+    mutation.isSuccess,
+    mutation.variables?.nickname,
+    nickname,
+    setError,
+  ])
+
+  const check = async () => {
+    // 앞뒤 공백은 닉네임으로 쓰지 않도록 폼 값과 API 요청값을 같은 값으로 맞춥니다.
+    const trimmedNickname = getValues('nickname').trim()
+
+    setValue('nickname', trimmedNickname, {
+      shouldDirty: true,
+      shouldValidate: false,
+    })
+
+    // 중복확인 버튼에서는 중복확인 완료 여부가 아니라 닉네임 입력값만 먼저 확인합니다.
+    if (!trimmedNickname) {
+      setError('nickname', {
+        type: 'manual',
+        message: '닉네임을 입력해주세요',
+      })
+      return
+    }
+
+    mutation.mutate(
+      { nickname: trimmedNickname },
+      {
+        onSuccess: () => {
+          clearErrors('nickname')
+        },
+        onError: (error) => {
+          setError('nickname', {
+            type: 'server',
+            message:
+              error.response?.data?.error_detail.nickname?.[0] ??
+              '닉네임 확인에 실패했습니다.',
+          })
+        },
+      }
+    )
+  }
+
+  return {
+    check,
+    isChecked,
+    isPending: mutation.isPending,
+  }
+}

--- a/src/mocks/data/auth.ts
+++ b/src/mocks/data/auth.ts
@@ -1,2 +1,0 @@
-// TODO: auth MSW 연결 시 로그인/회원가입 mock 데이터를 추가합니다.
-export {}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
 import { loginHandler } from './handlers/loginHandler'
+import { signupHandler } from './handlers/signupHandler'
 
-export const handlers = [...loginHandler]
+export const handlers = [...loginHandler, ...signupHandler]

--- a/src/mocks/handlers/signupHandler.ts
+++ b/src/mocks/handlers/signupHandler.ts
@@ -1,0 +1,216 @@
+import { delay, http, HttpResponse } from 'msw'
+
+import { toMswApiUrl } from '@/apis/apiPath'
+import { AUTH_ENDPOINTS } from '@/apis/auth'
+
+export const DUPLICATED_NICKNAMES = ['운동왕', '헬스마니아', 'test', 'admin']
+export const DUPLICATED_EMAILS = [
+  'test@example.com',
+  'admin@example.com',
+  'test@test.com',
+]
+const EMAIL_VERIFICATION_CODE = '123456'
+const EMAIL_TOKEN_EXPIRES_MS = 15 * 60 * 1000
+const emailTokenStore = new Map<
+  string,
+  {
+    email: string
+    expiresAt: number
+    used: boolean
+  }
+>()
+
+const createEmailToken = () => `mock-email-token-${crypto.randomUUID()}`
+const normalizeEmail = (email: string) => email.trim().toLowerCase()
+
+export const signupHandler = [
+  http.post(toMswApiUrl(AUTH_ENDPOINTS.signup), async ({ request }) => {
+    const { password, nickname, email_token } = (await request.json()) as {
+      password?: string
+      nickname?: string
+      email_token?: string
+    }
+
+    // 로딩 UI 확인용 지연입니다. 실제 API 연결 시 제거하거나 줄이면 됩니다.
+    await delay(1000)
+
+    const fieldErrors: Record<string, string[]> = {}
+
+    if (!password || password.length < 8) {
+      fieldErrors.password = ['비밀번호는 8자 이상이어야 합니다.']
+    }
+
+    if (!nickname) {
+      fieldErrors.nickname = ['닉네임을 입력해주세요']
+    }
+
+    const emailToken = email_token ? emailTokenStore.get(email_token) : null
+
+    // email_token은 인증번호 확인 성공 시 발급되는 1회성 토큰입니다.
+    if (!email_token || !emailToken) {
+      fieldErrors.email_token = ['이메일 인증을 완료해주세요.']
+    } else if (emailToken.used) {
+      fieldErrors.email_token = ['이미 사용된 이메일 인증입니다.']
+    } else if (Date.now() > emailToken.expiresAt) {
+      fieldErrors.email_token = ['이메일 인증 시간이 만료되었습니다.']
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      return HttpResponse.json({ error_detail: fieldErrors }, { status: 400 })
+    }
+
+    const conflictErrors: Record<string, string[]> = {}
+
+    // 이메일은 대소문자나 앞뒤 공백 차이로 중복 체크가 빠지지 않도록 정규화해서 비교합니다.
+    if (DUPLICATED_EMAILS.includes(normalizeEmail(emailToken!.email))) {
+      conflictErrors.email = ['이미 가입된 이메일입니다.']
+    }
+
+    if (DUPLICATED_NICKNAMES.includes(nickname!)) {
+      conflictErrors.nickname = ['이미 사용 중인 닉네임입니다.']
+    }
+
+    if (Object.keys(conflictErrors).length > 0) {
+      return HttpResponse.json(
+        {
+          error_detail: conflictErrors,
+        },
+        { status: 409 }
+      )
+    }
+
+    // 회원가입 성공 시 email_token을 사용 처리해 재사용을 막습니다.
+    emailToken!.used = true
+    DUPLICATED_NICKNAMES.push(nickname!)
+    DUPLICATED_EMAILS.push(normalizeEmail(emailToken!.email))
+
+    return HttpResponse.json(
+      {
+        detail: '회원가입이 완료되었습니다.',
+      },
+      { status: 201 }
+    )
+  }),
+
+  http.post(
+    toMswApiUrl(AUTH_ENDPOINTS.sendEmailVerification),
+    async ({ request }) => {
+      const { email } = (await request.json()) as { email?: string }
+      const normalizedEmail = email ? normalizeEmail(email) : ''
+
+      // 로딩 UI 확인용 지연입니다. 실제 API 연결 시 제거하거나 줄이면 됩니다.
+      await delay(1000)
+
+      if (!normalizedEmail) {
+        return HttpResponse.json(
+          {
+            error_detail: {
+              email: ['이 필드는 필수 항목입니다.'],
+            },
+          },
+          { status: 400 }
+        )
+      }
+
+      // 이미 가입된 이메일이면 인증번호를 보내지 않고 이메일 필드 에러를 내려줍니다.
+      if (DUPLICATED_EMAILS.includes(normalizedEmail)) {
+        return HttpResponse.json(
+          {
+            error_detail: {
+              email: ['이미 가입된 이메일입니다.'],
+            },
+          },
+          { status: 409 }
+        )
+      }
+
+      // MSW에서는 123456을 인증번호로 사용합니다.
+      return HttpResponse.json({
+        detail: '이메일 인증 코드가 전송되었습니다.',
+      })
+    }
+  ),
+
+  http.get(toMswApiUrl(AUTH_ENDPOINTS.verifyEmail), async ({ request }) => {
+    const { searchParams } = new URL(request.url)
+    const email = searchParams.get('email')?.trim()
+    const code = searchParams.get('code')?.trim()
+
+    // 로딩 UI 확인용 지연입니다. 실제 API 연결 시 제거하거나 줄이면 됩니다.
+    await delay(1000)
+
+    if (!email || !code) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            email: !email ? ['이 필드는 필수 항목입니다.'] : [],
+            code: !code ? ['이 필드는 필수 항목입니다.'] : [],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    if (code !== EMAIL_VERIFICATION_CODE) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            code: ['인증번호를 다시 확인해주세요.'],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    const emailToken = createEmailToken()
+
+    // 인증 성공 시 발급된 email_token은 이메일 정보를 품고 회원가입에서 1회만 사용할 수 있습니다.
+    emailTokenStore.set(emailToken, {
+      email: normalizeEmail(email),
+      expiresAt: Date.now() + EMAIL_TOKEN_EXPIRES_MS,
+      used: false,
+    })
+
+    return HttpResponse.json({
+      detail: '이메일 인증이 완료되었습니다.',
+      email_token: emailToken,
+    })
+  }),
+
+  http.get(toMswApiUrl(AUTH_ENDPOINTS.checkNickname), async ({ request }) => {
+    const { searchParams } = new URL(request.url)
+    const nickname = searchParams.get('nickname')?.trim()
+
+    // 로딩 UI 확인용 지연입니다. 실제 API 연결 시 제거하거나 줄이면 됩니다.
+    await delay(3000)
+
+    // 닉네임이 비어 있으면 실제 API 명세처럼 400 필드 에러를 내려줍니다.
+    if (!nickname) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            nickname: ['이 필드는 필수 항목입니다.'],
+          },
+        },
+        { status: 400 }
+      )
+    }
+
+    // 지금은 MSW 임시 데이터에 포함된 닉네임만 중복으로 처리합니다.
+    if (DUPLICATED_NICKNAMES.includes(nickname)) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            nickname: ['중복된 닉네임입니다.'],
+          },
+        },
+        { status: 409 }
+      )
+    }
+
+    // 중복 목록에 없으면 사용 가능한 닉네임으로 응답합니다.
+    return HttpResponse.json({
+      detail: '사용가능한 닉네임입니다.',
+    })
+  }),
+]

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -2,28 +2,22 @@ import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { Link } from 'react-router'
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import { LoaderCircle } from 'lucide-react'
 
-import { yellowCharacterImage } from '@/assets/images'
 import { Button } from '@/components/common/ui'
 import {
   AuthForm,
   AuthPageLayout,
   ProfileImageSelectField,
 } from '@/features/auth'
+import { useEmailVerification } from '@/features/auth/signup/hook/useEmailVerification'
+import { useNicknameCheck } from '@/features/auth/signup/hook/useNicknameCheck'
+import { useSignupMutation } from '@/query/auth'
 import {
   type SignupFormSchema,
   signupFormSchema,
 } from '@/schemas/auth/authForm.schema'
 import { cn } from '@/utils/cn'
-
-/*
- * TODO:
- * 1. 이메일 인증 요청 API 연결 (이메일 입력 후 '이메일확인' 버튼 클릭)
- * 2. 이메일 인증 코드 검증 → email_token은 form state가 아닌 API/auth 상태로 관리 검토
- * 3. 닉네임 중복확인 API 연결 ('중복확인' 버튼 클릭 시)
- * 4. TanStack Query로 mutation 분리 (emailVerify, nicknameCheck)
- * 5. 검증 성공 상태를 Zustand 등 별도 상태와 연동 (ex. emailToken, isEmailVerified, isNicknameChecked)
- */
 
 export function SignupPage() {
   const methods = useForm<SignupFormSchema>({
@@ -31,24 +25,47 @@ export function SignupPage() {
     resolver: zodResolver(signupFormSchema),
     defaultValues: {
       email: '',
+      code: '',
       nickname: '',
       password: '',
       passwordConfirm: '',
-      profile_image_url: yellowCharacterImage,
+      profile_image_url: '',
+      email_token: '',
     },
   })
 
   const {
     control,
     formState: { isValid, isDirty },
+    setError,
     setValue,
   } = methods
   const profileImageUrl = useWatch({ control, name: 'profile_image_url' })
 
   const SignupField = AuthForm.FormField<SignupFormSchema>
 
-  // API 연결 전 임시 제출 함수입니다. 회원가입 API가 붙으면 여기서 요청을 보냅니다.
-  const handleSignupSubmit = () => {}
+  const nicknameCheck = useNicknameCheck(methods)
+  const emailVerification = useEmailVerification(methods)
+  const signupMutation = useSignupMutation(setError)
+  const canSignup =
+    isDirty &&
+    isValid &&
+    nicknameCheck.isChecked &&
+    emailVerification.isVerified
+
+  const handleSignupSubmit = ({
+    email_token,
+    password,
+    nickname,
+    profile_image_url,
+  }: SignupFormSchema) => {
+    signupMutation.mutate({
+      password,
+      nickname,
+      profile_image_url,
+      email_token,
+    })
+  }
 
   return (
     <AuthPageLayout
@@ -64,27 +81,99 @@ export function SignupPage() {
             type="text"
             placeholder="닉네임을 입력해주세요"
           >
-            <Button>중복확인</Button>
-          </SignupField>
-
-          <SignupField control={control} name="email" label="이메일">
-            <Button type="button">이메일확인</Button>
+            <Button
+              className={cn(
+                'h-7 min-w-20 bg-transparent hover:text-white disabled:bg-transparent disabled:text-white',
+                nicknameCheck.isChecked && 'text-white'
+              )}
+              size={'sm'}
+              variant="outline"
+              disabled={nicknameCheck.isPending}
+              onClick={nicknameCheck.check}
+            >
+              {nicknameCheck.isPending ? (
+                <LoaderCircle size={14} className="animate-spin" />
+              ) : nicknameCheck.isChecked ? (
+                '사용가능'
+              ) : (
+                '중복확인'
+              )}
+            </Button>
           </SignupField>
 
           <SignupField
+            name="email"
+            label="이메일"
             control={control}
+            type="email"
+            placeholder="이메일을 입력해주세요"
+          >
+            <Button
+              className={cn(
+                'h-7 min-w-20 bg-transparent hover:text-white disabled:bg-transparent disabled:text-white',
+                emailVerification.isVerified && 'text-white'
+              )}
+              size={'sm'}
+              variant="outline"
+              disabled={emailVerification.isSending}
+              onClick={emailVerification.send}
+            >
+              {emailVerification.isSending ? (
+                <LoaderCircle size={14} className="animate-spin" />
+              ) : emailVerification.isVerified ? (
+                '인증완료'
+              ) : emailVerification.isSent ? (
+                '재전송'
+              ) : (
+                '인증'
+              )}
+            </Button>
+          </SignupField>
+
+          {emailVerification.isCodeFieldOpen ? (
+            <SignupField
+              name="code"
+              label="인증번호"
+              control={control}
+              type="text"
+              placeholder="인증번호를 입력해주세요"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-primary-500">
+                  {emailVerification.timerText}
+                </span>
+                <Button
+                  type="button"
+                  className="h-7 min-w-16 bg-transparent hover:text-white disabled:bg-transparent disabled:text-white"
+                  size={'sm'}
+                  variant="outline"
+                  disabled={emailVerification.isVerifying}
+                  onClick={emailVerification.verify}
+                >
+                  {emailVerification.isVerifying ? (
+                    <LoaderCircle size={14} className="animate-spin" />
+                  ) : (
+                    '확인'
+                  )}
+                </Button>
+              </div>
+            </SignupField>
+          ) : null}
+
+          <SignupField
             name="password"
             label="비밀번호"
+            control={control}
             type="password"
-            placeholder="비밀번호"
+            placeholder="비밀번호를 입력해주세요"
           />
 
           <SignupField
-            control={control}
             name="passwordConfirm"
             label="비밀번호 확인"
+            control={control}
             type="password"
-            placeholder="비밀번호 재입력"
+            placeholder="비밀번호 재입력해주세요"
           />
 
           <ProfileImageSelectField
@@ -99,19 +188,32 @@ export function SignupPage() {
 
           <div className="flex flex-col gap-3">
             <Button
+              variant={'neutral'}
               type="submit"
+              rounded={'lg'}
               className={cn(
-                'text-xl',
-                isValid ? 'bg-black hover:bg-[#121212]' : 'disabled:opacity-10'
+                'min-h-13 text-xl py-3 w-full',
+                signupMutation.isPending
+                  ? 'disabled:bg-black disabled:text-white'
+                  : canSignup
+                    ? 'bg-black hover:bg-[#121212]'
+                    : 'disabled:bg-black/30 disabled:text-white/20'
               )}
               size="lg"
-              disabled={!isDirty || !isValid}
+              disabled={!canSignup || signupMutation.isPending}
             >
-              회원가입
+              {signupMutation.isPending ? (
+                <LoaderCircle size={18} className="animate-spin" />
+              ) : (
+                '회원가입'
+              )}
             </Button>
-            <Link to="/login" className="text-center text-sm text-text-muted">
-              이미 계정이 있으신가요? 로그인
-            </Link>
+            <p className="flex justify-center items-center gap-3 mt-2 text-sm text-text-muted">
+              이미 계정이 있으신가요 ?
+              <Link to="/login" className="font-medium text-primary-600">
+                로그인
+              </Link>
+            </p>
           </div>
         </AuthForm>
       </FormProvider>

--- a/src/query/auth/index.ts
+++ b/src/query/auth/index.ts
@@ -1,0 +1,6 @@
+export { useCheckNicknameMutation } from './useCheckNicknameMutation'
+export {
+  useSendEmailVerificationMutation,
+  useVerifyEmailMutation,
+} from './useEmailVerificationMutations'
+export { useSignupMutation } from './useSignupMutation'

--- a/src/query/auth/useCheckNicknameMutation.ts
+++ b/src/query/auth/useCheckNicknameMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+import {
+  authApi,
+  type CheckNicknameRequest,
+  type CheckNicknameResponse,
+  type FieldErrorResponse,
+} from '@/apis/auth'
+
+export function useCheckNicknameMutation() {
+  // 중복확인 버튼 클릭처럼 사용자가 직접 실행하는 요청은 useMutation으로 처리합니다.
+  return useMutation<
+    CheckNicknameResponse,
+    AxiosError<FieldErrorResponse>,
+    CheckNicknameRequest
+  >({
+    mutationFn: authApi.checkNickname,
+  })
+}

--- a/src/query/auth/useEmailVerificationMutations.ts
+++ b/src/query/auth/useEmailVerificationMutations.ts
@@ -1,0 +1,33 @@
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+import {
+  authApi,
+  type FieldErrorResponse,
+  type SendEmailVerificationRequest,
+  type SendEmailVerificationResponse,
+  type VerifyEmailRequest,
+  type VerifyEmailResponse,
+} from '@/apis/auth'
+
+export function useSendEmailVerificationMutation() {
+  // 인증번호 발송은 사용자가 인증 버튼을 눌렀을 때만 실행합니다.
+  return useMutation<
+    SendEmailVerificationResponse,
+    AxiosError<FieldErrorResponse>,
+    SendEmailVerificationRequest
+  >({
+    mutationFn: authApi.sendEmailVerification,
+  })
+}
+
+export function useVerifyEmailMutation() {
+  // 인증번호 확인은 사용자가 확인 버튼을 눌렀을 때만 실행합니다.
+  return useMutation<
+    VerifyEmailResponse,
+    AxiosError<FieldErrorResponse>,
+    VerifyEmailRequest
+  >({
+    mutationFn: authApi.verifyEmail,
+  })
+}

--- a/src/query/auth/useSignupMutation.ts
+++ b/src/query/auth/useSignupMutation.ts
@@ -1,0 +1,65 @@
+import type { UseFormSetError } from 'react-hook-form'
+import { useNavigate } from 'react-router'
+
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+import {
+  authApi,
+  type FieldErrorResponse,
+  type SignupRequest,
+  type SignupResponse,
+} from '@/apis/auth'
+import { useToast } from '@/components/common/ui'
+import type { SignupFormSchema } from '@/schemas/auth/authForm.schema'
+
+export function useSignupMutation(setError: UseFormSetError<SignupFormSchema>) {
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  // 회원가입 제출은 사용자가 회원가입 버튼을 눌렀을 때만 실행합니다.
+  return useMutation<
+    SignupResponse,
+    AxiosError<FieldErrorResponse>,
+    SignupRequest
+  >({
+    mutationFn: authApi.signup,
+    onSuccess: (data) => {
+      // 회원가입 API가 성공하면 전역 토스트를 띄우고 로그인 페이지로 이동합니다.
+      toast.success(data.detail)
+      navigate('/login')
+    },
+    onError: (error) => {
+      const errorDetail = error.response?.data?.error_detail
+
+      // 서버에서 내려준 회원가입 필드 에러를 폼 에러로 연결합니다.
+      if (errorDetail?.email?.[0]) {
+        setError('email', {
+          type: 'server',
+          message: errorDetail.email[0],
+        })
+      }
+
+      if (errorDetail?.nickname?.[0]) {
+        setError('nickname', {
+          type: 'server',
+          message: errorDetail.nickname[0],
+        })
+      }
+
+      if (errorDetail?.email_token?.[0]) {
+        setError('code', {
+          type: 'server',
+          message: errorDetail.email_token[0],
+        })
+      }
+
+      if (!errorDetail) {
+        setError('nickname', {
+          type: 'server',
+          message: '회원가입에 실패했습니다.',
+        })
+      }
+    },
+  })
+}

--- a/src/schemas/auth/authForm.schema.ts
+++ b/src/schemas/auth/authForm.schema.ts
@@ -3,10 +3,11 @@ import * as z from 'zod'
 const email = z.email('이메일 형식이 올바르지 않습니다.')
 const loginPassword = z.string().min(1, '비밀번호를 입력해주세요')
 const signupPassword = z.string().min(8, '비밀번호는 8자 이상이어야 합니다.')
-const nickname = z.string().min(1, '닉네임을 입력해주세요')
-const profileImageUrl = z.string().optional()
+const nickname = z.string().trim().min(1, '닉네임을 입력해주세요')
+const profileImageUrl = z.string().min(1, '프로필 캐릭터를 선택해주세요')
 const code = z.string().min(1, '인증번호를 입력해주세요')
 const passwordConfirm = z.string().min(1, '비밀번호 확인을 입력해주세요')
+const emailToken = z.string()
 
 export const loginFormSchema = z.object({
   email,
@@ -21,10 +22,16 @@ export const signupFormSchema = z
     passwordConfirm,
     nickname,
     profile_image_url: profileImageUrl,
+    email_token: emailToken,
   })
-  .refine((data) => data.password === data.passwordConfirm, {
-    path: ['passwordConfirm'],
-    message: '비밀번호가 일치하지 않습니다',
+  .superRefine((data, ctx) => {
+    if (data.password !== data.passwordConfirm) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['passwordConfirm'],
+        message: '비밀번호가 일치하지 않습니다',
+      })
+    }
   })
 
 export type LoginFormSchema = z.infer<typeof loginFormSchema>


### PR DESCRIPTION
## 📌 관련 이슈

Closes #93

## ✨ 변경 내용

 - 회원가입 API, Query mutation, MSW mock을 연결
 - 닉네임 중복확인과 이메일 인증 플로우를 회원가입 화면에 적용
 - 회원가입 성공 시 토스트 표시 후 로그인 페이지로 이동하도록 처리
 - 프로필 캐릭터 선택 UI와 버튼 로딩/비활성 상태를 정리

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/5fecc05d-e134-4dcd-acec-fcc47f22b497


## 📚 참고사항
