### PR TITLE
feat: mypage UI layout

### DIFF
--- a/src/components/common/layout/Header.tsx
+++ b/src/components/common/layout/Header.tsx
@@ -43,16 +43,25 @@ export function Header() {
   return (
     <header className="max-w-7xl mx-auto w-full">
       <div className="flex items-center justify-between py-3 px-4">
-        <img
-          src={logoImage}
-          className="w-12 h-11 dark:hidden"
-          alt="OZ Union 로고"
-        />
-        <img
-          src={DarklogoImage}
-          className="hidden w-12 h-11 dark:block"
-          alt="OZ Union 로고"
-        />
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          className="cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
+          aria-label="메인페이지로 이동"
+        >
+          <img
+            src={logoImage}
+            className="w-12 h-11 dark:hidden"
+            alt=""
+            aria-hidden="true"
+          />
+          <img
+            src={DarklogoImage}
+            className="hidden w-12 h-11 dark:block"
+            alt=""
+            aria-hidden="true"
+          />
+        </button>
         <div className="flex items-center gap-6">
           <Button
             variant={'ghost'}

--- a/src/components/common/layout/MyPageLayout.tsx
+++ b/src/components/common/layout/MyPageLayout.tsx
@@ -1,0 +1,56 @@
+import { Outlet } from 'react-router'
+
+import { Bookmark, NotebookText } from 'lucide-react'
+
+import { Footer, Header } from '@/components/common/layout'
+import { cn } from '@/utils/cn'
+
+import { Button } from '../ui'
+
+const SIDEBAR_ITEMS = [
+  { label: '저장한 목표', Icon: Bookmark, isActive: false },
+  { label: '내가 쓴 게시글', Icon: NotebookText, isActive: false },
+] as const
+
+function MyPageSidebar() {
+  return (
+    <aside className="fixed inset-x-0 bottom-0 border-t border-border-default bg-surface md:static md:inset-auto md:min-h-dvh md:border-r md:border-t-0">
+      <nav
+        className="flex items-center flex-col justify-cneter mt-24 gap-4"
+        aria-label="마이페이지 메뉴"
+      >
+        {SIDEBAR_ITEMS.map(({ label, Icon, isActive }) => (
+          <Button
+            key={label}
+            aria-label={label}
+            aria-current={isActive ? 'page' : undefined}
+            className={cn(
+              'text-text-primary bg-transparent hover:bg-transparent transition-colors hover:text-primary-600 focus-visible:outline-2 focus-visible:outline-primary-600',
+              isActive && 'text-primary-600'
+            )}
+          >
+            <Icon className="size-7" strokeWidth={2} aria-hidden="true" />
+          </Button>
+        ))}
+      </nav>
+    </aside>
+  )
+}
+
+export function MyPageLayout() {
+  return (
+    <div className="grid min-h-dvh bg-background md:grid-cols-[80px_1fr]">
+      <MyPageSidebar />
+
+      <div className="flex min-h-dvh min-w-0 flex-col pb-16 md:pb-0">
+        <Header />
+
+        <main className="mx-auto py-7.5 w-full max-w-7xl flex-1 px-8">
+          <Outlet />
+        </main>
+
+        <Footer />
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/layout/RootLayout.tsx
+++ b/src/components/common/layout/RootLayout.tsx
@@ -11,7 +11,7 @@ export function RootLayout() {
     <div className="flex min-h-screen flex-col">
       <Header />
 
-      <div className="max-w-300 mx-auto mt-7.5 w-full flex-1 px-8">
+      <div className="max-w-300 mx-auto py-7.5 w-full flex-1 px-8">
         <Outlet />
       </div>
       <Footer />

--- a/src/components/common/layout/index.ts
+++ b/src/components/common/layout/index.ts
@@ -1,3 +1,4 @@
 export { Footer } from './Footer'
 export { Header } from './Header'
+export { MyPageLayout } from './MyPageLayout'
 export { RootLayout } from './RootLayout'

--- a/src/components/common/ui/calendar/Calendar.tsx
+++ b/src/components/common/ui/calendar/Calendar.tsx
@@ -47,7 +47,7 @@ export function Calendar({
 
       {/* 패널은 날짜 선택 모드와 월 선택 모드를 전환해서 보여줌 */}
       {state.isOpen && (
-        <div className="absolute left-0 top-full z-10 mt-3 h-fit w-2xs rounded-2xl border border-border-default/60 bg-white/80 p-4 shadow-card-main backdrop-blur-md">
+        <div className="absolute left-0 top-full z-10 mt-3 h-fit w-2xs rounded-2xl border border-border-default bg-surface/90 p-4 shadow-card-main backdrop-blur-md">
           <CalendarHeader
             currentDate={state.currentDate}
             onClose={actions.closeCalendar}
@@ -88,7 +88,7 @@ export function Calendar({
             <Button
               size="md"
               variant="neutral"
-              className="w-full"
+              className="w-full dark:bg-white/10 dark:text-text-primary dark:hover:bg-white/15"
               onClick={() => actions.updateDraftDate(null)}
             >
               초기화

--- a/src/components/common/ui/calendar/components/CalendarDay.tsx
+++ b/src/components/common/ui/calendar/components/CalendarDay.tsx
@@ -18,7 +18,7 @@ type DayButtonState = 'default' | 'disabled' | 'redDay' | 'selected' | 'today'
 
 // 상태별 날짜 버튼 스타일
 const DAY_BUTTON_STATE_CLASS: Record<DayButtonState, string> = {
-  default: 'text-primary',
+  default: 'text-text-primary',
   disabled:
     'cursor-not-allowed text-text-muted disabled:bg-transparent disabled:text-text-muted',
   redDay: 'text-red-500 hover:text-red-500',
@@ -65,17 +65,17 @@ export function CalendarDay({
     <div className="relative flex h-9 w-full items-center justify-center">
       {/* range 내부 날짜의 연결 배경 */}
       {isInRange && (
-        <div className="absolute left-0 right-0 top-1/2 h-9 -translate-y-1/2 bg-primary-100/80" />
+        <div className="absolute left-0 right-0 top-1/2 h-9 -translate-y-1/2 bg-primary-100/80 dark:bg-primary-600/20" />
       )}
 
       {/* 시작일에서 종료일 방향으로 이어지는 반쪽 배경 */}
       {isStart && hasRangeEnd && (
-        <div className="absolute left-1/2 right-0 top-1/2 h-9 -translate-y-1/2 bg-primary-100" />
+        <div className="absolute left-1/2 right-0 top-1/2 h-9 -translate-y-1/2 bg-primary-100 dark:bg-primary-600/20" />
       )}
 
       {/* 종료일에서 시작일 방향으로 이어지는 반쪽 배경 */}
       {isEnd && hasRangeStart && (
-        <div className="absolute left-0 right-1/2 top-1/2 h-9 -translate-y-1/2 bg-primary-100" />
+        <div className="absolute left-0 right-1/2 top-1/2 h-9 -translate-y-1/2 bg-primary-100 dark:bg-primary-600/20" />
       )}
 
       <Button
@@ -86,7 +86,7 @@ export function CalendarDay({
           'relative z-10 flex size-9 items-center rounded-full text-sm font-semibold',
           !isDisabled &&
             !isSelected &&
-            'cursor-pointer transition-colors hover:bg-primary-100/70 hover:text-primary-600',
+            'cursor-pointer transition-colors hover:bg-primary-100/70 hover:text-primary-600 dark:hover:bg-white/10 dark:hover:text-primary-400',
           DAY_BUTTON_STATE_CLASS[dayState]
         )}
       >

--- a/src/components/common/ui/calendar/components/CalendarHeader.tsx
+++ b/src/components/common/ui/calendar/components/CalendarHeader.tsx
@@ -36,7 +36,7 @@ export function CalendarHeader({
         aria-label="달력 닫기"
         onClick={onClose}
         leftIcon={<X aria-hidden="true" size={10} />}
-        className="absolute right-1.5 top-2 z-10 rounded-full bg-black/10 p-1 hover:bg-black/20"
+        className="absolute right-1.5 top-2 z-10 rounded-full bg-black/10 p-1 text-text-muted hover:bg-black/20 hover:text-text-primary dark:bg-white/10 dark:hover:bg-white/20"
       />
 
       <div className="my-2.5 grid grid-cols-[1fr_auto_1fr] items-center">
@@ -51,7 +51,7 @@ export function CalendarHeader({
         <Button
           variant="ghost"
           onClick={onTitleClick}
-          className="text-base text-text-primary hover:bg-primary-100"
+          className="text-base text-text-primary hover:bg-primary-100 dark:hover:bg-white/10"
         >
           {title}
         </Button>

--- a/src/components/common/ui/calendar/components/CalendarMonthPicker.tsx
+++ b/src/components/common/ui/calendar/components/CalendarMonthPicker.tsx
@@ -61,7 +61,7 @@ export function CalendarMonthPicker({
               'h-10 rounded-md text-sm font-semibold',
               !isDisabled &&
                 !isSelectedMonth &&
-                'transition-colors hover:bg-primary-100 hover:text-primary-600',
+                'transition-colors hover:bg-primary-100 hover:text-primary-600 dark:hover:bg-white/10 dark:hover:text-primary-400',
               MONTH_BUTTON_STATE_CLASS[monthState]
             )}
           >

--- a/src/features/my-page/components/MyPageGoalSection.tsx
+++ b/src/features/my-page/components/MyPageGoalSection.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+
+import { Plus, RotateCcw } from 'lucide-react'
+
+import { Button, GoalCardEdit, TabButton } from '@/components/common/ui'
+import { cn } from '@/utils/cn'
+
+const GOAL_FILTERS = ['전체 보기', '진행중', '미달성', '완료'] as const
+
+export function MyPageGoalSection() {
+  const [activeFilter, setActiveFilter] =
+    useState<(typeof GOAL_FILTERS)[number]>('진행중')
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
+
+  const handleResetFilter = () => {
+    setActiveFilter('전체 보기')
+  }
+
+  return (
+    <section className="flex flex-col gap-8">
+      {/* 목표 목록 필터와 생성 버튼을 한 줄로 묶는 상단 영역 */}
+      <div className="flex justify-between items-center border-b border-border-default  pb-1">
+        <div className="flex flex-wrap items-center gap-0.5">
+          {GOAL_FILTERS.map((filter) => (
+            <TabButton
+              key={filter}
+              type="button"
+              isActive={activeFilter === filter}
+              onClick={() => setActiveFilter(filter)}
+              className="px-0"
+            >
+              {filter}
+            </TabButton>
+          ))}
+          <span className="text-[#e0e0e0]">|</span>
+          <Button
+            variant="ghost"
+            rounded="full"
+            leftIcon={<RotateCcw className="size-4" aria-hidden="true" />}
+            onClick={handleResetFilter}
+            className="h-8 px-3 text-sm text-text-muted hover:text-primary-600"
+          >
+            초기화
+          </Button>
+        </div>
+
+        <Button
+          size={'md'}
+          rounded="full"
+          leftIcon={<Plus className="size-4" aria-hidden="true" />}
+          onClick={() => setIsCreateOpen(true)}
+          className="w-fit"
+        >
+          목표 생성
+        </Button>
+      </div>
+
+      {/* TODO: API 연결 후 생성 카드와 목표 카드 데이터를 서버 상태 기준으로 교체 */}
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(276px,1fr))] justify-items-center gap-y-4.5">
+        <div
+          className={cn(
+            'transition-opacity duration-200',
+            isCreateOpen ? 'opacity-100' : 'pointer-events-none opacity-40'
+          )}
+          aria-disabled={!isCreateOpen}
+        >
+          <GoalCardEdit
+            mode="create"
+            initialTitle=""
+            initialDateRange={{ start: null, end: null }}
+            initialProgressRate={0}
+            initialStatus="IN_PROGRESS"
+            onClose={() => setIsCreateOpen(false)}
+            onSubmit={() => setIsCreateOpen(false)}
+          />
+        </div>
+
+        {/* 목표 생성 카드 map 으로 */}
+      </div>
+    </section>
+  )
+}

--- a/src/features/my-page/components/MyPageStatsSummary.tsx
+++ b/src/features/my-page/components/MyPageStatsSummary.tsx
@@ -1,0 +1,56 @@
+import { cn } from '@/utils/cn'
+
+type StatsCardTone = 'yellow' | 'blue' | 'mint'
+
+export type MyPageStatsSummaryItem = {
+  label: string
+  value: string
+  tone: StatsCardTone
+}
+
+type MyPageStatsSummaryProps = {
+  items: MyPageStatsSummaryItem[]
+}
+
+const STATS_CARD_CLASS_NAME =
+  'flex w-full min-w-36 flex-1 flex-col items-center justify-center rounded-lg border px-6 py-5 text-center'
+
+const STATS_CARD_TONE_CLASS_NAME: Record<StatsCardTone, string> = {
+  yellow: 'border-border-mypage-stats-card-yellow bg-mypage-stats-card-yellow',
+  blue: 'border-border-mypage-stats-card-blue bg-mypage-stats-card-blue',
+  mint: 'border-border-mypage-stats-card-mint bg-mypage-stats-card-mint',
+}
+
+const STATS_VALUE_TONE_CLASS_NAME: Record<StatsCardTone, string> = {
+  yellow: 'text-primary-600',
+  blue: 'text-text-secondary',
+  mint: 'text-green-500',
+}
+
+export function MyPageStatsSummary({ items }: MyPageStatsSummaryProps) {
+  return (
+    <div className="order-1 flex w-full flex-wrap gap-4 lg:order-2">
+      {items.map(({ label, value, tone }) => (
+        <div
+          key={label}
+          className={cn(
+            STATS_CARD_CLASS_NAME,
+            STATS_CARD_TONE_CLASS_NAME[tone]
+          )}
+        >
+          <strong
+            className={cn(
+              'block text-xl font-bold',
+              STATS_VALUE_TONE_CLASS_NAME[tone]
+            )}
+          >
+            {value}
+          </strong>
+          <span className="mt-2 block text-base text-text-secondary">
+            {label}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/features/my-page/components/index.ts
+++ b/src/features/my-page/components/index.ts
@@ -1,0 +1,5 @@
+export { MyPageGoalSection } from './MyPageGoalSection'
+export {
+  MyPageStatsSummary,
+  type MyPageStatsSummaryItem,
+} from './MyPageStatsSummary'

--- a/src/features/my-page/index.ts
+++ b/src/features/my-page/index.ts
@@ -1,0 +1,5 @@
+export {
+  MyPageGoalSection,
+  MyPageStatsSummary,
+  type MyPageStatsSummaryItem,
+} from './components'

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,0 +1,45 @@
+import {
+  MyPageGoalSection,
+  MyPageStatsSummary,
+  type MyPageStatsSummaryItem,
+} from '@/features/my-page'
+
+const MY_PAGE_STATS_ITEMS = [
+  {
+    label: '함께한 기간',
+    value: '100일',
+    tone: 'yellow',
+  },
+  {
+    label: '완료한 일정',
+    value: '100개',
+    tone: 'blue',
+  },
+  {
+    label: '전체 달성률',
+    value: '100%',
+    tone: 'mint',
+  },
+] satisfies MyPageStatsSummaryItem[]
+
+export function MyPage() {
+  return (
+    <div className="flex w-full flex-col gap-8 ">
+      <section className="rounded-lg border border-border-mypage-stats-section bg-mypage-stats-section px-6 py-6 shadow-card-main flex flex-col gap-3">
+        <h2 className="text-xl font-semibold text-text-primary">
+          나의 활동 요약
+        </h2>
+
+        <div className="grid w-full grid-cols-1 items-stretch gap-7 lg:grid-cols-[minmax(0,1fr)_230px]">
+          <div className="order-2 flex w-full items-center justify-center rounded-lg border border-border-default bg-background/20 backdrop-blur-2xl text-sm lg:order-1">
+            히트맵
+          </div>
+
+          <MyPageStatsSummary items={MY_PAGE_STATS_ITEMS} />
+        </div>
+      </section>
+
+      <MyPageGoalSection />
+    </div>
+  )
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,5 +1,6 @@
 export { LoginPage } from './LoginPage'
 export { default as Main } from './Main'
+export { MyPage } from './MyPage'
 export { NotFoundPage } from './not-found'
 export { PostCreatePage } from './PostCreatePage'
 export { PostEditPage } from './PostEditPage'

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,9 +1,10 @@
 import { createBrowserRouter } from 'react-router'
 
-import { RootLayout } from '@/components/common/layout'
+import { MyPageLayout, RootLayout } from '@/components/common/layout'
 import {
   LoginPage,
   Main,
+  MyPage,
   NotFoundPage,
   PostCreatePage,
   PostEditPage,
@@ -33,6 +34,16 @@ export const router = createBrowserRouter([
       {
         path: 'post/:id/edit',
         element: <PostEditPage />,
+      },
+    ],
+  },
+  {
+    path: '/mypage',
+    element: <MyPageLayout />,
+    children: [
+      {
+        index: true,
+        element: <MyPage />,
       },
     ],
   },


### PR DESCRIPTION
## 📌 관련 이슈

Closes #106

## ✨ 변경 내용

  - 마이페이지 전용 레이아웃을 추가하고 `/mypage` 라우터를 연결
  - 마이페이지 사이드바, 활동 요약, 통계 카드, 목표 생성/목표 목록 UI를 구성
  - 통계 카드와 목표 섹션을 `features/my-page` 컴포넌트로 분리
  - 헤더 로고 클릭 시 메인 페이지로 이동하도록 연결
  - 캘린더 컴포넌트의 다크모드 스타일을 보완
  - RootLayout  `mt-7.5` ->  footer 영역과 gap 이없어 py-7.5로 변경

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/fa7c041c-b0b8-4b3c-9f3a-8eb0955666b5


## 📚 참고사항
  - 히트맵 영역은 현재 자리만 잡아둔 상태이며, 별도 컴포넌트로 구현 예정입니다.
  - 목표 생성 / 수정 / 삭제 MSW / API 연결 예정 입니다
  - 나의 활동요약 하드코딩 되어있어 MSW / API 연결 예정입니다
  - 마이페이지 사이드바 UI는 추후 변경 예정입니다. 모바일 대응 및 레이아웃 작업으로 인해 현재 구조에 일부 번거로움이 있습니다.
  - 목표생성 구현시 날짜 필터링 추가 예정