### PR TITLE
feat: post create/edit msw

### DIFF
--- a/src/apis/post/endpoints.ts
+++ b/src/apis/post/endpoints.ts
@@ -1,0 +1,6 @@
+export const POST_ENDPOINTS = {
+  goals: '/goals',
+  tags: '/tags',
+  posts: '/posts',
+  post: (postId: number | string) => `/posts/${postId}`,
+} as const

--- a/src/apis/post/index.ts
+++ b/src/apis/post/index.ts
@@ -1,0 +1,2 @@
+export { POST_ENDPOINTS } from './endpoints'
+export { postApi } from './post.api'

--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -1,0 +1,26 @@
+import { apiClient } from '@/apis/apiClient'
+import type {
+  ApiGoalResponse,
+  ApiPostCreateRequest,
+  ApiPostCreateResponse,
+  ApiPostResponse,
+  ApiPostUpdateRequest,
+  ApiTagResponse,
+} from '@/features/post/post.api.types'
+
+import { POST_ENDPOINTS } from './endpoints'
+
+export const postApi = {
+  getGoals: () => apiClient.get<ApiGoalResponse[]>(POST_ENDPOINTS.goals),
+
+  getTags: () => apiClient.get<ApiTagResponse[]>(POST_ENDPOINTS.tags),
+
+  getPost: (postId: number) =>
+    apiClient.get<ApiPostResponse>(POST_ENDPOINTS.post(postId)),
+
+  createPost: (body: ApiPostCreateRequest) =>
+    apiClient.post<ApiPostCreateResponse>(POST_ENDPOINTS.posts, body),
+
+  updatePost: (postId: number, body: ApiPostUpdateRequest) =>
+    apiClient.patch<void>(POST_ENDPOINTS.post(postId), body),
+} as const

