### PR TITLE
feat: auth msw login

### DIFF
--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -1,38 +1,43 @@
 import { apiClient } from '@/apis/apiClient'
 
-import type {
-  CheckNicknameRequest,
-  CheckNicknameResponse,
-  SendEmailVerificationRequest,
-  SendEmailVerificationResponse,
-  SignupRequest,
-  SignupResponse,
-  VerifyEmailRequest,
-  VerifyEmailResponse,
-} from './auth.schema'
-import { AUTH_ENDPOINTS } from './endpoints'
+import * as authSchema from './auth.schema'
+import { AUTH_ENDPOINTS, type SocialLoginProvider } from './endpoints'
+
+type SocialLoginCallbackRequestMap = {
+  kakao: authSchema.KakaoLoginCallbackRequest
+  naver: authSchema.NaverLoginCallbackRequest
+  google: authSchema.GoogleLoginCallbackRequest
+}
+
+const socialLoginCallbackRequestSchemas = {
+  kakao: authSchema.kakaoLoginCallbackRequestSchema,
+  naver: authSchema.naverLoginCallbackRequestSchema,
+  google: authSchema.googleLoginCallbackRequestSchema,
+} as const
 
 export const authApi = {
-  signup: async (payload: SignupRequest) => {
-    const { data } = await apiClient.post<SignupResponse>(
+  signup: async (payload: authSchema.SignupRequest) => {
+    const { data } = await apiClient.post<authSchema.SignupResponse>(
       AUTH_ENDPOINTS.signup,
       payload
     )
+    return data
+  },
+
+  sendEmailVerification: async ({
+    email,
+  }: authSchema.SendEmailVerificationRequest) => {
+    const { data } =
+      await apiClient.post<authSchema.SendEmailVerificationResponse>(
+        AUTH_ENDPOINTS.sendEmailVerification,
+        { email }
+      )
 
     return data
   },
 
-  sendEmailVerification: async ({ email }: SendEmailVerificationRequest) => {
-    const { data } = await apiClient.post<SendEmailVerificationResponse>(
-      AUTH_ENDPOINTS.sendEmailVerification,
-      { email }
-    )
-
-    return data
-  },
-
-  verifyEmail: async ({ email, code }: VerifyEmailRequest) => {
-    const { data } = await apiClient.get<VerifyEmailResponse>(
+  verifyEmail: async ({ email, code }: authSchema.VerifyEmailRequest) => {
+    const { data } = await apiClient.get<authSchema.VerifyEmailResponse>(
       AUTH_ENDPOINTS.verifyEmail,
       {
         params: { email, code },
@@ -42,8 +47,8 @@ export const authApi = {
     return data
   },
 
-  checkNickname: async ({ nickname }: CheckNicknameRequest) => {
-    const { data } = await apiClient.get<CheckNicknameResponse>(
+  checkNickname: async ({ nickname }: authSchema.CheckNicknameRequest) => {
+    const { data } = await apiClient.get<authSchema.CheckNicknameResponse>(
       AUTH_ENDPOINTS.checkNickname,
       {
         params: { nickname },
@@ -51,5 +56,42 @@ export const authApi = {
     )
 
     return data
+  },
+
+  login: async (
+    payload: authSchema.LoginRequest
+  ): Promise<authSchema.LoginResponse> => {
+    // 로그인 요청 스키마를 그대로 사용해 API 호출 전에 payload 형태를 한 번 검증합니다.
+    // 추후 실제 API가 붙어도 이 함수의 호출부는 유지하고 endpoint/baseURL만 실제 서버로 향하게 됩니다.
+    const requestPayload = authSchema.loginRequestSchema.parse(payload)
+
+    const { data } = await apiClient.post<authSchema.LoginResponse>(
+      AUTH_ENDPOINTS.login,
+      requestPayload
+    )
+
+    // MSW 응답도 실제 API 응답과 같은 스키마를 따르는지 확인합니다.
+    // 실제 API 연동 후 응답 형태가 확정되면 이 검증으로 프론트/백엔드 계약을 빠르게 확인할 수 있습니다.
+    return authSchema.loginResponseSchema.parse(data)
+  },
+
+  socialLoginCallback: async <TProvider extends SocialLoginProvider>(
+    provider: TProvider,
+    payload: SocialLoginCallbackRequestMap[TProvider]
+  ): Promise<authSchema.LoginResponse> => {
+    const requestSchema = socialLoginCallbackRequestSchemas[provider]
+
+    // 소셜 로그인은 provider마다 필요한 callback payload가 달라서 provider별 스키마로 검증합니다.
+    // 현재 로그인 페이지에서는 MSW 테스트용 mock code/state를 보내며, 실제 OAuth 연동 시 callback 페이지에서 받은 값을 넘기면 됩니다.
+    const requestPayload = requestSchema.parse(payload)
+
+    const { data } = await apiClient.post<authSchema.LoginResponse>(
+      AUTH_ENDPOINTS.socialLoginCallback(provider),
+      requestPayload
+    )
+
+    // 소셜 로그인 callback 응답도 일반 로그인과 동일한 응답 스키마를 재사용합니다.
+    // 현재는 MSW 확인용 access_token이며, 실제 토큰 저장 정책이 정해지기 전까지 호출부에서 저장하지 않습니다.
+    return authSchema.loginResponseSchema.parse(data)
   },
 } as const

--- a/src/components/common/layout/Header.tsx
+++ b/src/components/common/layout/Header.tsx
@@ -3,18 +3,23 @@ import { useNavigate } from 'react-router'
 import { Laptop, Moon, Sun } from 'lucide-react'
 
 import { DarklogoImage, logoImage } from '@/assets/images'
+import { ActionMenu } from '@/components/common/overlay'
+import { Button } from '@/components/common/ui'
 import { useTheme } from '@/lib/theme/ThemeProvider'
+import { useAuthStore } from '@/store/authStore'
 
-const THEME_ICON = {
-  light: Sun,
-  dark: Moon,
-  system: Laptop,
+const THEME_META = {
+  light: { label: '라이트 테마', display: 'Light', Icon: Sun },
+  dark: { label: '다크 테마', display: 'Dark', Icon: Moon },
+  system: { label: '시스템 테마', display: 'System', Icon: Laptop },
 } as const
 
 export function Header() {
   const { theme, setTheme } = useTheme()
   const navigate = useNavigate()
-  const ThemeIcon = THEME_ICON[theme]
+  const user = useAuthStore((state) => state.user)
+  const clearSession = useAuthStore((state) => state.clearSession)
+  const { label, display, Icon } = THEME_META[theme]
 
   const handleClickTheme = () => {
     if (theme === 'light') {
@@ -30,6 +35,11 @@ export function Header() {
     setTheme('light')
   }
 
+  const handleLogout = () => {
+    clearSession()
+    navigate('/')
+  }
+
   return (
     <header className="max-w-7xl mx-auto w-full">
       <div className="flex items-center justify-between py-3 px-4">
@@ -43,20 +53,51 @@ export function Header() {
           className="hidden w-12 h-11 dark:block"
           alt="OZ Union 로고"
         />
-        <div className="flex items-center gap-2">
-          {/* TODO: 레이아웃 확정 후 로그인 상태와 공통 버튼 컴포넌트에 맞춰 헤더 props 분리 */}
-          <button
-            type="button"
-            className="relative flex size-9 items-center justify-center"
+        <div className="flex items-center gap-6">
+          <Button
+            variant={'ghost'}
+            rounded={'full'}
             onClick={handleClickTheme}
-            aria-label={`현재 테마: ${theme}`}
+            aria-label={`${label} 사용 중. 클릭하면 다음 테마로 변경됩니다.`}
+            className="relative h-9 justify-start border border-border-default bg-transparent py-0 pl-4 pr-12 text-text-primary transition-shadow duration-300 hover:bg-transparent shadow-card-main"
           >
-            <ThemeIcon className="text-text-primary" />
-          </button>
+            <span className="text-sm font-medium leading-none">{display}</span>
+            <span className="absolute right-0 top-1/2 flex size-9 -translate-y-1/2 items-center justify-center rounded-full border border-white/30 bg-white/30 text-text-primary backdrop-blur-md shadow-[0_3px_10px_rgba(151,151,151,0.18),inset_0_1px_2px_rgba(255,255,255,0.8)] transition-transform duration-300 hover:scale-110 dark:border-white/15 dark:bg-white/5 dark:shadow-[0_10px_30px_rgba(0,0,0,0.18),inset_0_1px_1px_rgba(255,255,255,0.55),inset_0_-1px_2px_rgba(255,255,255,0.12)]">
+              <Icon className="size-4.5" aria-hidden="true" />
+            </span>
+          </Button>
 
-          <button onClick={() => navigate('/login')} className="text-lg">
-            로그인
-          </button>
+          {user ? (
+            <ActionMenu
+              className="flex items-center"
+              align="right"
+              items={[
+                { label: '마이페이지', onClick: () => navigate('/mypage') },
+                { label: '로그아웃', onClick: handleLogout },
+              ]}
+              trigger={
+                <div className="flex items-center gap-2">
+                  <img
+                    src={user.profileImageUrl}
+                    alt={`${user.nickname} 프로필`}
+                    className="size-8 rounded-full object-contain"
+                  />
+                  <span className="max-w-24 truncate text-sm font-medium leading-none">
+                    {user.nickname}
+                  </span>
+                </div>
+              }
+            />
+          ) : (
+            <Button
+              variant="ghost"
+              onClick={() => navigate('/login')}
+              rounded="full"
+              className="ml-3 h-9 bg-transparent px-0 py-0 text-sm text-text-primary hover:bg-transparent hover:text-primary-600 dark:hover:text-primary-400"
+            >
+              로그인
+            </Button>
+          )}
         </div>
       </div>
     </header>

--- a/src/components/common/overlay/dropdown/action-menu/ActionMenu.tsx
+++ b/src/components/common/overlay/dropdown/action-menu/ActionMenu.tsx
@@ -12,12 +12,14 @@ type ActionMenuProps = {
   trigger: React.ReactNode
   items: ActionMenuItem[]
   align?: 'left' | 'right'
+  className?: string
 }
 
 export function ActionMenu({
   trigger,
   items,
   align = 'right',
+  className,
 }: ActionMenuProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [isClosing, setIsClosing] = useState(false)
@@ -41,7 +43,7 @@ export function ActionMenu({
       <button
         type="button"
         onClick={() => (isOpen ? close() : setIsOpen(true))}
-        className="cursor-pointer"
+        className={cn('cursor-pointer', className)}
         aria-label="메뉴 열기"
       >
         {trigger}

--- a/src/components/common/ui/toast/useToast.ts
+++ b/src/components/common/ui/toast/useToast.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 
-import { toast } from 'sonner'
+import { type ExternalToast, toast } from 'sonner'
 
 import { Toast } from './Toast'
 
@@ -11,15 +11,23 @@ export type ToastProps = {
   type?: ToastType
 }
 
-const showCustomToast = (type: ToastType, message: string) => {
-  return toast.custom(() => createElement(Toast, { type, message }))
+const showCustomToast = (
+  type: ToastType,
+  message: string,
+  options?: ExternalToast
+) => {
+  return toast.custom(() => createElement(Toast, { type, message }), options)
 }
 
 export const useToast = () => {
   return {
-    success: (message: string) => showCustomToast('success', message),
-    error: (message: string) => showCustomToast('error', message),
-    warning: (message: string) => showCustomToast('warning', message),
-    info: (message: string) => showCustomToast('info', message),
+    success: (message: string, options?: ExternalToast) =>
+      showCustomToast('success', message, options),
+    error: (message: string, options?: ExternalToast) =>
+      showCustomToast('error', message, options),
+    warning: (message: string, options?: ExternalToast) =>
+      showCustomToast('warning', message, options),
+    info: (message: string, options?: ExternalToast) =>
+      showCustomToast('info', message, options),
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -473,3 +473,33 @@ input:-webkit-autofill:focus {
   /* prevent flash of default color */
   transition: background-color 9999s ease-out 0s;
 }
+
+/* Sonner top-center 기준점을 viewport 정중앙으로 고정합니다. */
+[data-sonner-toaster][data-x-position='center'] {
+  left: 50vw !important;
+  right: auto !important;
+  width: min(300px, calc(100vw - 32px)) !important;
+  transform: translateX(-50%) !important;
+}
+
+/* Sonner가 생성하는 toast wrapper도 컨테이너 중앙 기준으로 다시 맞춥니다. */
+[data-sonner-toaster][data-x-position='center'] [data-sonner-toast] {
+  left: 50% !important;
+  right: auto !important;
+  width: min(300px, calc(100vw - 32px)) !important;
+  translate: -50% 0;
+}
+
+/* 커스텀 Toast 내부 박스가 wrapper 너비를 그대로 사용하게 합니다. */
+[data-sonner-toaster][data-x-position='center'] [data-sonner-toast] > div {
+  width: 100%;
+  max-width: 100%;
+}
+
+/* 모바일에서는 좌우 16px 여백을 남기고 가운데 정렬을 유지합니다. */
+@media (max-width: 600px) {
+  [data-sonner-toaster][data-x-position='center'] {
+    left: 50vw !important;
+    width: calc(100vw - 32px) !important;
+  }
+}

--- a/src/mocks/data/auth.ts
+++ b/src/mocks/data/auth.ts
@@ -1,0 +1,38 @@
+import type { LoginResponse, SocialLoginProvider } from '@/apis/auth'
+
+export const mockLoginUser = {
+  // 로그인 MSW에서만 사용하는 임시 계정입니다.
+  // 실제 API가 개발되면 이 mock 계정 데이터는 삭제하고 서버 응답을 사용합니다.
+  email: 'test@example.com',
+  password: 'password123',
+} as const
+
+export const mockLoginResponse: LoginResponse = {
+  // auth.schema.ts의 loginResponseSchema에 맞춘 mock token입니다.
+  // 아직 실제 access token 정책이 없으므로 프론트에서는 이 값을 저장하지 않습니다.
+  access_token: 'mock-access-token',
+}
+
+export const mockSocialLoginPayload = {
+  // 소셜 로그인 MSW callback 호출을 확인하기 위한 임시 code/state 값입니다.
+  // 실제 OAuth 연동 시 provider에서 받은 code/state로 대체되고 이 mock 값들은 삭제됩니다.
+  kakao: {
+    code: 'mock-kakao-code',
+  },
+  naver: {
+    code: 'mock-naver-code',
+    state: 'mock-naver-state',
+  },
+  google: {
+    code: 'mock-google-code',
+    state: 'mock-google-state',
+  },
+} as const
+
+export const getMockSocialLoginResponse = (
+  provider: SocialLoginProvider
+): LoginResponse => ({
+  // provider별 callback endpoint가 정상 연결됐는지 구분하기 위한 MSW 전용 token입니다.
+  // 실제 API 연동 후에는 서버에서 받은 응답을 그대로 사용합니다.
+  access_token: `mock-${provider}-access-token`,
+})

--- a/src/mocks/handlers/loginHandler.ts
+++ b/src/mocks/handlers/loginHandler.ts
@@ -1,11 +1,86 @@
-//login관련 msw 핸들러
+// login 관련 MSW 핸들러
 import { http, HttpResponse } from 'msw'
 
 import { toMswApiUrl } from '@/apis/apiPath'
 import { AUTH_ENDPOINTS } from '@/apis/auth'
+import {
+  googleLoginCallbackRequestSchema,
+  kakaoLoginCallbackRequestSchema,
+  loginRequestSchema,
+  naverLoginCallbackRequestSchema,
+} from '@/apis/auth/auth.schema'
+import {
+  getMockSocialLoginResponse,
+  mockLoginResponse,
+  mockLoginUser,
+} from '@/mocks/data/auth'
+
+const socialLoginCallbackRequestSchemas = {
+  kakao: kakaoLoginCallbackRequestSchema,
+  naver: naverLoginCallbackRequestSchema,
+  google: googleLoginCallbackRequestSchema,
+} as const
 
 export const loginHandler = [
-  http.post(toMswApiUrl(AUTH_ENDPOINTS.login), () => {
-    return HttpResponse.json({ access_token: 'mock-access-token' })
+  http.post(toMswApiUrl(AUTH_ENDPOINTS.login), async ({ request }) => {
+    const body = await request.json()
+
+    // MSW에서도 실제 API와 같은 요청 스키마를 사용해 잘못된 payload를 field error로 내려줍니다.
+    // 추후 실제 API가 붙으면 이 handler 전체가 삭제되고 서버 검증 결과를 사용하게 됩니다.
+    const parsedBody = loginRequestSchema.safeParse(body)
+
+    if (!parsedBody.success) {
+      return HttpResponse.json(
+        {
+          error_detail: {
+            email: ['이메일 형식이 올바르지 않습니다.'],
+            password: ['비밀번호를 입력해주세요'],
+          },
+        },
+        { status: 422 }
+      )
+    }
+
+    const { email, password } = parsedBody.data
+    const isMockUser =
+      email === mockLoginUser.email && password === mockLoginUser.password
+
+    if (!isMockUser) {
+      return HttpResponse.json(
+        { error_detail: '이메일 또는 비밀번호가 올바르지 않습니다.' },
+        { status: 401 }
+      )
+    }
+
+    // 로그인 성공 mock 응답입니다. 실제 access token이 아직 없어서 화면 흐름 확인용으로만 사용합니다.
+    return HttpResponse.json(mockLoginResponse)
   }),
+
+  ...(['kakao', 'naver', 'google'] as const).map((provider) =>
+    http.post(
+      toMswApiUrl(AUTH_ENDPOINTS.socialLoginCallback(provider)),
+      async ({ request }) => {
+        const body = await request.json()
+        const requestSchema = socialLoginCallbackRequestSchemas[provider]
+
+        // provider별 callback payload를 스키마 기준으로 검증합니다.
+        // 실제 OAuth 연동 시 이 handler는 삭제되고, 백엔드 callback API가 같은 역할을 담당합니다.
+        const parsedBody = requestSchema.safeParse(body)
+
+        if (!parsedBody.success) {
+          return HttpResponse.json(
+            {
+              error_detail: {
+                code: ['소셜 로그인 인증 코드가 올바르지 않습니다.'],
+              },
+            },
+            { status: 422 }
+          )
+        }
+
+        // 소셜 로그인 성공 mock 응답입니다. token은 저장하지 않고 MSW 연결 확인에만 사용합니다.
+        return HttpResponse.json(getMockSocialLoginResponse(provider))
+      }
+    )
+  ),
 ]

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,10 +1,14 @@
+import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { Link } from 'react-router'
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import { LoaderCircle } from 'lucide-react'
 
 import { Button } from '@/components/common/ui'
 import { AuthForm, AuthPageLayout } from '@/features/auth'
+import { mockSocialLoginPayload } from '@/mocks/data/auth'
+import { useLoginMutation, useSocialLoginMutation } from '@/query/auth'
 import {
   type LoginFormSchema,
   loginFormSchema,
@@ -33,6 +37,10 @@ const socialLoginButtons = [
 ] as const
 
 export function LoginPage() {
+  const [pendingSocialProvider, setPendingSocialProvider] = useState<
+    (typeof socialLoginButtons)[number]['provider'] | null
+  >(null)
+
   const methods = useForm<LoginFormSchema>({
     mode: 'onChange',
     resolver: zodResolver(loginFormSchema),
@@ -45,17 +53,65 @@ export function LoginPage() {
   const {
     control,
     formState: { isValid, isDirty },
+    setError,
   } = methods
 
   const LoginField = AuthForm.FormField<LoginFormSchema>
+  const loginMutation = useLoginMutation(setError)
+  const socialLoginMutation = useSocialLoginMutation()
+  const isSocialLoginPending = socialLoginMutation.isPending
 
-  // 로그인 API 연결 전 임시 제출 함수입니다.
-  const handleLoginSubmit = () => {}
+  const handleLoginSubmit = (formValues: LoginFormSchema) => {
+    // 로그인 폼 제출 시 authApi.login -> MSW login handler 순서로 요청이 흐릅니다.
+    // 실제 API가 개발되면 같은 mutation을 유지한 채 baseURL만 실제 서버로 연결하면 됩니다.
+    loginMutation.mutate(formValues)
+  }
   const handleSocialLogin = (
     provider: (typeof socialLoginButtons)[number]['provider']
   ) => {
-    // TODO: 소셜 로그인 시작 API 또는 OAuth URL 연결
-    void provider
+    // 현재는 OAuth redirect가 없어서 MSW callback endpoint를 직접 호출합니다.
+    // 추후 실제 소셜 로그인 연동 시 provider 로그인 URL로 이동하거나 callback 페이지에서 이 요청을 실행하도록 교체합니다.
+    setPendingSocialProvider(provider)
+
+    const mutationOptions = {
+      onSettled: () => {
+        // 소셜 버튼별 loading 표시를 끝내기 위한 로컬 상태입니다.
+        // 실제 OAuth redirect 방식으로 바뀌면 이 상태는 삭제될 수 있습니다.
+        setPendingSocialProvider(null)
+      },
+    }
+
+    // provider별 callback payload 모양이 달라서 분기별로 mutation 변수를 넘깁니다.
+    // 이렇게 두면 스키마 타입과 provider가 어긋나는 실수를 TypeScript가 잡아줍니다.
+    if (provider === 'kakao') {
+      socialLoginMutation.mutate(
+        {
+          provider,
+          payload: mockSocialLoginPayload.kakao,
+        },
+        mutationOptions
+      )
+      return
+    }
+
+    if (provider === 'naver') {
+      socialLoginMutation.mutate(
+        {
+          provider,
+          payload: mockSocialLoginPayload.naver,
+        },
+        mutationOptions
+      )
+      return
+    }
+
+    socialLoginMutation.mutate(
+      {
+        provider,
+        payload: mockSocialLoginPayload.google,
+      },
+      mutationOptions
+    )
   }
 
   return (
@@ -86,14 +142,20 @@ export function LoginPage() {
             rounded={'lg'}
             className={cn(
               'text-xl py-3 w-full',
-              isValid
-                ? 'bg-black hover:bg-[#121212]'
-                : 'disabled:bg-black/30 disabled:text-white/20'
+              loginMutation.isPending
+                ? 'disabled:bg-black disabled:text-white'
+                : isValid
+                  ? 'bg-black hover:bg-[#121212]'
+                  : 'disabled:bg-black/30 disabled:text-white/20'
             )}
             size="lg"
-            disabled={!isDirty || !isValid}
+            disabled={!isDirty || !isValid || loginMutation.isPending}
           >
-            로그인
+            {loginMutation.isPending ? (
+              <LoaderCircle size={18} className="animate-spin" />
+            ) : (
+              '로그인'
+            )}
           </Button>
 
           <div className="flex items-center gap-3 py-1">
@@ -114,9 +176,14 @@ export function LoginPage() {
                     'flex size-14 items-center justify-center text-xl font-bold transition-colors',
                     className
                   )}
+                  disabled={isSocialLoginPending}
                   onClick={() => handleSocialLogin(provider)}
                 >
-                  <span aria-hidden="true">{iconLabel}</span>
+                  {pendingSocialProvider === provider ? (
+                    <LoaderCircle size={18} className="animate-spin" />
+                  ) : (
+                    <span aria-hidden="true">{iconLabel}</span>
+                  )}
                 </Button>
               )
             )}

--- a/src/query/auth/index.ts
+++ b/src/query/auth/index.ts
@@ -3,4 +3,6 @@ export {
   useSendEmailVerificationMutation,
   useVerifyEmailMutation,
 } from './useEmailVerificationMutations'
+export { useLoginMutation } from './useLoginMutation'
 export { useSignupMutation } from './useSignupMutation'
+export { useSocialLoginMutation } from './useSocialLoginMutation'

--- a/src/query/auth/useLoginMutation.ts
+++ b/src/query/auth/useLoginMutation.ts
@@ -1,0 +1,75 @@
+import type { UseFormSetError } from 'react-hook-form'
+import { useNavigate } from 'react-router'
+
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+import {
+  authApi,
+  type FieldErrorResponse,
+  type LoginRequest,
+  type LoginResponse,
+  type LoginUnauthorizedResponse,
+} from '@/apis/auth'
+import { yellowCharacterImage } from '@/assets/images'
+import type { LoginFormSchema } from '@/schemas/auth/authForm.schema'
+import { useAuthStore } from '@/store/authStore'
+
+export function useLoginMutation(setError: UseFormSetError<LoginFormSchema>) {
+  const navigate = useNavigate()
+  const setSession = useAuthStore((state) => state.setSession)
+
+  // 로그인은 사용자가 로그인 버튼을 눌렀을 때만 실행되는 동작이라 useMutation으로 관리합니다.
+  return useMutation<
+    LoginResponse,
+    AxiosError<FieldErrorResponse | LoginUnauthorizedResponse>,
+    LoginRequest
+  >({
+    mutationFn: authApi.login,
+    onSuccess: (data, variables) => {
+      // 현재 로그인 응답에는 access_token만 있어서 닉네임/프로필은 임시값으로 표시합니다.
+      // 추후 내 정보 API가 붙으면 로그인 직후 사용자 정보를 조회해 이 값을 교체하면 됩니다.
+      setSession(data.access_token, {
+        nickname: variables.email.split('@')[0],
+        profileImageUrl: yellowCharacterImage,
+      })
+      navigate('/')
+    },
+    onError: (error) => {
+      const errorDetail = error.response?.data?.error_detail
+
+      // 로그인 실패 응답이 문자열이면 이메일/비밀번호 조합 실패로 보고 비밀번호 필드에 표시합니다.
+      // 이 문구는 auth.schema.ts의 loginUnauthorizedResponseSchema와 MSW handler가 같은 값을 사용합니다.
+      if (typeof errorDetail === 'string') {
+        setError('password', {
+          type: 'server',
+          message: errorDetail,
+        })
+        return
+      }
+
+      // 서버 또는 MSW에서 field error 형태로 내려준 경우 폼 필드 에러로 연결합니다.
+      // 실제 API 연동 시 백엔드 field key가 바뀌면 이 매핑만 조정하면 됩니다.
+      if (errorDetail?.email?.[0]) {
+        setError('email', {
+          type: 'server',
+          message: errorDetail.email[0],
+        })
+      }
+
+      if (errorDetail?.password?.[0]) {
+        setError('password', {
+          type: 'server',
+          message: errorDetail.password[0],
+        })
+      }
+
+      if (!errorDetail) {
+        setError('password', {
+          type: 'server',
+          message: '로그인에 실패했습니다.',
+        })
+      }
+    },
+  })
+}

--- a/src/query/auth/useSignupMutation.ts
+++ b/src/query/auth/useSignupMutation.ts
@@ -25,9 +25,11 @@ export function useSignupMutation(setError: UseFormSetError<SignupFormSchema>) {
   >({
     mutationFn: authApi.signup,
     onSuccess: (data) => {
-      // 회원가입 API가 성공하면 전역 토스트를 띄우고 로그인 페이지로 이동합니다.
-      toast.success(data.detail)
-      navigate('/login')
+      // 성공 토스트가 사라진 뒤 로그인 페이지로 이동하도록 짧은 지연을 둡니다.
+      toast.success(data.detail, { duration: 2000 })
+      window.setTimeout(() => {
+        navigate('/login')
+      }, 2000)
     },
     onError: (error) => {
       const errorDetail = error.response?.data?.error_detail

--- a/src/query/auth/useSocialLoginMutation.ts
+++ b/src/query/auth/useSocialLoginMutation.ts
@@ -1,0 +1,60 @@
+import { useNavigate } from 'react-router'
+
+import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
+
+import {
+  authApi,
+  type FieldErrorResponse,
+  type GoogleLoginCallbackRequest,
+  type KakaoLoginCallbackRequest,
+  type LoginResponse,
+  type LoginUnauthorizedResponse,
+  type NaverLoginCallbackRequest,
+} from '@/apis/auth'
+import { yellowCharacterImage } from '@/assets/images'
+import { useToast } from '@/components/common/ui'
+import { useAuthStore } from '@/store/authStore'
+
+type SocialLoginVariables =
+  | {
+      provider: 'kakao'
+      payload: KakaoLoginCallbackRequest
+    }
+  | {
+      provider: 'naver'
+      payload: NaverLoginCallbackRequest
+    }
+  | {
+      provider: 'google'
+      payload: GoogleLoginCallbackRequest
+    }
+
+export function useSocialLoginMutation() {
+  const toast = useToast()
+  const navigate = useNavigate()
+  const setSession = useAuthStore((state) => state.setSession)
+
+  // 현재는 OAuth redirect가 아니라 MSW callback endpoint를 직접 호출하는 임시 흐름입니다.
+  // 추후 실제 소셜 로그인 API가 붙으면 로그인 시작 URL 이동 또는 callback 페이지 처리로 교체될 자리입니다.
+  return useMutation<
+    LoginResponse,
+    AxiosError<FieldErrorResponse | LoginUnauthorizedResponse>,
+    SocialLoginVariables
+  >({
+    mutationFn: ({ provider, payload }) =>
+      authApi.socialLoginCallback(provider, payload),
+    onSuccess: (data, variables) => {
+      // 현재 소셜 로그인 응답에는 access_token만 있어서 닉네임/프로필은 임시값으로 표시합니다.
+      // 추후 내 정보 API가 붙으면 로그인 직후 사용자 정보를 조회해 이 값을 교체하면 됩니다.
+      setSession(data.access_token, {
+        nickname: `${variables.provider} 사용자`,
+        profileImageUrl: yellowCharacterImage,
+      })
+      navigate('/')
+    },
+    onError: () => {
+      toast.error('소셜 로그인에 실패했습니다.')
+    },
+  })
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type AuthUser = {
+  nickname: string
+  profileImageUrl: string
+}
+
+type AuthState = {
+  accessToken: string | null
+  user: AuthUser | null
+  setSession: (accessToken: string, user: AuthUser) => void
+  clearSession: () => void
+}
+
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      accessToken: null,
+      user: null,
+      setSession: (accessToken, user) => set({ accessToken, user }),
+      clearSession: () => set({ accessToken: null, user: null }),
+    }),
+    {
+      name: 'auth-session',
+    }
+  )
+)


### PR DESCRIPTION
## 📌 관련 이슈

Closes #97

## ✨ 변경 내용

  - 로그인 MSW 핸들러 및 mock 데이터 연결
  - 일반 로그인 / 소셜 로그인 mutation 흐름 추가
  - 로그인 성공 시 access token을 auth store에 임시 저장
  - Header, Toast, index.css 테마 관련 UI 스타일 조정

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/db483d4a-fb4e-43b4-83b1-044429412787

## 📚 참고사항
  - 소셜 로그인은 실제 OAuth 연동 전 단계로, MSW mock payload를 사용해 임시 로그인 흐름을 구성했습니다.
  - 로그인 성공 시 발급되는 access token은 추후 API 인증 연동을 고려해 auth store에 임시 저장하도록 처리했습니다.
  - 현재 access token 저장 방식은 개발 단계용이며, 실제 배포 전 보안 정책에 맞춰 저장 위치 및 만료 처리 방식 검토가 필요합니다.
  - 로그인 테스트 코드는 일반 로그인 성공/실패 케이스와 소셜 로그인 mock 응답 흐름을 기준으로 추가했습니다.
  -  Action button 컴포넌트 className 추가  
  - 토스트 관련 css 는 다시 한번 확인해보겠습니다 가운데 정렬이 안되어 우선 급한대로 index.css 랑 토스트 UI 변경했습니다