### PR TITLE
feat: add ranking, post msw handler and type

### DIFF
--- a/src/apis/api.types.ts
+++ b/src/apis/api.types.ts
@@ -1,0 +1,6 @@
+// 백엔드 공통 에러 응답 형식은 두가지 타입
+// - 필드 레벨: { error_detail: { sort_by: ["정렬 기준이 올바르지 않습니다."] } }
+// - 단순 메시지: { error_detail: "해당하는 게시글이 없습니다." }
+export type ApiErrorResponse = {
+  error_detail: Record<string, string[]> | string
+}

--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -1,5 +1,9 @@
 import { apiClient } from '@/apis/apiClient'
 import type {
+  ApiPostListParams,
+  ApiPostListResponse,
+} from '@/features/main/post-list/post-list.api.types'
+import type {
   ApiGoalResponse,
   ApiPostCreateRequest,
   ApiPostCreateResponse,
@@ -11,15 +15,23 @@ import type {
 import { POST_ENDPOINTS } from './endpoints'
 
 export const postApi = {
+  // 전체 목표 조회
   getGoals: () => apiClient.get<ApiGoalResponse[]>(POST_ENDPOINTS.goals),
 
+  // 전체 태그 조회
   getTags: () => apiClient.get<ApiTagResponse[]>(POST_ENDPOINTS.tags),
 
+  // 단일 게시글 조회
   getPost: (postId: number) =>
     apiClient.get<ApiPostResponse>(POST_ENDPOINTS.post(postId)),
 
+  // 게시글 생성
   createPost: (body: ApiPostCreateRequest) =>
     apiClient.post<ApiPostCreateResponse>(POST_ENDPOINTS.posts, body),
+
+  // 게시글 목록 조회
+  getPosts: (params?: ApiPostListParams) =>
+    apiClient.get<ApiPostListResponse>(POST_ENDPOINTS.posts, { params }),
 
   updatePost: (postId: number, body: ApiPostUpdateRequest) =>
     apiClient.patch<void>(POST_ENDPOINTS.post(postId), body),

--- a/src/apis/ranking/endpoints.ts
+++ b/src/apis/ranking/endpoints.ts
@@ -1,0 +1,8 @@
+import type { RankingType } from '@/features/main/ranking'
+
+export const RANKING_ENDPOINTS = {
+  ranking: (type: RankingType) => `/statics/rankings/${type}`,
+  // ranking()은 RankingType만 허용해 ':rankingType' 같은 MSW 패턴 문자열을 넘길 수 없으므로
+  // MSW 핸들러 전용 패턴 경로를 별도 분리
+  rankingPattern: '/statics/rankings/:rankingType',
+} as const

--- a/src/apis/ranking/index.ts
+++ b/src/apis/ranking/index.ts
@@ -1,0 +1,2 @@
+export { RANKING_ENDPOINTS } from './endpoints'
+export { rankingApi } from './ranking.api'

--- a/src/apis/ranking/ranking.api.ts
+++ b/src/apis/ranking/ranking.api.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@/apis/apiClient'
+import type { RankingType, RankingUser } from '@/features/main/ranking'
+
+import { RANKING_ENDPOINTS } from './endpoints'
+import type { ApiRankingResponse } from './ranking.api.types'
+
+export const rankingApi = {
+  getRanking: async (type: RankingType): Promise<RankingUser[]> => {
+    const response = await apiClient.get<ApiRankingResponse>(
+      RANKING_ENDPOINTS.ranking(type)
+    )
+    return response.data.detail.rankings as RankingUser[]
+  },
+} as const

--- a/src/apis/ranking/ranking.api.types.ts
+++ b/src/apis/ranking/ranking.api.types.ts
@@ -1,0 +1,38 @@
+// GET /api/v1/statics/rankings/weekly
+export type ApiWeeklyRankingUser = {
+  user_id: number
+  nickname: string
+  profile_img_url: string | null
+  rank: number
+  week_cert_count: number
+}
+
+// GET /api/v1/statics/rankings/monthly
+export type ApiMonthlyRankingUser = {
+  user_id: number
+  nickname: string
+  profile_img_url: string | null
+  rank: number
+  month_cert_count: number
+}
+
+// GET /api/v1/statics/rankings/total
+export type ApiTotalRankingUser = {
+  user_id: number
+  nickname: string
+  profile_img_url: string | null
+  rank: number
+  total_cert_count: number
+}
+
+export type ApiRankingItem =
+  | ApiWeeklyRankingUser
+  | ApiMonthlyRankingUser
+  | ApiTotalRankingUser
+
+// GET /api/v1/statics/rankings/:type — 200 OK
+export type ApiRankingResponse = {
+  detail: {
+    rankings: ApiRankingItem[]
+  }
+}

--- a/src/components/common/ui/card/Card.tsx
+++ b/src/components/common/ui/card/Card.tsx
@@ -6,7 +6,7 @@ export function Card({ className, children, ...props }: CardProps) {
   return (
     <div
       className={cn(
-        'w-69 h-85 px-2.5 py-3 rounded-2xl bg-surface border border-border-default hover:shadow-card-light hover:border-border-active transition-colors',
+        'w-full px-2.5 py-3 rounded-2xl bg-surface border border-border-default hover:shadow-card-light hover:border-border-active transition-colors',
         className
       )}
       {...props}

--- a/src/components/common/ui/card/PostCard.stories.tsx
+++ b/src/components/common/ui/card/PostCard.stories.tsx
@@ -16,15 +16,15 @@ const baseProps = {
   nickname: '작심며칠',
   createdAt: '3시간 전',
   title: '운동 vs 공부 뭐부터 할까? 진짜 너무 고민된다 아무것도 못하겠어',
-  preview:
+  contentPreview:
     '오늘부터 마음 다시 잡으려고 합니다 운동이랑 공부 중에 뭐부터 시작하면 좋을까요. 사실 둘 다 하고 싶긴 한데 체력이 딸려서 고민이에요. 여러분은 어떻게 하시나요?',
   tags: ['공부', '운동'],
   likeCount: 10,
   commentCount: 0,
-  isBookmarked: false,
+  isScrapped: false,
   onLike: () => {},
   onShare: () => {},
-  onBookmark: () => {},
+  onScrap: () => {},
 }
 
 export const WithImage: Story = {
@@ -38,7 +38,7 @@ export const WithoutImage: Story = {
 }
 
 export const Bookmarked: Story = {
-  render: () => <PostCard {...baseProps} isBookmarked />,
+  render: () => <PostCard {...baseProps} isScrapped />,
 }
 
 export const DarkWithImage: Story = {

--- a/src/components/common/ui/card/PostCard.tsx
+++ b/src/components/common/ui/card/PostCard.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-
 import { Bookmark, Heart, MessageCircle, Share2 } from 'lucide-react'
 
 import { Button } from '@/components/common/ui'
@@ -7,172 +5,213 @@ import { cn } from '@/utils/cn'
 
 import { Card } from './Card'
 import type { PostCardProps } from './PostCard.types'
+import { usePostCardActions } from './usePostCardActions'
 
-export type { PostCardProps } from './PostCard.types'
+export function PostCard(props: PostCardProps) {
+  const {
+    image,
+    profileImage,
+    nickname,
+    createdAt,
+    title,
+    tags,
+    contentPreview,
+    likeCount,
+    commentCount,
+    isScrapped = false,
+    isLiked = false,
+    onClick,
+    onLike,
+    onShare,
+    onScrap,
+  } = props
 
-export function PostCard({
-  image,
-  profileImage,
-  nickname,
-  createdAt,
-  title,
-  tags,
-  preview,
-  likeCount,
-  commentCount,
-  isBookmarked = false, // 스크랩 여부
-  isLiked = false, // 좋아요 여부
-  onClick, // 게시글 클릭 시 이동할 페이지로 이동
-  onLike, // 좋아요 버튼 클릭 시
-  onShare, // 공유 버튼 클릭 시
-  onBookmark, // 스크랩 버튼 클릭 시
-}: PostCardProps) {
-  const [bookmarked, setBookmarked] = useState(isBookmarked)
-  const [liked, setLiked] = useState(isLiked)
-  const [localLikeCount, setLocalLikeCount] = useState(likeCount)
-
-  // API 연결 시 낙관적 업데이트나 useEffect 등으로 동기화 처리가 필요
-  const toggleLike = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    setLocalLikeCount((prev) => (liked ? prev - 1 : prev + 1))
-    setLiked((prev) => !prev)
-    onLike()
-  }
-
-  const toggleBookmark = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    setBookmarked((prev) => !prev)
-    onBookmark()
-  }
-
-  const handleShare = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    onShare()
-  }
+  const {
+    liked,
+    scrapped,
+    localLikeCount,
+    toggleLike,
+    toggleScrap,
+    handleShare,
+  } = usePostCardActions({
+    likeCount,
+    isLiked,
+    isScrapped,
+    onLike,
+    onScrap,
+    onShare,
+  })
 
   return (
     <Card
-      className="p-0 h-84.5 overflow-hidden flex flex-col cursor-pointer"
+      className="p-0 h-84 overflow-hidden flex flex-col cursor-pointer"
       onClick={onClick}
     >
-      {/* 이미지 (선택) */}
-      {image && (
-        <img
-          src={image}
-          alt={`${title} 이미지`}
-          loading="lazy"
-          className="w-full h-32 object-cover shrink-0"
-        />
-      )}
+      <PostCardImage src={image} title={title} />
 
-      {/* 게시글 내용 */}
       <div className="flex flex-col flex-1 min-h-0 px-4 py-5">
-        {/* 프로필 */}
-        <div className="flex items-center gap-2 mb-2">
-          <img
-            src={profileImage}
-            alt={nickname}
-            loading="lazy"
-            className="size-7 rounded-full object-cover shrink-0"
-          />
-          <div className="min-w-0 text-2xs">
-            <p className="font-semibold text-text-primary truncate">
-              {nickname}
-            </p>
-            {/* TODO: 시간 포맷 변경 필요 -> 2026.04.14 12:00 로 할건지 몇시간 전, 몇일 전으로 할건지 정해지면 */}
-            <p className="text-text-muted">{createdAt}</p>
-          </div>
-        </div>
+        <PostCardProfile
+          image={profileImage}
+          nickname={nickname}
+          createdAt={createdAt}
+        />
 
-        {/* 제목 */}
         <h3 className="text-text-primary line-clamp-1 mb-0 font-semibold">
           {title}
         </h3>
 
-        {/* 태그 */}
-        {tags.length > 0 && (
-          <div className="flex flex-wrap text-xs text-text-muted gap-1 mb-3">
-            {tags.map((tag) => (
-              <span key={tag}>#{tag}</span>
-            ))}
-          </div>
-        )}
+        <PostCardTags tags={tags} />
 
-        {/* 내용 미리보기 */}
-        <p className="text-sm text-text-muted line-clamp-2">{preview}</p>
+        <p className="text-sm text-text-muted line-clamp-2">{contentPreview}</p>
       </div>
 
-      {/* 하단 액션 */}
-      <div className="flex items-center border-t border-border-default px-3 py-1.5">
-        <div className="flex items-center gap-3">
-          {/* 좋아요 */}
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              aria-label="좋아요"
-              aria-pressed={liked}
-              className="group p-0 hover:bg-transparent"
-              onClick={toggleLike}
-            >
-              <Heart
-                size={20}
-                className={cn(
-                  liked ? 'fill-current text-error-500' : 'text-text-primary',
-                  'transition-transform duration-200 group-hover:scale-110'
-                )}
-              />
-            </Button>
-            <span className="tabular-nums text-sm text-text-primary">
-              {localLikeCount}
-            </span>
-          </div>
-
-          {/* 댓글 */}
-          <div className="flex items-center gap-1">
-            <MessageCircle
-              size={20}
-              className="text-text-primary hover:scale-110 transition-transform duration-200"
-            />
-            <span className="tabular-nums text-sm text-text-primary">
-              {commentCount}
-            </span>
-          </div>
-
-          {/* 공유 */}
-          <Button
-            variant="ghost"
-            size="sm"
-            aria-label="공유하기"
-            className="group p-0 hover:bg-transparent"
-            onClick={handleShare}
-          >
-            <Share2
-              size={20}
-              className="text-text-primary transition-transform duration-200 group-hover:scale-110"
-            />
-          </Button>
-
-          <Button
-            variant="ghost"
-            size="sm"
-            aria-label={bookmarked ? '스크랩 취소' : '스크랩'}
-            aria-pressed={bookmarked}
-            className="group p-0 hover:bg-transparent"
-            onClick={toggleBookmark}
-          >
-            <Bookmark
-              size={20}
-              className={cn(
-                bookmarked
-                  ? 'fill-current text-primary-600'
-                  : 'text-text-primary',
-                'transition-transform duration-200 group-hover:scale-110'
-              )}
-            />
-          </Button>
-        </div>
-      </div>
+      <PostCardFooter
+        liked={liked}
+        likeCount={localLikeCount}
+        commentCount={commentCount}
+        scrapped={scrapped}
+        onLike={toggleLike}
+        onShare={handleShare}
+        onScrap={toggleScrap}
+      />
     </Card>
   )
 }
+
+// --- 내부 서브 컴포넌트 ---
+
+const PostCardImage = ({ src, title }: { src?: string; title: string }) => {
+  if (!src) return null
+  return (
+    <div className="w-full h-32 shrink-0 bg-border-default overflow-hidden">
+      <img
+        src={src}
+        alt={`${title} 이미지`}
+        loading="lazy"
+        decoding="async"
+        className="size-full object-cover"
+      />
+    </div>
+  )
+}
+
+const PostCardProfile = ({
+  image,
+  nickname,
+  createdAt,
+}: {
+  image: string
+  nickname: string
+  createdAt: string
+}) => (
+  <div className="flex items-center gap-2 mb-2">
+    <img
+      src={image}
+      alt={nickname}
+      loading="lazy"
+      decoding="async"
+      className="size-7 rounded-full object-cover shrink-0"
+    />
+    <div className="min-w-0 text-2xs">
+      <p className="font-semibold text-text-primary truncate">{nickname}</p>
+      <p className="text-text-muted">{createdAt}</p>
+    </div>
+  </div>
+)
+
+const PostCardTags = ({ tags }: { tags: string[] }) => {
+  if (tags.length === 0) return null
+  return (
+    <div className="flex flex-wrap text-xs text-text-muted gap-1 mb-3">
+      {tags.map((tag) => (
+        <span key={tag}>#{tag}</span>
+      ))}
+    </div>
+  )
+}
+
+type PostCardFooterProps = {
+  liked: boolean
+  likeCount: number
+  commentCount: number
+  scrapped: boolean
+  onLike: (e: React.MouseEvent<HTMLButtonElement>) => void
+  onShare: (e: React.MouseEvent<HTMLButtonElement>) => void
+  onScrap: (e: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+const PostCardFooter = ({
+  liked,
+  likeCount,
+  commentCount,
+  scrapped,
+  onLike,
+  onShare,
+  onScrap,
+}: PostCardFooterProps) => (
+  <div className="flex items-center border-t border-border-default px-3 py-1.5 mt-auto">
+    <div className="flex items-center gap-3">
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="좋아요"
+          aria-pressed={liked}
+          className="group p-0 hover:bg-transparent"
+          onClick={onLike}
+        >
+          <Heart
+            size={20}
+            className={cn(
+              liked ? 'fill-current text-error-500' : 'text-text-primary',
+              'transition-transform duration-200 group-hover:scale-110'
+            )}
+          />
+        </Button>
+        <span className="tabular-nums text-sm text-text-primary">
+          {likeCount}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-1">
+        <MessageCircle
+          size={20}
+          className="text-text-primary hover:scale-110 transition-transform duration-200"
+        />
+        <span className="tabular-nums text-sm text-text-primary">
+          {commentCount}
+        </span>
+      </div>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label="공유하기"
+        className="group p-0 hover:bg-transparent"
+        onClick={onShare}
+      >
+        <Share2
+          size={20}
+          className="text-text-primary transition-transform duration-200 group-hover:scale-110"
+        />
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-label={scrapped ? '스크랩 취소' : '스크랩'}
+        aria-pressed={scrapped}
+        className="group p-0 hover:bg-transparent"
+        onClick={onScrap}
+      >
+        <Bookmark
+          size={20}
+          className={cn(
+            scrapped ? 'fill-current text-primary-600' : 'text-text-primary',
+            'transition-transform duration-200 group-hover:scale-110'
+          )}
+        />
+      </Button>
+    </div>
+  </div>
+)

--- a/src/components/common/ui/card/PostCard.tsx
+++ b/src/components/common/ui/card/PostCard.tsx
@@ -7,25 +7,23 @@ import { Card } from './Card'
 import type { PostCardProps } from './PostCard.types'
 import { usePostCardActions } from './usePostCardActions'
 
-export function PostCard(props: PostCardProps) {
-  const {
-    image,
-    profileImage,
-    nickname,
-    createdAt,
-    title,
-    tags,
-    contentPreview,
-    likeCount,
-    commentCount,
-    isScrapped = false,
-    isLiked = false,
-    onClick,
-    onLike,
-    onShare,
-    onScrap,
-  } = props
-
+export function PostCard({
+  image,
+  profileImage,
+  nickname,
+  createdAt,
+  title,
+  tags,
+  contentPreview,
+  likeCount,
+  commentCount,
+  isScrapped = false,
+  isLiked = false,
+  onClick,
+  onLike,
+  onShare,
+  onScrap,
+}: PostCardProps) {
   const {
     liked,
     scrapped,

--- a/src/components/common/ui/card/PostCard.types.ts
+++ b/src/components/common/ui/card/PostCard.types.ts
@@ -5,13 +5,13 @@ export type PostCardProps = {
   createdAt: string
   title: string
   tags: string[]
-  preview: string
+  contentPreview: string
   likeCount: number
   commentCount: number
-  isBookmarked?: boolean
+  isScrapped?: boolean
   isLiked?: boolean
   onClick?: () => void
   onLike: () => void
   onShare: () => void
-  onBookmark: () => void
+  onScrap: () => void
 }

--- a/src/components/common/ui/card/PostCardSkeleton.tsx
+++ b/src/components/common/ui/card/PostCardSkeleton.tsx
@@ -1,0 +1,5 @@
+export function PostCardSkeleton() {
+  return (
+    <div className="w-full h-84 animate-pulse rounded-2xl border border-border-default bg-border-default" />
+  )
+}

--- a/src/components/common/ui/card/index.ts
+++ b/src/components/common/ui/card/index.ts
@@ -6,4 +6,5 @@ export {
   type GoalStatus,
 } from './GoalCard.types'
 export { GoalCardEdit } from './GoalCardEdit'
-export { PostCard, type PostCardProps } from './PostCard'
+export { PostCard } from './PostCard'
+export { PostCardSkeleton } from './PostCardSkeleton'

--- a/src/components/common/ui/card/usePostCardActions.ts
+++ b/src/components/common/ui/card/usePostCardActions.ts
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+
+type UsePostCardActionsProps = {
+  likeCount: number
+  isLiked: boolean
+  isScrapped: boolean
+  onLike: () => void
+  onScrap: () => void
+  onShare: () => void
+}
+
+export function usePostCardActions({
+  likeCount,
+  isLiked,
+  isScrapped,
+  onLike,
+  onScrap,
+  onShare,
+}: UsePostCardActionsProps) {
+  const [liked, setLiked] = useState(isLiked)
+  const [scrapped, setScrapped] = useState(isScrapped)
+  // 사용자 기준 count 값 --> like API 연동 후 필요없어질 상태
+  const [localLikeCount, setLocalLikeCount] = useState(likeCount)
+
+  const toggleLike = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const newLiked = !liked
+    setLiked(newLiked)
+    setLocalLikeCount((prev) => (newLiked ? prev + 1 : prev - 1))
+    onLike()
+  }
+
+  const toggleScrap = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setScrapped((prev) => !prev)
+    onScrap()
+  }
+
+  const handleShare = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onShare()
+  }
+
+  return {
+    liked,
+    scrapped,
+    localLikeCount,
+    toggleLike,
+    toggleScrap,
+    handleShare,
+  }
+}

--- a/src/components/common/ui/index.ts
+++ b/src/components/common/ui/index.ts
@@ -3,12 +3,18 @@ export { Badge } from './badge/Badge'
 export { Button } from './button/Button'
 export { Calendar } from './calendar/Calendar'
 export type {
+  CardProps,
   GoalCardEditProps,
   GoalCardProps,
   GoalStatus,
-  PostCardProps,
 } from './card'
-export { Card, type CardProps, GoalCard, GoalCardEdit, PostCard } from './card'
+export {
+  Card,
+  GoalCard,
+  GoalCardEdit,
+  PostCard,
+  PostCardSkeleton,
+} from './card'
 export type { Comment } from './comment'
 export { CommentInput, CommentItem, CommentList } from './comment'
 export { Input, type InputProps } from './field/Input'

--- a/src/features/main/post-list/post-list.api.types.ts
+++ b/src/features/main/post-list/post-list.api.types.ts
@@ -1,0 +1,31 @@
+// GET /api/v1/posts — 게시글 목록 조회 시 개별 항목
+export type ApiPostListItem = {
+  post_id: number
+  images: string[]
+  profile_image_url: string | null
+  nickname: string
+  created_at: string
+  title: string
+  tags: string[]
+  content_preview: string
+  like_count: number
+  comment_count: number
+  // is_liked: boolean 존재 해야 하는데 like API 만들어지면 추가 예정
+  is_scrapped: boolean
+}
+
+// GET /api/v1/posts — 게시글 목록 응답
+export type ApiPostListResponse = {
+  posts: ApiPostListItem[]
+  page: number
+  size: number
+  total_count: number
+}
+
+// GET /api/v1/posts — 요청 쿼리 파라미터
+export type ApiPostListParams = {
+  scope?: string
+  sortBy?: string
+  page?: number
+  size?: number
+}

--- a/src/features/main/ranking/index.ts
+++ b/src/features/main/ranking/index.ts
@@ -1,2 +1,2 @@
 export type { RankingType, RankingUser } from './Ranking.types'
-export { RankingSection } from './RankingSection'
+// export { RankingSection } from './RankingSection'

--- a/src/features/main/ranking/index.ts
+++ b/src/features/main/ranking/index.ts
@@ -1,2 +1,2 @@
-export { Ranking } from './Ranking'
-export type { RankingProps, RankingType } from './Ranking.types'
+export type { RankingType, RankingUser } from './Ranking.types'
+export { RankingSection } from './RankingSection'

--- a/src/mocks/data/post.ts
+++ b/src/mocks/data/post.ts
@@ -1,8 +1,25 @@
+import type { ApiPostListItem } from '@/features/main/post-list/post-list.api.types'
 import type {
   ApiGoalResponse,
   ApiPostResponse,
   ApiTagResponse,
 } from '@/features/post/post.api.types'
+
+const PLACEHOLDER_COLORS = [
+  '%23f87171',
+  '%2360a5fa',
+  '%2334d399',
+  '%23fbbf24',
+  '%23a78bfa',
+  '%23f472b6',
+  '%2338bdf8',
+  '%234ade80',
+]
+
+function makePlaceholderImage(index: number): string {
+  const color = PLACEHOLDER_COLORS[index % PLACEHOLDER_COLORS.length]
+  return `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='300'%3E%3Crect width='400' height='300' fill='${color}' opacity='0.3'/%3E%3C/svg%3E`
+}
 
 export const mockGoals: ApiGoalResponse[] = [
   {
@@ -43,6 +60,121 @@ export const mockTags: ApiTagResponse[] = [
   { id: 3, name: '공부' },
   { id: 4, name: '식단' },
   { id: 5, name: '명상' },
+]
+
+export const mockPostList: ApiPostListItem[] = [
+  {
+    post_id: 301,
+    images: ['https://picsum.photos/seed/post301/600/400'],
+    profile_image_url: null,
+    nickname: '운동왕',
+    created_at: '2026-04-20',
+    title: '오늘의 헬스 인증!',
+    tags: ['헬스', '운동'],
+    content_preview:
+      '오늘도 열심히 운동했습니다. 벤치프레스 100kg 달성! 목표를 향해 꾸준히 달려가겠습니다.',
+    like_count: 1,
+    comment_count: 8,
+    is_scrapped: false,
+  },
+  {
+    post_id: 302,
+    images: [],
+    profile_image_url: null,
+    nickname: '달리기선수',
+    created_at: '2026-04-19',
+    title: '10km 달리기 완주 (이미지 없음 테스트)',
+    tags: ['러닝', '마라톤'],
+    content_preview:
+      '오늘 새벽 6시에 일어나서 10km를 달렸습니다. 날씨가 너무 좋아서 기분이 최고였어요.',
+    like_count: 35,
+    comment_count: 5,
+    is_scrapped: true,
+  },
+  {
+    post_id: 303,
+    images: ['https://picsum.photos/seed/post303/600/600'],
+    profile_image_url: null,
+    nickname: '요가고수',
+    created_at: '2026-04-18',
+    title: '요가 1시간 인증',
+    tags: ['요가', '명상', '스트레칭'],
+    content_preview:
+      '아침 요가로 하루를 시작했습니다. 몸과 마음이 맑아지는 느낌이에요.',
+    like_count: 28,
+    comment_count: 3,
+    is_scrapped: false,
+  },
+  {
+    post_id: 304,
+    images: [],
+    profile_image_url: null,
+    nickname: '헬스마니아',
+    created_at: '2026-04-17',
+    title: '스쿼트 200개 챌린지 성공 (이미지 없음 테스트)',
+    tags: ['스쿼트', '하체운동'],
+    content_preview:
+      '드디어 스쿼트 200개 챌린지를 완료했습니다! 허벅지가 떨리지만 너무 뿌듯합니다.',
+    like_count: 61,
+    comment_count: 12,
+    is_scrapped: false,
+  },
+  {
+    post_id: 306,
+    images: ['https://picsum.photos/seed/post306/400/800'],
+    profile_image_url: null,
+    nickname: '수영러버',
+    created_at: '2026-04-16',
+    title: '수영 1km 완주 기록',
+    tags: ['수영', '유산소'],
+    content_preview:
+      '오늘 수영장에서 1km를 쉬지 않고 완주했습니다. 자유형 위주로 훈련 중이에요.',
+    like_count: 19,
+    comment_count: 6,
+    is_scrapped: false,
+  },
+  {
+    post_id: 307,
+    images: [makePlaceholderImage(5)],
+    profile_image_url: null,
+    nickname: '운동왕',
+    created_at: '2026-04-15',
+    title: '줄넘기 500회 인증',
+    tags: ['줄넘기', '유산소'],
+    content_preview:
+      '오늘 줄넘기 500회를 달성했습니다. 30분 만에 완료! 다음 목표는 1000회입니다.',
+    like_count: 33,
+    comment_count: 9,
+    is_scrapped: false,
+  },
+  {
+    post_id: 308,
+    images: [makePlaceholderImage(6)],
+    profile_image_url: null,
+    nickname: '달리기선수',
+    created_at: '2026-04-14',
+    title: '풀업 20개 달성',
+    tags: ['상체운동', '맨몸운동'],
+    content_preview:
+      '드디어 풀업 20개를 연속으로 달성했습니다. 6개월간의 노력이 결실을 맺었네요.',
+    like_count: 47,
+    comment_count: 14,
+    is_scrapped: true,
+  },
+  {
+    post_id: 309,
+    images: [makePlaceholderImage(7)],
+    profile_image_url: null,
+    nickname: '요가고수',
+    created_at: '2026-04-13',
+    title: '필라테스 첫 수업 후기',
+    tags: ['필라테스', '코어운동'],
+    content_preview:
+      '오늘 처음으로 필라테스 수업을 들었습니다. 생각보다 훨씬 어렵고 코어 운동에 효과적이었어요.',
+    like_count: 22,
+    comment_count: 7,
+    is_scrapped: false,
+  },
 ]
 
 export const mockPost: ApiPostResponse = {

--- a/src/mocks/data/ranking.ts
+++ b/src/mocks/data/ranking.ts
@@ -1,0 +1,119 @@
+import type {
+  ApiMonthlyRankingUser,
+  ApiTotalRankingUser,
+  ApiWeeklyRankingUser,
+} from '@/apis/ranking/ranking.api.types'
+
+export const mockWeeklyRankings: ApiWeeklyRankingUser[] = [
+  {
+    user_id: 1,
+    nickname: '운동왕',
+    rank: 1,
+    week_cert_count: 20,
+    profile_img_url: null,
+  },
+  {
+    user_id: 2,
+    nickname: '헬스마니아',
+    rank: 2,
+    week_cert_count: 18,
+    profile_img_url: null,
+  },
+  {
+    user_id: 3,
+    nickname: '달리기선수',
+    rank: 3,
+    week_cert_count: 15,
+    profile_img_url: null,
+  },
+  {
+    user_id: 4,
+    nickname: '요가고수',
+    rank: 4,
+    week_cert_count: 12,
+    profile_img_url: null,
+  },
+  {
+    user_id: 5,
+    nickname: '수영러버',
+    rank: 5,
+    week_cert_count: 10,
+    profile_img_url: null,
+  },
+]
+
+export const mockMonthlyRankings: ApiMonthlyRankingUser[] = [
+  {
+    user_id: 1,
+    nickname: '운동왕',
+    rank: 1,
+    month_cert_count: 80,
+    profile_img_url: null,
+  },
+  {
+    user_id: 3,
+    nickname: '달리기선수',
+    rank: 2,
+    month_cert_count: 72,
+    profile_img_url: null,
+  },
+  {
+    user_id: 2,
+    nickname: '헬스마니아',
+    rank: 3,
+    month_cert_count: 65,
+    profile_img_url: null,
+  },
+  {
+    user_id: 5,
+    nickname: '수영러버',
+    rank: 4,
+    month_cert_count: 50,
+    profile_img_url: null,
+  },
+  {
+    user_id: 4,
+    nickname: '요가고수',
+    rank: 5,
+    month_cert_count: 45,
+    profile_img_url: null,
+  },
+]
+
+export const mockTotalRankings: ApiTotalRankingUser[] = [
+  {
+    user_id: 3,
+    nickname: '달리기선수',
+    rank: 1,
+    total_cert_count: 520,
+    profile_img_url: null,
+  },
+  {
+    user_id: 1,
+    nickname: '운동왕',
+    rank: 2,
+    total_cert_count: 498,
+    profile_img_url: null,
+  },
+  {
+    user_id: 4,
+    nickname: '요가고수',
+    rank: 3,
+    total_cert_count: 430,
+    profile_img_url: null,
+  },
+  {
+    user_id: 2,
+    nickname: '헬스마니아',
+    rank: 4,
+    total_cert_count: 380,
+    profile_img_url: null,
+  },
+  {
+    user_id: 5,
+    nickname: '수영러버',
+    rank: 5,
+    total_cert_count: 310,
+    profile_img_url: null,
+  },
+]

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,11 @@
 import { loginHandler } from './handlers/loginHandler'
 import { postHandler } from './handlers/postHandler'
+import { rankingHandler } from './handlers/rankingHandler'
 import { signupHandler } from './handlers/signupHandler'
 
-export const handlers = [...loginHandler, ...signupHandler, ...postHandler]
+export const handlers = [
+  ...loginHandler,
+  ...signupHandler,
+  ...postHandler,
+  ...rankingHandler,
+]

--- a/src/mocks/handlers/postHandler.ts
+++ b/src/mocks/handlers/postHandler.ts
@@ -3,7 +3,7 @@ import { delay, http, HttpResponse } from 'msw'
 import { toMswApiUrl } from '@/apis/apiPath'
 import { POST_ENDPOINTS } from '@/apis/post'
 
-import { mockGoals, mockPost, mockTags } from '../data/post'
+import { mockGoals, mockPost, mockPostList, mockTags } from '../data/post'
 
 export const postHandler = [
   // GET /api/v1/goals — 목표 목록 조회
@@ -16,6 +16,25 @@ export const postHandler = [
   http.get(toMswApiUrl(POST_ENDPOINTS.tags), async () => {
     await delay(300)
     return HttpResponse.json(mockTags, { status: 200 })
+  }),
+
+  // GET /api/v1/posts — 게시글 목록 조회
+  http.get(toMswApiUrl(POST_ENDPOINTS.posts), async ({ request }) => {
+    await delay(400)
+
+    const url = new URL(request.url)
+    const page = Number(url.searchParams.get('page') ?? 0)
+    const size = Number(url.searchParams.get('size') ?? 20)
+
+    return HttpResponse.json(
+      {
+        posts: mockPostList,
+        page,
+        size,
+        total_count: mockPostList.length,
+      },
+      { status: 200 }
+    )
   }),
 
   // GET /api/v1/posts/:postId — 게시글 단건 조회

--- a/src/mocks/handlers/rankingHandler.ts
+++ b/src/mocks/handlers/rankingHandler.ts
@@ -1,0 +1,48 @@
+import { delay, http, HttpResponse } from 'msw'
+
+import { toMswApiUrl } from '@/apis/apiPath'
+import { RANKING_ENDPOINTS } from '@/apis/ranking'
+
+import {
+  mockMonthlyRankings,
+  mockTotalRankings,
+  mockWeeklyRankings,
+} from '../data/ranking'
+
+export const rankingHandler = [
+  // GET /api/v1/statics/rankings/:rankingType
+  http.get(
+    toMswApiUrl(RANKING_ENDPOINTS.rankingPattern),
+    async ({ params }) => {
+      await delay(400)
+
+      const { rankingType } = params
+
+      if (rankingType === 'weekly') {
+        return HttpResponse.json(
+          { detail: { rankings: mockWeeklyRankings } },
+          { status: 200 }
+        )
+      }
+
+      if (rankingType === 'monthly') {
+        return HttpResponse.json(
+          { detail: { rankings: mockMonthlyRankings } },
+          { status: 200 }
+        )
+      }
+
+      if (rankingType === 'total') {
+        return HttpResponse.json(
+          { detail: { rankings: mockTotalRankings } },
+          { status: 200 }
+        )
+      }
+
+      return HttpResponse.json(
+        { error_detail: '요청 값이 올바르지 않습니다.' },
+        { status: 400 }
+      )
+    }
+  ),
+]


### PR DESCRIPTION
## 📌 관련 이슈

Closes #103 

## ✨ 변경 내용

- ranking 과 post 목록 조회 api 를 endpoint로 작성 후 msw handler 추가 + mock 데이터
- 공통 ApiErrorResponse 공유 타입 추가 (error_detail: string | Record<string, string[]>) -> 에러 응답은 2가지 형태
- ranking 과 post API 타입 더 명확하게 재정의 + 클라이언트 타입 또한 수정
-  게시글 카드 Image + profile + tag + cardfooter 컴포넌트로 분해 -> 추후 로직 추가 시 컴포넌트별 파일 분리 처리 예정
- 게시글 카드를 위한 usePostCardActions hook 생성 

## 📸 스크린샷(선택)

## 📚 참고사항
메인 페이지 작업 하다 보니 바로 다음 PR에 msw 연동된 스크린샷을 첨부하겠습니다. 
msw와 UI 작업을 한번에 올리려고 하니까 파일 크기가 꽤 많아져서 리뷰하기 힘드실거 같아서 나눠서 올립니다 이번 PR은 1탄입니다. 