--- a/src/components/common/ui/calendar/useCalendar.ts
+++ b/src/components/common/ui/calendar/useCalendar.ts
@@ -49,7 +49,7 @@ export function useCalendar({
   const [currentDate, setCurrentDate] = useState<Date>(
     selectedDate.start ?? new Date()
   )
-  const [isOpen, setIsOpen] = useState(true)
+  const [isOpen, setIsOpen] = useState(false)
   const [viewMode, setViewMode] = useState<CalendarViewMode>('day')
 
   // minDate가 없으면 오늘 이전 날짜를 선택하지 못하게 막음

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -83,17 +83,19 @@ export function VoteEditor({
           })}
         </div>
 
-        <div className="mt-8 flex justify-center">
-          <Button
-            type="button"
-            variant="primary"
-            onClick={onSubmit}
-            disabled={isSubmitDisabled}
-            className="h-10 w-full max-w-md"
-          >
-            {submitLabel}
-          </Button>
-        </div>
+        {onSubmit && (
+          <div className="mt-8 flex justify-center">
+            <Button
+              type="button"
+              variant="primary"
+              onClick={onSubmit}
+              disabled={isSubmitDisabled}
+              className="h-10 w-full max-w-md"
+            >
+              {submitLabel}
+            </Button>
+          </div>
+        )}
       </section>
 
       <div className="mt-4 flex items-center gap-2 text-sm text-text-muted">

--- a/src/features/post/components/PostFormLayout.tsx
+++ b/src/features/post/components/PostFormLayout.tsx
@@ -8,10 +8,12 @@ import { cn } from '@/utils/cn'
 import { usePostForm } from '../hooks/usePostForm'
 import { MAX_CONTENT, MAX_IMAGES, MAX_TITLE } from '../post.constants'
 import type { PostFormData, PostFormMode } from '../post.types'
-import { PostGoalSection } from './PostGoalSection'
-import { PostTagSection } from './PostTagSection'
-import { PostVoteSection } from './PostVoteSection'
-import { SectionLabel } from './SectionLabel'
+import {
+  PostGoalSection,
+  PostTagSection,
+  PostVoteSection,
+  SectionLabel,
+} from '.'
 
 type PostFormLayoutProps = {
   mode: PostFormMode
@@ -48,60 +50,23 @@ export function PostFormLayout({
     form.addImages(files)
   }
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (form.isSubmitDisabled || isPending) return
+  function handleSubmit() {
     onSubmit(form.buildFormData())
   }
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-6 p-6">
-      {/* 제목 */}
-      <div className="flex flex-col gap-2">
-        <SectionLabel label="제목" required />
-        <Input
-          placeholder="제목을 입력하세요"
-          value={form.title}
-          onChange={(e) => form.changeTitle(e.target.value)}
-        />
-        <p
-          className={cn(
-            'self-end text-xs',
-            form.titleLen >= MAX_TITLE
-              ? 'text-status-error-text'
-              : 'text-text-muted'
-          )}
-        >
-          {form.titleLen}/{MAX_TITLE}
-        </p>
-      </div>
-
-      {/* 이미지 업로드 (hidden input) */}
-      <input
-        ref={imageInputRef}
-        type="file"
-        accept="image/*"
-        multiple
-        className="hidden"
-        onChange={handleImageSelect}
-      />
-
       {/* 이미지 업로드 */}
       <div className="flex flex-col gap-2">
         <SectionLabel label="이미지 선택" />
         <div
           role="button"
-          tabIndex={0}
           aria-label={`이미지 업로드 (최대 ${MAX_IMAGES}장)`}
           onClick={() => form.canAddImage && imageInputRef.current?.click()}
-          onKeyDown={(e) =>
-            (e.key === 'Enter' || e.key === ' ') &&
-            imageInputRef.current?.click()
-          }
           onDrop={handleDrop}
           onDragOver={(e) => {
             e.preventDefault()
-            setIsDragging(true)
+            if (form.canAddImage) setIsDragging(true)
           }}
           onDragLeave={() => setIsDragging(false)}
           className={cn(
@@ -113,7 +78,7 @@ export function PostFormLayout({
               'cursor-pointer hover:border-focus-border hover:bg-gray-100 dark:hover:bg-gray-750'
           )}
         >
-          {form.images.length === 0 ? (
+          {form.imageItems.length === 0 ? (
             <div className="flex flex-1 flex-col items-center justify-center gap-2 text-text-muted">
               <ImagePlus className="size-8" />
               <span className="text-sm">
@@ -126,10 +91,13 @@ export function PostFormLayout({
           ) : (
             <div className="flex flex-col gap-3">
               <div className="flex flex-wrap gap-3">
-                {form.images.map((src, i) => (
-                  <div key={i} className="relative size-32 shrink-0">
+                {form.imageItems.map((item, i) => (
+                  <div
+                    key={item.previewUrl}
+                    className="relative size-32 shrink-0"
+                  >
                     <img
-                      src={src}
+                      src={item.previewUrl}
                       alt={`첨부한 이미지 ${i + 1} 번째`}
                       className="size-full rounded-xl object-cover"
                     />
@@ -148,13 +116,42 @@ export function PostFormLayout({
               </div>
               {form.canAddImage && (
                 <p className="text-text-muted">
-                  {form.images.length}/{MAX_IMAGES}장 · 클릭하거나 드래그하여
-                  추가
+                  {form.imageItems.length}/{MAX_IMAGES}장
                 </p>
               )}
             </div>
           )}
         </div>
+      </div>
+
+      {/* 이미지 업로드 실제 input (hidden) */}
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        onChange={handleImageSelect}
+      />
+
+      {/* 제목 */}
+      <div className="flex flex-col gap-2">
+        <SectionLabel label="제목" required />
+        <Input
+          placeholder="제목을 입력하세요"
+          value={form.title}
+          onChange={(e) => form.changeTitle(e.target.value)}
+        />
+        <p
+          className={cn(
+            'self-end text-xs',
+            form.titleLen >= MAX_TITLE
+              ? 'text-status-error-text'
+              : 'text-text-muted'
+          )}
+        >
+          {form.titleLen}/{MAX_TITLE}
+        </p>
       </div>
 
       {/* 내용 */}
@@ -179,31 +176,32 @@ export function PostFormLayout({
       </div>
 
       {/* 태그 선택 */}
-      <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2 min-h-8">
         <SectionLabel label="태그 선택" />
         <PostTagSection
           selectedTagIds={form.selectedTagIds}
           onToggle={form.toggleTag}
+          defaultTagNames={defaultValues?.tagNames}
+          onInitialize={form.initializeTags}
         />
       </div>
 
       {/* 투표 생성 */}
-      <PostVoteSection
-        mode={mode}
-        question={form.voteQuestion}
-        options={form.voteOptions}
-        period={form.votePeriod}
-        onChangeQuestion={form.changeVoteQuestion}
-        onChangeOption={form.changeVoteOption}
-        onChangePeriod={form.changeVotePeriod}
-        onConfirm={form.confirmVote}
-      />
+      <div className="flex flex-col gap-3">
+        <SectionLabel label="투표 관리" />
+        <PostVoteSection
+          mode={mode}
+          options={form.voteOptions}
+          period={form.votePeriod}
+          onChangeOption={form.changeVoteOption}
+          onChangePeriod={form.changeVotePeriod}
+        />
+      </div>
 
       {/* 목표 선택 */}
       <div className="flex flex-col gap-3">
         <SectionLabel label="목표 선택" />
         <PostGoalSection
-          mode={mode}
           selectedGoalId={form.selectedGoalId}
           onChange={form.changeGoal}
         />

--- a/src/features/post/components/PostFormSkeleton.tsx
+++ b/src/features/post/components/PostFormSkeleton.tsx
@@ -1,0 +1,65 @@
+function SkeletonBox({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 ${className ?? ''}`}
+    />
+  )
+}
+
+export function PostFormSkeleton() {
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      {/* 이미지 선택 */}
+      <div className="flex flex-col gap-2">
+        <SkeletonBox className="h-5 w-24" />
+        <SkeletonBox className="h-40 w-full rounded-2xl" />
+      </div>
+
+      {/* 제목 */}
+      <div className="flex flex-col gap-2">
+        <SkeletonBox className="h-5 w-16" />
+        <SkeletonBox className="h-13.5 w-full rounded-xl" />
+        <SkeletonBox className="h-4 w-12 self-end" />
+      </div>
+
+      {/* 내용 */}
+      <div className="flex flex-col gap-2">
+        <SkeletonBox className="h-5 w-12" />
+        <SkeletonBox className="h-58 w-full rounded-xl" />
+        <SkeletonBox className="h-4 w-12 self-end" />
+      </div>
+
+      {/* 태그 선택 */}
+      <div className="flex flex-wrap items-center gap-2">
+        <SkeletonBox className="h-5 w-20" />
+        {Array.from({ length: 5 }).map((_, i) => (
+          <SkeletonBox
+            key={i}
+            className={`h-8 rounded-full ${i % 2 === 0 ? 'w-16' : 'w-20'}`}
+          />
+        ))}
+      </div>
+
+      {/* 투표 생성 */}
+      <div className="flex flex-col gap-3">
+        <SkeletonBox className="h-5 w-20" />
+        <div className="rounded-2xl border border-border-default p-4">
+          <SkeletonBox className="h-62.5 w-full rounded-xl" />
+        </div>
+      </div>
+
+      {/* 목표 선택 */}
+      <div className="flex flex-col gap-3">
+        <SkeletonBox className="h-5 w-20" />
+        <SkeletonBox className="h-19 w-full rounded-2xl" />
+      </div>
+
+      {/* 버튼 */}
+      <div className="flex justify-end gap-2 pt-2">
+        <SkeletonBox className="h-8 w-14 rounded-md" />
+        <SkeletonBox className="h-8 w-24 rounded-md" />
+      </div>
+    </div>
+  )
+}

--- a/src/features/post/components/PostFormSkeleton.tsx
+++ b/src/features/post/components/PostFormSkeleton.tsx
@@ -1,8 +1,13 @@
-function SkeletonBox({ className }: { className?: string }) {
+import { cn } from '@/utils/cn'
+
+export function SkeletonBox({ className }: { className?: string }) {
   return (
     <div
       aria-hidden="true"
-      className={`animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 ${className ?? ''}`}
+      className={cn(
+        'animate-pulse rounded-md bg-gray-200 dark:bg-gray-700',
+        className
+      )}
     />
   )
 }

--- a/src/features/post/components/PostGoalSection.tsx
+++ b/src/features/post/components/PostGoalSection.tsx
@@ -1,69 +1,44 @@
+import { useEffect } from 'react'
+
 import { Dropdown } from '@/components/common/overlay'
+import { useToast } from '@/components/common/ui'
 import { DonutChart } from '@/components/common/ui/chart/DonutChart'
-
-import type { GoalOption, PostFormMode } from '../post.types'
-
-// TODO: 레이아웃 테스트용 mock 데이터 -> MSW 연동 필요
-// 실제 데이터는 GET lazy fetch 예정
-const MOCK_GOALS: GoalOption[] = [
-  {
-    id: 1,
-    title: '매일 1시간 운동',
-    startDate: '2026.04.01',
-    endDate: '2026.06.30',
-    progressRate: 48,
-    status: 'IN_PROGRESS',
-  },
-  {
-    id: 2,
-    title: '매일 독서 30분',
-    startDate: '2026.04.01',
-    endDate: '2026.04.30',
-    progressRate: 70,
-    status: 'IN_PROGRESS',
-  },
-  {
-    id: 3,
-    title: '코딩 스터디',
-    startDate: '2026.03.01',
-    endDate: '2026.05.31',
-    progressRate: 30,
-    status: 'IN_PROGRESS',
-  },
-]
+import { useGoalsQuery } from '@/query/post'
 
 type PostGoalSectionProps = {
-  mode: PostFormMode
   selectedGoalId?: number
   onChange: (goalId: number | undefined) => void
 }
 
 export function PostGoalSection({
-  mode,
   selectedGoalId,
   onChange,
 }: PostGoalSectionProps) {
-  // TODO: API 연동 시 MOCK_GOALS를 useQuery 또는 fetch 결과로 교체
-  // GET /api/v1/goals?status=IN_PROGRESS
-  const goals = MOCK_GOALS
+  const toast = useToast()
+  const { data: goals = [], isError } = useGoalsQuery()
 
-  const selectedGoal = goals.find((g) => g.id === selectedGoalId)
-  const placeholder =
-    mode === 'create'
-      ? '목표를 선택해주세요.'
-      : '해당되는 항목을 선택해 주세요.'
+  useEffect(() => {
+    if (isError) toast.error('목표 목록을 불러오지 못했습니다.')
+  }, [isError, toast])
+
+  const selectedGoal = goals.find((g) => g.goalId === selectedGoalId)
 
   return (
     <div className="flex flex-col gap-4 rounded-2xl border border-border-default bg-surface p-4">
       <Dropdown
-        options={goals.map((g) => ({ value: String(g.id), label: g.title }))}
+        options={goals.map((goal) => ({
+          value: String(goal.goalId),
+          label: goal.title,
+        }))}
         value={
           selectedGoalId !== undefined ? String(selectedGoalId) : undefined
         }
-        onChange={(val) =>
-          onChange(val !== undefined ? Number(val) : undefined)
-        }
-        placeholder={placeholder}
+        onChange={(val) => {
+          if (val === undefined) return onChange(undefined)
+          const id = Number(val)
+          onChange(Number.isNaN(id) ? undefined : id)
+        }}
+        placeholder="목표를 선택해주세요."
       />
 
       {selectedGoal && (

--- a/src/features/post/components/PostGoalSection.tsx
+++ b/src/features/post/components/PostGoalSection.tsx
@@ -1,9 +1,16 @@
-import { useEffect } from 'react'
+import { lazy, Suspense, useEffect } from 'react'
 
 import { Dropdown } from '@/components/common/overlay'
 import { useToast } from '@/components/common/ui'
-import { DonutChart } from '@/components/common/ui/chart/DonutChart'
 import { useGoalsQuery } from '@/query/post'
+
+import { SkeletonBox } from './PostFormSkeleton'
+
+const DonutChart = lazy(() =>
+  import('@/components/common/ui/chart/DonutChart').then((m) => ({
+    default: m.DonutChart,
+  }))
+)
 
 type PostGoalSectionProps = {
   selectedGoalId?: number
@@ -53,10 +60,14 @@ export function PostGoalSection({
           </div>
 
           <div className="flex justify-center">
-            <DonutChart
-              progressRate={selectedGoal.progressRate}
-              status="progress"
-            />
+            <Suspense
+              fallback={<SkeletonBox className="h-35 w-35 rounded-full" />}
+            >
+              <DonutChart
+                progressRate={selectedGoal.progressRate}
+                status="progress"
+              />
+            </Suspense>
           </div>
         </div>
       )}

--- a/src/features/post/components/PostTagSection.tsx
+++ b/src/features/post/components/PostTagSection.tsx
@@ -1,32 +1,41 @@
-import { Button } from '@/components/common/ui'
+import { useEffect } from 'react'
+
+import { Button, useToast } from '@/components/common/ui'
+import { useTagsQuery } from '@/query/post'
 import { cn } from '@/utils/cn'
 
 import { MAX_TAGS } from '../post.constants'
-import type { TagOption } from '../post.types'
-
-// TODO: 레이아웃 테스트용 mock 데이터 — API 연동 시 제거
-// 실제 데이터는 GET /api/v1/tags 로 fetch
-const MOCK_TAGS: TagOption[] = [
-  { id: 1, name: '운동' },
-  { id: 2, name: '독서' },
-  { id: 3, name: '공부' },
-  { id: 4, name: '식단' },
-  { id: 5, name: '취미' },
-  { id: 6, name: '자기계발' },
-]
 
 type PostTagSectionProps = {
   selectedTagIds: number[]
   onToggle: (id: number) => void
+  defaultTagNames?: string[]
+  onInitialize?: (ids: number[]) => void
 }
 
 export function PostTagSection({
   selectedTagIds,
   onToggle,
+  defaultTagNames,
+  onInitialize,
 }: PostTagSectionProps) {
-  // TODO: API 연동 시 MOCK_TAGS를 useQuery 또는 fetch 결과로 교체
-  // GET /api/v1/tags
-  const tags = MOCK_TAGS
+  const toast = useToast()
+  const { data: tags = [], isError } = useTagsQuery()
+
+  useEffect(() => {
+    if (isError) toast.error('태그 목록을 불러오지 못했습니다.')
+  }, [isError, toast])
+
+  useEffect(() => {
+    if (!onInitialize || !defaultTagNames?.length || !tags.length) return
+
+    const ids = defaultTagNames
+      .map((name) => tags.find((t) => t.name === name)?.id)
+      .filter((id): id is number => id !== undefined)
+
+    onInitialize(ids)
+  }, [tags, defaultTagNames, onInitialize])
+
   const isMaxReached = selectedTagIds.length >= MAX_TAGS
 
   return (

--- a/src/features/post/components/PostVoteSection.tsx
+++ b/src/features/post/components/PostVoteSection.tsx
@@ -1,51 +1,31 @@
-import type { VoteEditorMode } from '@/components/common/ui'
-import { Input, VoteEditor } from '@/components/common/ui'
+import { VoteEditor } from '@/components/common/ui'
 import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
 
 import type { PostFormMode } from '../post.types'
-import { SectionLabel } from './SectionLabel'
 
 type PostVoteSectionProps = {
   mode: PostFormMode
-  question: string
   options: string[]
   period?: DateRange
-  onChangeQuestion: (question: string) => void
   onChangeOption: (index: number, value: string) => void
   onChangePeriod: (date: DateRange | null) => void
-  onConfirm: () => void
 }
 
 export function PostVoteSection({
   mode,
-  question,
   options,
   period,
-  onChangeQuestion,
   onChangeOption,
   onChangePeriod,
-  onConfirm,
 }: PostVoteSectionProps) {
-  // 일단 생성 페이지에서 투표 생성 , 수정 페이지에선 투표 수정 한다는 가정
-  const voteEditorMode = mode as VoteEditorMode
-
   return (
     <div className="flex flex-col gap-3 rounded-2xl border border-border-default bg-surface p-4">
-      <SectionLabel label="투표 생성" />
-
-      <Input
-        placeholder="투표 제목을 입력하세요"
-        value={question}
-        onChange={(e) => onChangeQuestion(e.target.value)}
-      />
-
       <VoteEditor
-        mode={voteEditorMode}
+        mode={mode}
         options={options}
         period={period}
         onChangeOption={onChangeOption}
         onChangePeriod={onChangePeriod}
-        onSubmit={onConfirm}
       />
     </div>
   )

--- a/src/features/post/components/index.ts
+++ b/src/features/post/components/index.ts
@@ -1,0 +1,6 @@
+export { PostFormLayout } from './PostFormLayout'
+export { PostFormSkeleton } from './PostFormSkeleton'
+export { PostGoalSection } from './PostGoalSection'
+export { PostTagSection } from './PostTagSection'
+export { PostVoteSection } from './PostVoteSection'
+export { SectionLabel } from './SectionLabel'

--- a/src/features/post/hooks/usePostForm.ts
+++ b/src/features/post/hooks/usePostForm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
 
@@ -8,9 +8,8 @@ import {
   MAX_TAGS,
   MAX_TITLE,
   MAX_VOTE_OPTION,
-  MAX_VOTE_QUESTION,
 } from '../post.constants'
-import type { PostFormData, PostFormMode } from '../post.types'
+import type { PostFormData, PostFormMode, PostImageItem } from '../post.types'
 
 function charLen(str: string) {
   return Array.from(str).length
@@ -23,25 +22,40 @@ export function usePostForm(
   // 기본 필드
   const [title, setTitle] = useState(defaultValues?.title ?? '')
   const [content, setContent] = useState(defaultValues?.content ?? '')
-  const [images, setImages] = useState<string[]>(defaultValues?.images ?? [])
 
-  // 태그
-  const [selectedTagIds, setSelectedTagIds] = useState<number[]>(
-    defaultValues?.tagIds ?? []
+  // 이미지: 서버 이미지는 file 없이 previewUrl만 보유
+  const [imageItems, setImageItems] = useState<PostImageItem[]>(
+    (defaultValues?.images ?? []).map((url) => ({ previewUrl: url }))
   )
+  // 언마운트 시 revoke할 blob URL 추적
+  const blobUrlsRef = useRef<string[]>([])
+
+  useEffect(() => {
+    return () => {
+      blobUrlsRef.current.forEach((url) => URL.revokeObjectURL(url))
+    }
+  }, [])
+
+  // 태그 — 초기 선택은 PostTagSection이 tagNames를 보고 initializeTags로 설정
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([])
+  const tagInitializedRef = useRef(false)
+
+  function initializeTags(ids: number[]) {
+    if (tagInitializedRef.current) return
+    tagInitializedRef.current = true
+    setSelectedTagIds(ids)
+  }
 
   // 투표
-  const [voteQuestion, setVoteQuestion] = useState(
-    defaultValues?.vote?.question ?? ''
-  )
   const [voteOptions, setVoteOptions] = useState<string[]>(
     defaultValues?.vote?.options.map((o) => o.content) ?? ['', '']
   )
-  const [votePeriod, setVotePeriod] = useState<DateRange | undefined>()
-  const [voteConfirmed, setVoteConfirmed] = useState(
-    mode === 'edit' && !!defaultValues?.vote
-  )
-
+  const [votePeriod, setVotePeriod] = useState<DateRange | undefined>(() => {
+    if (mode !== 'edit' || !defaultValues?.vote) return undefined
+    const { startDate, endDate } = defaultValues.vote
+    if (!startDate || !endDate) return undefined
+    return { start: new Date(startDate), end: new Date(endDate) }
+  })
   // 목표
   const [selectedGoalId, setSelectedGoalId] = useState<number | undefined>(
     mode === 'edit' ? defaultValues?.goalId : undefined
@@ -54,7 +68,7 @@ export function usePostForm(
   const titleLen = charLen(title)
   const contentLen = charLen(content)
   const isSubmitDisabled = title.trim() === '' || content.trim() === ''
-  const canAddImage = images.length < MAX_IMAGES
+  const canAddImage = imageItems.length < MAX_IMAGES
 
   // 제목 / 내용
   function changeTitle(val: string) {
@@ -67,18 +81,24 @@ export function usePostForm(
 
   // 이미지
   function addImages(files: File[]) {
-    const remaining = MAX_IMAGES - images.length
-    const urls = files.slice(0, remaining).map(URL.createObjectURL)
-    setImages((prev) => [...prev, ...urls])
+    const remaining = MAX_IMAGES - imageItems.length
+    const newItems = files.slice(0, remaining).map((file) => {
+      const previewUrl = URL.createObjectURL(file)
+      blobUrlsRef.current.push(previewUrl)
+      return { file, previewUrl }
+    })
+    setImageItems((prev) => [...prev, ...newItems])
   }
 
   function removeImage(index: number) {
-    setImages((prev) => {
-      const url = prev[index]
-      // blob URL인 경우에만 revoke (서버 URL은 no-op 방지)
-      if (url.startsWith('blob:')) URL.revokeObjectURL(url)
-      return prev.filter((_, i) => i !== index)
-    })
+    const item = imageItems[index]
+    if (item?.file) {
+      URL.revokeObjectURL(item.previewUrl)
+      blobUrlsRef.current = blobUrlsRef.current.filter(
+        (u) => u !== item.previewUrl
+      )
+    }
+    setImageItems((prev) => prev.filter((_, i) => i !== index))
   }
 
   // 태그
@@ -91,74 +111,64 @@ export function usePostForm(
   }
 
   // 투표
-  function changeVoteQuestion(question: string) {
-    if (charLen(question) <= MAX_VOTE_QUESTION) {
-      setVoteQuestion(question)
-      setVoteConfirmed(false)
-    }
-  }
-
   function changeVoteOption(index: number, value: string) {
     if (charLen(value) <= MAX_VOTE_OPTION) {
       setVoteOptions((prev) => prev.map((o, i) => (i === index ? value : o)))
-      setVoteConfirmed(false)
     }
   }
 
   function changeVotePeriod(date: DateRange | null) {
     setVotePeriod(date ?? undefined)
-    setVoteConfirmed(false)
-  }
-
-  function confirmVote() {
-    setVoteConfirmed(true)
-  }
-
-  // 목표
-  function changeGoal(goalId: number | undefined) {
-    setSelectedGoalId(goalId)
   }
 
   // 최종 payload 빌드
+  // images: 서버 URL(이미 업로드됨)만 포함. 새 파일은 S3 업로드 후 URL이 확정되면 추가
   function buildFormData(): PostFormData {
-    const base: Omit<PostFormData, 'postId' | 'vote'> = {
+    const uploadedImages = imageItems
+      .filter((item) => !item.file)
+      .map((item) => item.previewUrl)
+
+    const hasActiveVote =
+      Boolean(votePeriod?.start && votePeriod?.end) &&
+      voteOptions.filter((opt) => opt.trim() !== '').length >= 2
+
+    const vote: PostFormData['vote'] = hasActiveVote
+      ? {
+          options: voteOptions
+            .filter((c) => c.trim() !== '')
+            .map((c, i) => ({ content: c.trim(), sortOrder: i + 1 })),
+          startDate: votePeriod?.start?.toISOString().split('T')[0],
+          endDate: votePeriod?.end?.toISOString().split('T')[0],
+        }
+      : undefined
+
+    const base: Omit<PostFormData, 'postId'> = {
       title: title.trim(),
       content: content.trim(),
-      images,
+      images: uploadedImages,
       hasGoal: selectedGoalId !== undefined,
       goalId: selectedGoalId,
-      hasVote: voteConfirmed,
+      hasVote: hasActiveVote,
+      vote,
       tagIds: selectedTagIds,
     }
 
     if (mode === 'edit') {
-      // edit 모드에서 postId가 없는 것은 프로그래밍 오류
       if (postId === undefined) {
         throw new Error('[usePostForm] edit 모드에서 postId는 필수입니다.')
       }
-      // PATCH 스펙: vote 필드 미포함. API 변환(post_id 등)은 호출부(Page)에서 처리
       return { postId, ...base }
     }
 
-    // POST 스펙: vote 포함
-    return {
-      ...base,
-      vote: voteConfirmed
-        ? {
-            question: voteQuestion,
-            options: voteOptions.map((c, i) => ({ content: c, sortOrder: i })),
-          }
-        : undefined,
-    }
+    return base
   }
 
   return {
     // state
     title,
     content,
-    images,
+    imageItems,
     selectedTagIds,
-    voteQuestion,
     voteOptions,
     votePeriod,
     selectedGoalId,
@@ -172,12 +182,11 @@ export function usePostForm(
     changeContent,
     addImages,
     removeImage,
+    initializeTags,
     toggleTag,
-    changeVoteQuestion,
     changeVoteOption,
     changeVotePeriod,
-    confirmVote,
-    changeGoal,
+    changeGoal: setSelectedGoalId,
     buildFormData,
   }
 }

--- a/src/features/post/index.ts
+++ b/src/features/post/index.ts
@@ -1,4 +1,4 @@
-export { PostFormLayout } from './components/PostFormLayout'
+export * from './components'
 
 // 프론트 전용 타입
 export type {
@@ -6,6 +6,7 @@ export type {
   GoalStatus,
   PostFormData,
   PostFormMode,
+  PostImageItem,
   TagOption,
   VoteFormData,
   VoteOptionFormData,
@@ -15,6 +16,8 @@ export type {
 export type {
   ApiGoalResponse,
   ApiPostCreateRequest,
+  ApiPostCreateResponse,
+  ApiPostResponse,
   ApiPostUpdateRequest,
   ApiTagResponse,
 } from './post.api.types'
@@ -24,4 +27,5 @@ export {
   toApiCreateRequest,
   toApiUpdateRequest,
   toGoalOption,
+  toPostFormData,
 } from './post.mappers'

--- a/src/features/post/post.api.types.ts
+++ b/src/features/post/post.api.types.ts
@@ -1,5 +1,8 @@
 import type { GoalStatus } from './post.types'
 
+// 현재 API 명세서 기준 snake_case와 camelCase가 혼용되어 있어 타입이 다소 복잡합니다.
+// 추후 API 명세가 바뀌면 바뀌는 타입에 맞춰 수정해야합니다.
+
 // GET /api/v1/goals 응답
 export type ApiGoalResponse = {
   goal_id: number
@@ -18,53 +21,74 @@ export type ApiTagResponse = {
   name: string
 }
 
+export type VoteContent = {
+  options: Array<{ content: string; sort_order: number }>
+  start_date?: string
+  end_date?: string
+}
+
 // POST /api/v1/posts 요청
 export type ApiPostCreateRequest = {
   title: string
   content: string
-  images: string[]
-  hasGoal: boolean
-  goalId?: number
-  hasVote: boolean
-  vote?: {
-    question: string
-    options: Array<{ content: string; sortOrder: number }>
-  }
-  tagIds: number[]
+  images?: string[]
+  has_goal: boolean
+  goal_id?: number
+  has_vote: boolean
+  vote?: VoteContent
+  tag_ids?: number[]
 }
 
-// POST /api/v1/posts/votes 요청
-// TODO: 백엔드 엔드포인트 확정 후 타입 추가
-// 투표는 게시글 생성 전에 먼저 독립적으로 생성됨 (post_id 없이 요청)
-// 요청 body 예시: { question, options: string[], start_at: datetime, end_at: datetime }
-// export type ApiVoteCreateRequest = {
-//   question: string
-//   options: string[]
-//   start_at: string  // ISO datetime
-//   end_at: string    // ISO datetime
-// }
+// POST /api/v1/posts 응답
+export type ApiPostCreateResponse = {
+  detail: string
+  post_id: number
+}
 
-// POST /api/v1/posts/votes 응답
-// TODO: 백엔드 응답 확정 후 타입 추가
-// 생성된 vote_id와 options를 게시글 생성 요청(vote 필드)에 활용
-// export type ApiVoteCreateResponse = {
-//   vote_id: number
-//   post_id: number
-//   question: string
-//   start_at: string
-//   end_at: string
-//   status: string
-//   options: Array<{ vote_option_id: number; content: string }>
-// }
+// GET /api/v1/posts/:postId 응답
+export type ApiPostResponse = {
+  post_id: number
+  images: string[]
+  profile_image_url: string | null
+  nickname: string
+  created_at: string
+  title: string
+  content: string
+  tags: string[] | null
+  like_count: number
+  comment_count: number
+  is_scrapped: boolean
+  has_goal: boolean
+  goal_info: {
+    goal_id: number
+    goal_title: string
+    goal_start_date: string | null
+    goal_end_date: string | null
+    goal_progress: number | null
+  } | null
+  has_vote: boolean
+  vote_info: {
+    vote_id: number
+    start_at: string
+    end_at: string
+    status: string
+    options: Array<{
+      option_id: number
+      content: string
+      sort_order: number
+    }>
+  } | null
+}
 
 // PATCH /api/v1/posts/:postId 요청
 export type ApiPostUpdateRequest = {
   post_id: number
   title: string
   content: string
-  images: string[]
-  hasGoal: boolean
-  goalId?: number
-  hasVote: boolean
-  tagIds: number[]
+  images?: string[]
+  has_goal: boolean
+  goal_id?: number
+  has_vote: boolean
+  vote?: VoteContent
+  tag_ids?: number[]
 }

--- a/src/features/post/post.constants.ts
+++ b/src/features/post/post.constants.ts
@@ -2,5 +2,4 @@ export const MAX_TITLE = 100
 export const MAX_CONTENT = 500
 export const MAX_IMAGES = 3
 export const MAX_TAGS = 3
-export const MAX_VOTE_QUESTION = 100
 export const MAX_VOTE_OPTION = 100

--- a/src/features/post/post.mappers.ts
+++ b/src/features/post/post.mappers.ts
@@ -1,6 +1,7 @@
 import type {
   ApiGoalResponse,
   ApiPostCreateRequest,
+  ApiPostResponse,
   ApiPostUpdateRequest,
 } from './post.api.types'
 import type { GoalOption, PostFormData } from './post.types'
@@ -9,7 +10,7 @@ import type { GoalOption, PostFormData } from './post.types'
 
 export function toGoalOption(api: ApiGoalResponse): GoalOption {
   return {
-    id: api.goal_id,
+    goalId: api.goal_id,
     title: api.title,
     startDate: api.startDate,
     endDate: api.endDate,
@@ -18,34 +19,55 @@ export function toGoalOption(api: ApiGoalResponse): GoalOption {
   }
 }
 
-// 투표 관련 매퍼 (TODO: 백엔드 엔드포인트 확정 후 구현)
-// [1] PostFormData + votePeriod → ApiVoteCreateRequest
-//   - usePostForm의 votePeriod(DateRange)를 ISO datetime 문자열로 변환
-//   - vote options는 string[] 형태로 전달 (sortOrder 없이)
-// [2] ApiVoteCreateResponse → PostFormData.vote 병합용 객체
-//   - 응답의 options(vote_option_id, content)를 { content, sortOrder } 형태로 변환
-//   - 게시글 생성 요청의 vote 필드에 주입
+// GET /api/v1/posts/:postId 응답 → PostFormData (수정 모드 초기값)
+// tagNames: 서버에서 받은 태그 이름 그대로 전달 — name→id 변환은 PostTagSection이 담당
+export function toPostFormData(api: ApiPostResponse): PostFormData {
+  return {
+    postId: api.post_id,
+    title: api.title,
+    content: api.content,
+    images: api.images,
+    hasGoal: api.has_goal,
+    goalId: api.goal_info?.goal_id,
+    hasVote: api.has_vote,
+    vote: api.vote_info
+      ? {
+          options: api.vote_info.options.map((o) => ({
+            content: o.content,
+            sortOrder: o.sort_order,
+          })),
+          startDate: api.vote_info.start_at,
+          endDate: api.vote_info.end_at,
+        }
+      : undefined,
+    tagNames: api.tags ?? [],
+    tagIds: [],
+  }
+}
 
 // 프론트 타입 → API 요청
+function toApiVoteContent(vote?: PostFormData['vote']) {
+  if (!vote) return undefined
+  return {
+    options: vote.options.map((o) => ({
+      content: o.content,
+      sort_order: o.sortOrder,
+    })),
+    ...(vote.startDate && { start_date: vote.startDate }),
+    ...(vote.endDate && { end_date: vote.endDate }),
+  }
+}
 
 export function toApiCreateRequest(data: PostFormData): ApiPostCreateRequest {
   return {
     title: data.title,
     content: data.content,
     images: data.images,
-    hasGoal: data.hasGoal,
-    ...(data.goalId !== undefined && { goalId: data.goalId }),
-    hasVote: data.hasVote,
-    ...(data.vote !== undefined && {
-      vote: {
-        question: data.vote.question,
-        options: data.vote.options.map((o) => ({
-          content: o.content,
-          sortOrder: o.sortOrder,
-        })),
-      },
-    }),
-    tagIds: data.tagIds,
+    has_goal: data.hasGoal,
+    ...(data.goalId !== undefined && { goal_id: data.goalId }),
+    has_vote: data.hasVote,
+    vote: toApiVoteContent(data.vote),
+    tag_ids: data.tagIds,
   }
 }
 
@@ -59,9 +81,10 @@ export function toApiUpdateRequest(data: PostFormData): ApiPostUpdateRequest {
     title: data.title,
     content: data.content,
     images: data.images,
-    hasGoal: data.hasGoal,
-    ...(data.goalId !== undefined && { goalId: data.goalId }),
-    hasVote: data.hasVote,
-    tagIds: data.tagIds,
+    has_goal: data.hasGoal,
+    ...(data.goalId !== undefined && { goal_id: data.goalId }),
+    has_vote: data.hasVote,
+    vote: toApiVoteContent(data.vote),
+    tag_ids: data.tagIds,
   }
 }

--- a/src/features/post/post.types.ts
+++ b/src/features/post/post.types.ts
@@ -12,11 +12,14 @@ export type VoteOptionFormData = {
 }
 
 export type VoteFormData = {
-  question: string
   options: VoteOptionFormData[]
+  startDate?: string
+  endDate?: string
 }
 
 // 폼 상태 및 컴포넌트 간 전달에 사용
+// tagNames: edit 모드에서 서버로부터 받은 태그 이름 목록 — PostTagSection이 name→id 변환 후 초기 선택 처리
+// tagIds: 현재 선택된 태그 ID 목록 — PostTagSection이 관리
 export type PostFormData = {
   postId?: number
   title: string
@@ -26,12 +29,21 @@ export type PostFormData = {
   goalId?: number
   hasVote: boolean
   vote?: VoteFormData
+  tagNames?: string[]
   tagIds: number[]
+}
+
+// 이미지 업로드 아이템
+// file 있음 → 새로 선택한 파일 (S3 업로드 대기)
+// file 없음 → 이미 업로드된 서버 이미지
+export type PostImageItem = {
+  file?: File
+  previewUrl: string
 }
 
 // 목표 드롭다운에서 사용하는 프론트 전용 타입
 export type GoalOption = {
-  id: number
+  goalId: number
   title: string
   startDate: string
   endDate: string

--- a/src/mocks/data/post.ts
+++ b/src/mocks/data/post.ts
@@ -1,0 +1,79 @@
+import type {
+  ApiGoalResponse,
+  ApiPostResponse,
+  ApiTagResponse,
+} from '@/features/post/post.api.types'
+
+export const mockGoals: ApiGoalResponse[] = [
+  {
+    goal_id: 101,
+    title: '매일 1시간 운동',
+    startDate: '2026-04-08',
+    endDate: '2026-05-08',
+    status: 'IN_PROGRESS',
+    created_at: '2026-04-08T19:00:00',
+    progressRate: 48,
+    isCheckedToday: true,
+  },
+  {
+    goal_id: 102,
+    title: '하루 30분 독서',
+    startDate: '2026-04-01',
+    endDate: '2026-04-30',
+    status: 'IN_PROGRESS',
+    created_at: '2026-04-01T09:00:00',
+    progressRate: 65,
+    isCheckedToday: false,
+  },
+  {
+    goal_id: 103,
+    title: '주 3회 영어 공부',
+    startDate: '2026-03-01',
+    endDate: '2026-03-31',
+    status: 'COMPLETED',
+    created_at: '2026-03-01T08:00:00',
+    progressRate: 100,
+    isCheckedToday: false,
+  },
+]
+
+export const mockTags: ApiTagResponse[] = [
+  { id: 1, name: '운동' },
+  { id: 2, name: '독서' },
+  { id: 3, name: '공부' },
+  { id: 4, name: '식단' },
+  { id: 5, name: '명상' },
+]
+
+export const mockPost: ApiPostResponse = {
+  post_id: 305,
+  images: [],
+  profile_image_url: null,
+  nickname: '테스트유저',
+  created_at: '2026-04-20T10:00:00',
+  title: '오늘의 운동 기록',
+  content: '오늘도 열심히 운동했습니다. 1시간 동안 러닝과 스트레칭을 했어요.',
+  tags: ['운동'],
+  like_count: 5,
+  comment_count: 3,
+  is_scrapped: false,
+  has_goal: true,
+  goal_info: {
+    goal_id: 101,
+    goal_title: '매일 1시간 운동',
+    goal_start_date: '2026-04-08',
+    goal_end_date: '2026-05-08',
+    goal_progress: 48,
+  },
+  has_vote: true,
+  vote_info: {
+    vote_id: 10,
+    start_at: '2026-04-20T00:00:00',
+    end_at: '2026-04-27T23:59:59',
+    status: 'in_progress',
+    options: [
+      { option_id: 1, content: '아침 운동이 좋다', sort_order: 1 },
+      { option_id: 2, content: '저녁 운동이 좋다', sort_order: 2 },
+    ],
+  },
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,5 @@
 import { loginHandler } from './handlers/loginHandler'
+import { postHandler } from './handlers/postHandler'
 import { signupHandler } from './handlers/signupHandler'
 
-export const handlers = [...loginHandler, ...signupHandler]
+export const handlers = [...loginHandler, ...signupHandler, ...postHandler]

--- a/src/mocks/handlers/postHandler.ts
+++ b/src/mocks/handlers/postHandler.ts
@@ -1,0 +1,55 @@
+import { delay, http, HttpResponse } from 'msw'
+
+import { toMswApiUrl } from '@/apis/apiPath'
+import { POST_ENDPOINTS } from '@/apis/post'
+
+import { mockGoals, mockPost, mockTags } from '../data/post'
+
+export const postHandler = [
+  // GET /api/v1/goals — 목표 목록 조회
+  http.get(toMswApiUrl(POST_ENDPOINTS.goals), async () => {
+    await delay(300)
+    return HttpResponse.json(mockGoals, { status: 200 })
+  }),
+
+  // GET /api/v1/tags — 태그 목록 조회
+  http.get(toMswApiUrl(POST_ENDPOINTS.tags), async () => {
+    await delay(300)
+    return HttpResponse.json(mockTags, { status: 200 })
+  }),
+
+  // GET /api/v1/posts/:postId — 게시글 단건 조회
+  // mockPost.post_id(305) 외 ID 접근 시 404 반환 → isError 분기 동작 확인 가능
+  http.get(toMswApiUrl(POST_ENDPOINTS.post(':postId')), async ({ params }) => {
+    await delay(400)
+
+    const postId = Number(params.postId)
+    if (postId !== mockPost.post_id) {
+      return HttpResponse.json(
+        { detail: '해당 게시글을 찾을 수 없습니다.' },
+        { status: 404 }
+      )
+    }
+
+    return HttpResponse.json(mockPost, { status: 200 })
+  }),
+
+  // POST /api/v1/posts — 게시글 생성
+  http.post(toMswApiUrl(POST_ENDPOINTS.posts), async () => {
+    await delay(600)
+    return HttpResponse.json(
+      { detail: '게시글이 성공적으로 생성되었습니다.', post_id: 306 },
+      { status: 201 }
+    )
+  }),
+
+  // PATCH /api/v1/posts/:postId — 게시글 수정
+  http.patch(toMswApiUrl(POST_ENDPOINTS.post(':postId')), async () => {
+    await delay(600)
+
+    return HttpResponse.json(
+      { detail: '게시글이 성공적으로 수정되었습니다.' },
+      { status: 200 }
+    )
+  }),
+]

--- a/src/pages/PostCreatePage.tsx
+++ b/src/pages/PostCreatePage.tsx
@@ -1,40 +1,26 @@
 import { useNavigate } from 'react-router'
 
-import type { PostFormData } from '@/features/post'
-import { PostFormLayout, toApiCreateRequest } from '@/features/post'
+import { useToast } from '@/components/common/ui'
+import { PostFormLayout } from '@/features/post'
+import { useCreatePostMutation } from '@/query/post'
 
 export function PostCreatePage() {
   const navigate = useNavigate()
+  const toast = useToast()
 
-  async function handleSubmit(data: PostFormData) {
-    // TODO: [투표 선생성 → 게시글 생성] 2단계 순차 API 호출 구현 필요
-    //
-    // [1단계] 투표가 있는 경우 먼저 투표를 생성
-    //   - POST /api/v1/posts/votes
-    //   - 요청 body: { question, options: string[], start_at, end_at }
-    //   - 응답(200): ApiVoteCreateResponse (vote_id, question, options 등)
-    //   ※ start_at / end_at 은 현재 usePostForm의 votePeriod 상태에서 가져와야 함
-    //   ※ votePeriod가 PostFormData에 포함되지 않으므로, PostFormData.vote 또는
-    //      별도 필드로 추가하는 타입 변경이 선행되어야 함 (post.types.ts, usePostForm.ts 수정 필요)
-    //
-    // [2단계] 1단계 응답값을 이용해 게시글 생성
-    //   - POST /api/v1/posts
-    //   - hasVote: true, vote: { question, options: [{ content, sortOrder }] } 포함
-    //   - vote 데이터는 1단계 응답(ApiVoteCreateResponse)을 toApiCreateRequest mapper로 변환하여 사용
-    //
-    // [타입/매퍼 추가 필요]
-    //   - post.api.types.ts: ApiVoteCreateRequest, ApiVoteCreateResponse 타입 추가
-    //   - post.mappers.ts: toApiVoteCreateRequest, fromApiVoteCreateResponse 매퍼 추가
-
-    const body = toApiCreateRequest(data)
-    console.log('create post:', body)
-  }
+  const { mutate: createPost, isPending } = useCreatePostMutation({
+    onSuccess: () => {
+      navigate(-1)
+    }, // TODO: 추후 게시글 목록 페이지로 이동하도록 변경 필요
+    onError: () => toast.error('게시글 생성에 실패했습니다.'),
+  })
 
   return (
     <PostFormLayout
       mode="create"
-      onSubmit={handleSubmit}
+      onSubmit={createPost}
       onCancel={() => navigate(-1)}
+      isPending={isPending}
     />
   )
 }

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -1,25 +1,41 @@
-import { useNavigate, useParams } from 'react-router'
+import { Navigate, useNavigate, useParams } from 'react-router'
 
-import type { PostFormData } from '@/features/post'
-import { PostFormLayout, toApiUpdateRequest } from '@/features/post'
+import { useToast } from '@/components/common/ui'
+import {
+  PostFormLayout,
+  PostFormSkeleton,
+  toPostFormData,
+} from '@/features/post'
+import { usePostQuery, useUpdatePostMutation } from '@/query/post'
 
 export function PostEditPage() {
   const navigate = useNavigate()
+  const toast = useToast()
   const { id } = useParams<{ id: string }>()
+  const postId = Number(id)
 
-  function handleSubmit(data: PostFormData) {
-    if (data.postId === undefined) return
-    const body = toApiUpdateRequest(data)
-    // TODO: PATCH /api/v1/posts/:id 연동
-    // defaultValues는 GET /api/v1/posts/:id 응답 후 PostFormLayout에 전달 (로딩 중 렌더링 보류)
-    console.log(`edit post ${id}:`, body)
-  }
+  const { data: post, isLoading, isError } = usePostQuery(postId)
+
+  const { mutate: updatePost, isPending } = useUpdatePostMutation(postId, {
+    onSuccess: () => {
+      navigate(-1)
+    }, // TODO: 추후 게시글 목록으로 이동하도록 변경 필요
+    onError: () => toast.error('게시글 수정에 실패했습니다.'),
+  })
+
+  if (isNaN(postId)) return <Navigate to="/not-found" replace />
+  if (isLoading) return <PostFormSkeleton />
+  if (isError || !post) return <Navigate to="/not-found" replace />
+
+  const defaultValues = toPostFormData(post)
 
   return (
     <PostFormLayout
       mode="edit"
-      onSubmit={handleSubmit}
+      defaultValues={defaultValues}
+      onSubmit={updatePost}
       onCancel={() => navigate(-1)}
+      isPending={isPending}
     />
   )
 }

--- a/src/query/post/index.ts
+++ b/src/query/post/index.ts
@@ -1,0 +1,5 @@
+export { useCreatePostMutation } from './useCreatePostMutation'
+export { useGoalsQuery } from './useGoalsQuery'
+export { usePostQuery } from './usePostQuery'
+export { useTagsQuery } from './useTagsQuery'
+export { useUpdatePostMutation } from './useUpdatePostMutation'

--- a/src/query/post/useCreatePostMutation.ts
+++ b/src/query/post/useCreatePostMutation.ts
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post'
+import { type PostFormData, toApiCreateRequest } from '@/features/post'
+
+type Options = {
+  onSuccess: () => void
+  onError: () => void
+}
+
+// 추후 성공 시 stale한 값 설정 후 캐시 제거 필요
+export function useCreatePostMutation(options: Options) {
+  return useMutation({
+    mutationFn: (data: PostFormData) => {
+      const body = toApiCreateRequest(data)
+      return postApi.createPost(body)
+    },
+    onSuccess: options.onSuccess,
+    onError: options.onError,
+  })
+}

--- a/src/query/post/useGoalsQuery.ts
+++ b/src/query/post/useGoalsQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post'
+import { toGoalOption } from '@/features/post'
+
+export function useGoalsQuery() {
+  return useQuery({
+    queryKey: ['goals'], // staleTime, gcTime 설정 필요
+    queryFn: () => postApi.getGoals().then((res) => res.data.map(toGoalOption)),
+  })
+}

--- a/src/query/post/usePostQuery.ts
+++ b/src/query/post/usePostQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post'
+
+export function usePostQuery(postId: number) {
+  return useQuery({
+    queryKey: ['post', postId], // staleTime, gcTime 설정 필요
+    queryFn: () => postApi.getPost(postId).then((res) => res.data),
+    enabled: !isNaN(postId),
+  })
+}

--- a/src/query/post/useTagsQuery.ts
+++ b/src/query/post/useTagsQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post'
+
+export function useTagsQuery() {
+  return useQuery({
+    queryKey: ['tags'], // staleTime, gcTime 설정 필요
+    queryFn: () => postApi.getTags().then((res) => res.data),
+  })
+}

--- a/src/query/post/useUpdatePostMutation.ts
+++ b/src/query/post/useUpdatePostMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post'
+import { type PostFormData, toApiUpdateRequest } from '@/features/post'
+
+type Options = {
+  onSuccess: () => void
+  onError: () => void
+}
+
+// 추후 성공 시 stale한 값 설정 후 캐시 제거 필요
+export function useUpdatePostMutation(postId: number, options: Options) {
+  return useMutation({
+    mutationFn: (data: PostFormData) => {
+      const body = toApiUpdateRequest(data)
+      return postApi.updatePost(postId, body)
+    },
+    onSuccess: () => {
+      options.onSuccess()
+    },
+    onError: options.onError,
+  })
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #95 

## ✨ 변경 내용

- `src/query/post/` — React Query 훅 분리 (`usePostQuery`, `useTagsQuery`, `useGoalsQuery`, `useCreatePostMutation`, `useUpdatePostMutation`)
- `src/apis/post/` — API 클라이언트, 엔드포인트 모듈 신규 구성
- `PostFormSkeleton` — 게시글 수정 페이지 로딩 스켈레톤 추가
- MSW 핸들러 및 mock 데이터 추가 (`postHandler`, `mockPost`, `mockGoals`, `mockTags`)
- `PostCreatePage` / `PostEditPage` — `useMutation` 연동, 에러 시 toast, 유효하지 않은 postId 접근 시 `/not-found` 리다이렉트
- `usePostForm` —  `voteConfirmed` 제거 후 기간+옵션 자동 파생으로 교체, tag 초기화 책임을 `PostTagSection`으로 위임
- `PostTagSection` — 태그 조회 직접 소유 (`useTagsQuery`)
- `PostGoalSection` — 목표 조회 직접 소유 (`useGoalsQuery`)
- `post.mappers.ts` / `post.api.types.ts` — API 스펙에 맞게 필드명 수정 (현재 API 명세서 기준 snake_case + camelCase)
- `VoteEditor` — 투표 생성/수정 버튼 제거 (게시글 생성 시 투표 날짜 + 투표 옵션 값으로 생성되기 때문에 불필요)

## 📸 스크린샷(선택)

1. 게시글 생성

https://github.com/user-attachments/assets/f361de3a-2956-4619-9c81-939793b25146




2. 게시글 수정

https://github.com/user-attachments/assets/24fe0f4e-2066-41cc-82d5-46c8534b8082




## 📚 참고사항
useCalender의 isOpen 상태의 초기값이 true -> false로 변경하였습니다.
VoteEditor에서 onSubmit 함수를 props로 받을 때만 투표 생성/수정하기 버튼이 보이도록 추가하였습니다.
이미지 업로드는 S3 업로드 API 개발 후 로직을 추가할 예정입니다. (현재는 이미지 전달 하고 있지 않음)
게시글 목록 조회 페이지가 없기 때문에 이전 화면 + 성공 시 이동 로직 처리는 TODO로 주석 처리 하였습니다. + queryKey 설정 등등