### PR TITLE
feat: add comment ui components

### DIFF
--- a/src/components/common/ui/button/Button.style.ts
+++ b/src/components/common/ui/button/Button.style.ts
@@ -22,6 +22,8 @@ export const buttonVariants = cva(
 
         modal:
           'bg-button-modal-cancel-bg text-white hover:bg-button-modal-cancel-hover',
+
+        submit: 'bg-gray-400 text-white hover:bg-button-primary-bg',
       },
 
       size: {

--- a/src/components/common/ui/comment/Comment.type.ts
+++ b/src/components/common/ui/comment/Comment.type.ts
@@ -1,0 +1,10 @@
+export type Comment = {
+  id: number
+  user_id?: number
+  nickname: string
+  content: string
+  created_at: string
+  like_count: number
+  is_liked: boolean
+  profile_image_url: string | null
+}

--- a/src/components/common/ui/comment/CommentInput.tsx
+++ b/src/components/common/ui/comment/CommentInput.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+
+import { Button } from '@/components/common/ui/button/Button'
+import { Textarea } from '@/components/common/ui/field/Textarea'
+
+type CommentInputProps = {
+  onSubmit: (content: string) => void
+  maxLength?: number
+  isLoading?: boolean
+  placeholder?: string
+  profileImageUrl?: string | null
+  nickname?: string
+}
+
+export function CommentInput({
+  onSubmit,
+  maxLength = 500,
+  isLoading = false,
+  placeholder = '댓글을 입력해주세요',
+  profileImageUrl,
+  nickname,
+}: CommentInputProps) {
+  const [value, setValue] = useState('')
+
+  const isDisabled = value.trim().length === 0 || isLoading
+
+  const handleSubmit = () => {
+    if (isDisabled) return
+
+    onSubmit(value.trim())
+    setValue('')
+  }
+
+  return (
+    <div className="flex gap-3">
+      {/* 프로필 (나중에 사용자 정보로 교체 가능) */}
+      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full bg-gray-200">
+        {profileImageUrl ? (
+          <img
+            src={profileImageUrl}
+            alt={nickname ? `${nickname}의 프로필 이미지` : '프로필 이미지'}
+            className="h-full w-full object-cover"
+          />
+        ) : null}
+      </div>
+
+      {/* 입력 영역 */}
+      <div className="flex flex-1 flex-col gap-2">
+        <Textarea
+          className="bg-gray-100 focus:bg-white"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={placeholder}
+          maxLength={maxLength}
+        />
+
+        {/* 하단 영역 */}
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-text-muted">
+            {value.length}/{maxLength}
+          </span>
+          <Button
+            variant="submit"
+            size="sm"
+            rounded="full"
+            onClick={handleSubmit}
+            disabled={isDisabled}
+          >
+            등록
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/ui/comment/CommentItem.tsx
+++ b/src/components/common/ui/comment/CommentItem.tsx
@@ -1,0 +1,115 @@
+import { Heart, MoreHorizontal } from 'lucide-react'
+
+import { Button } from '@/components/common/ui/button/Button'
+import { cn } from '@/utils/cn'
+
+import type { Comment } from './Comment.type'
+
+const formatTime = (dateString: string) => {
+  const now = new Date()
+  const date = new Date(dateString)
+
+  const diff = Math.floor((now.getTime() - date.getTime()) / 1000)
+
+  {
+    /* 분리예정 */
+  }
+  if (diff < 60) return '방금 전'
+  if (diff < 3600) return `${Math.floor(diff / 60)}분 전`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}시간 전`
+  return `${Math.floor(diff / 86400)}일 전`
+}
+
+type CommentItemProps = {
+  comment: Comment
+  isOwner?: boolean
+  isSelected?: boolean
+  onSelect?: () => void
+  onLike?: (id: number) => void
+  onDelete?: (id: number) => void
+}
+
+export function CommentItem({
+  comment,
+  isOwner = false,
+  isSelected = false,
+  onSelect,
+  onLike,
+  onDelete,
+}: CommentItemProps) {
+  const {
+    id,
+    nickname,
+    content,
+    created_at,
+    like_count,
+    is_liked,
+    profile_image_url,
+  } = comment
+
+  return (
+    <div
+      className={cn(
+        'flex gap-3 rounded-xl  px-4 py-3',
+        isSelected && 'bg-primary-100/50'
+      )}
+      onClick={() => onSelect?.()}
+    >
+      {/* 프로필 */}
+      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full bg-gray-200">
+        {profile_image_url ? (
+          <img
+            src={profile_image_url}
+            alt={`${nickname}의 프로필 이미지`}
+            className="h-full w-full object-cover"
+          />
+        ) : null}
+      </div>
+
+      {/* 내용 */}
+      <div className="flex flex-1 flex-col gap-1">
+        {/* 상단 */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-text-primary">
+              {nickname}
+            </span>
+            <span className="text-xs text-text-muted">
+              {formatTime(created_at)}
+            </span>
+          </div>
+
+          {/* 더보기 */}
+          {isOwner ? (
+            <Button variant="ghost" size="sm" onClick={() => onDelete?.(id)}>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          ) : null}
+        </div>
+
+        {/* 본문 */}
+        <p className="text-sm text-text-primary">{content}</p>
+
+        {/* 하단 액션 */}
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onLike?.(id)}
+            className="flex items-center gap-1"
+            aria-label="댓글 좋아요"
+          >
+            <Heart
+              className={cn(
+                'h-4 w-4',
+                is_liked
+                  ? 'fill-primary-500 text-primary-500'
+                  : 'text-text-muted'
+              )}
+            />
+            <span className="text-xs text-text-muted">{like_count}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/ui/comment/CommentList.tsx
+++ b/src/components/common/ui/comment/CommentList.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+
+import type { Comment } from './Comment.type'
+import { CommentItem } from './CommentItem'
+
+type CommentListProps = {
+  comments: Comment[]
+  currentUserId?: number
+  isLoading?: boolean
+  emptyMessage?: string
+  onLike?: (id: number) => void
+  onDelete?: (id: number) => void
+}
+
+export function CommentList({
+  comments,
+  currentUserId,
+  isLoading = false,
+  emptyMessage = '아직 댓글이 없어요. 첫 댓글을 남겨보세요.',
+  onLike,
+  onDelete,
+}: CommentListProps) {
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+
+  if (isLoading) {
+    return (
+      <div className="py-6 text-center text-sm text-text-muted">
+        댓글을 불러오는 중입니다.
+      </div>
+    )
+  }
+
+  if (comments.length === 0) {
+    return (
+      <div className="py-6 text-center text-sm text-text-muted">
+        {emptyMessage}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {comments.map((comment) => (
+        <CommentItem
+          key={comment.id}
+          comment={comment}
+          isOwner={!!currentUserId && currentUserId === comment.user_id}
+          isSelected={selectedId === comment.id}
+          onSelect={() => setSelectedId(comment.id)}
+          onLike={onLike}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/common/ui/comment/index.ts
+++ b/src/components/common/ui/comment/index.ts
@@ -1,0 +1,4 @@
+export type { Comment } from './Comment.type'
+export { CommentInput } from './CommentInput'
+export { CommentItem } from './CommentItem'
+export { CommentList } from './CommentList'

--- a/src/components/common/ui/index.ts
+++ b/src/components/common/ui/index.ts
@@ -9,6 +9,8 @@ export type {
   PostCardProps,
 } from './card'
 export { Card, type CardProps, GoalCard, GoalCardEdit, PostCard } from './card'
+export type { Comment } from './comment'
+export { CommentInput, CommentItem, CommentList } from './comment'
 export { Input, type InputProps } from './field/Input'
 export { SearchBar, type SearchBarProps } from './field/SearchBar'
 export { Textarea, type TextareaProps } from './field/Textarea'


### PR DESCRIPTION
## 📌 관련 이슈

Closes #84 

## ✨ 변경 내용
- 댓글 UI 공통 컴포넌트 추가
  - CommentInput
  - CommentList
  - CommentItem
- 댓글 선택 상태 배경 스타일 적용
- 프로필 이미지, 좋아요 버튼, 더보기 버튼 UI 반영
- 공통 ui index export 추가
- 댓글 등록 버튼 스타일 variant 추가

## 📸 스크린샷

https://github.com/user-attachments/assets/f983d67f-5216-4308-aa08-5432c6b47591

## 📚 참고사항

- 댓글 데이터는 현재 UI 확인용 구조로 작성했으며, 실제 API 연동은 후속 작업에서 진행 예정입니다.
- 시간 표시는 현재 컴포넌트 내부 임시 포맷 로직을 사용하고 있으며, 추후 공통 util로 분리 예정입니다.
- 선택 상태 배경은 추후 수정/답글 등 상태 기반 UI와 연결 예정입니다.
- 더보기 버튼 클릭 시 실제 드롭다운(수정/삭제/신고) 플로우는 후속 작업에서 구현 예정입니다.