### PR TITLE
feat: connect ppst detail api

### DIFF
--- a/src/features/post-detail/PostDetailPage.tsx
+++ b/src/features/post-detail/PostDetailPage.tsx
@@ -1,5 +1,0 @@
-import { PostDetailLayout } from './components/PostDetailLayout'
-
-export function PostDetailPage() {
-  return <PostDetailLayout />
-}

--- a/src/features/post-detail/components/PostDetailHeader.tsx
+++ b/src/features/post-detail/components/PostDetailHeader.tsx
@@ -1,7 +1,7 @@
 type PostDetailHeaderProps = {
   author: {
     nickname: string
-    profileImageUrl: string
+    profileImageUrl?: string | null
   }
   createdAt: string
 }
@@ -9,12 +9,14 @@ type PostDetailHeaderProps = {
 export function PostDetailHeader({ author, createdAt }: PostDetailHeaderProps) {
   return (
     <div className="mt-9 flex items-center gap-3">
-      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full bg-gray-200">
-        <img
-          src={author.profileImageUrl}
-          alt={`${author.nickname}의 프로필 이미지`}
-          className="h-full w-full object-cover"
-        />
+      <div className="h-10 w-10 overflow-hidden rounded-full bg-gray-200">
+        {author.profileImageUrl ? (
+          <img
+            src={author.profileImageUrl}
+            alt={`${author.nickname}의 프로필 이미지`}
+            className="h-full w-full object-cover"
+          />
+        ) : null}
       </div>
 
       <div className="flex flex-col">

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -1,22 +1,25 @@
-import { VoteDisplay } from '@/components/common/ui'
+import type { PostDetailData } from '@/features/post/post.types'
 
-import {
-  mockGoal,
-  mockPostDetail,
-  mockVote,
-} from '../constants/post-detail.constants'
 import { PostDetailActions } from './PostDetailActions'
 import { PostDetailBody } from './PostDetailBody'
 import { PostDetailCommentSection } from './PostDetailCommentSection'
 import { PostDetailHeader } from './PostDetailHeader'
 import { PostGoalSection } from './PostGoalSection'
 
-export function PostDetailLayout() {
-  const post = mockPostDetail
+type PostDetailLayoutProps = {
+  post: PostDetailData
+}
 
+export function PostDetailLayout({ post }: PostDetailLayoutProps) {
   return (
     <article className="rounded-2xl border border-border-default bg-white px-16 py-6 shadow-card-main">
-      <PostDetailHeader author={post.author} createdAt={post.createdAt} />
+      <PostDetailHeader
+        author={{
+          nickname: post.nickname,
+          profileImageUrl: post.profileImageUrl,
+        }}
+        createdAt={post.createdAt}
+      />
 
       <div className="mt-6">
         <PostDetailBody
@@ -27,27 +30,14 @@ export function PostDetailLayout() {
         />
       </div>
 
-      {/* 투표 영역 */}
-      {mockVote && (
-        <div className="mt-6">
-          <VoteDisplay
-            mode={mockVote.mode}
-            options={mockVote.options}
-            participantCount={mockVote.participantCount}
-            period={mockVote.period}
-          />
-        </div>
-      )}
-
-      {/* 목표/그래프 영역 */}
-      {mockGoal && (
+      {post.hasGoal && post.goalInfo && (
         <div className="mt-6">
           <PostGoalSection
-            title={mockGoal.title}
-            startDate={mockGoal.startDate}
-            endDate={mockGoal.endDate}
-            progressRate={mockGoal.progressRate}
-            status={mockGoal.status}
+            title={post.goalInfo.title}
+            startDate={post.goalInfo.startDate ?? ''}
+            endDate={post.goalInfo.endDate ?? ''}
+            progressRate={post.goalInfo.progressRate ?? 0}
+            status="IN_PROGRESS"
           />
         </div>
       )}

--- a/src/features/post/post.mappers.ts
+++ b/src/features/post/post.mappers.ts
@@ -4,7 +4,7 @@ import type {
   ApiPostResponse,
   ApiPostUpdateRequest,
 } from './post.api.types'
-import type { GoalOption, PostFormData } from './post.types'
+import type { GoalOption, PostDetailData, PostFormData } from './post.types'
 
 // API 응답 → 프론트 타입
 
@@ -42,6 +42,47 @@ export function toPostFormData(api: ApiPostResponse): PostFormData {
       : undefined,
     tagNames: api.tags ?? [],
     tagIds: [],
+  }
+}
+
+// GET /api/v1/posts/:postId 응답 → PostDetailData (게시글 상세 페이지용)
+export function toPostDetailData(api: ApiPostResponse): PostDetailData {
+  return {
+    postId: api.post_id,
+    images: api.images,
+    profileImageUrl: api.profile_image_url,
+    nickname: api.nickname,
+    createdAt: api.created_at,
+    title: api.title,
+    content: api.content,
+    tags: api.tags ?? [],
+    likeCount: api.like_count,
+    commentCount: api.comment_count,
+    isScrapped: api.is_scrapped,
+    hasGoal: api.has_goal,
+    goalInfo: api.goal_info
+      ? {
+          goalId: api.goal_info.goal_id,
+          title: api.goal_info.goal_title,
+          startDate: api.goal_info.goal_start_date,
+          endDate: api.goal_info.goal_end_date,
+          progressRate: api.goal_info.goal_progress,
+        }
+      : null,
+    hasVote: api.has_vote,
+    voteInfo: api.vote_info
+      ? {
+          voteId: api.vote_info.vote_id,
+          startAt: api.vote_info.start_at,
+          endAt: api.vote_info.end_at,
+          status: api.vote_info.status,
+          options: api.vote_info.options.map((o) => ({
+            optionId: o.option_id,
+            content: o.content,
+            sortOrder: o.sort_order,
+          })),
+        }
+      : null,
   }
 }
 

--- a/src/features/post/post.types.ts
+++ b/src/features/post/post.types.ts
@@ -56,3 +56,38 @@ export type TagOption = {
   id: number
   name: string
 }
+
+//게시글 상세 페이지 화면용
+export type PostDetailData = {
+  postId: number
+  images: string[]
+  profileImageUrl: string | null
+  nickname: string
+  createdAt: string
+  title: string
+  content: string
+  tags: string[]
+  likeCount: number
+  commentCount: number
+  isScrapped: boolean
+  hasGoal: boolean
+  goalInfo: {
+    goalId: number
+    title: string
+    startDate: string | null
+    endDate: string | null
+    progressRate: number | null
+  } | null
+  hasVote: boolean
+  voteInfo: {
+    voteId: number
+    startAt: string
+    endAt: string
+    status: string
+    options: {
+      optionId: number
+      content: string
+      sortOrder: number
+    }[]
+  } | null
+}

--- a/src/pages/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage.tsx
@@ -1,9 +1,16 @@
 import { PostDetailLayout } from '@/features/post-detail/components/PostDetailLayout'
+import { usePostDetailQuery } from '@/query/post/usePostDetailQuery'
 
 export function PostDetailPage() {
+  const { data: post, isLoading, error } = usePostDetailQuery(305)
+
+  if (isLoading) return <div>로딩중</div>
+  if (error) return <div>에러</div>
+  if (!post) return <div>게시글 없음</div>
+
   return (
     <div className="flex min-h-full justify-start">
-      <PostDetailLayout />
+      <PostDetailLayout post={post} />
     </div>
   )
 }

--- a/src/query/post/usePostDetailQuery.ts
+++ b/src/query/post/usePostDetailQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post/post.api'
+import { toPostDetailData } from '@/features/post/post.mappers.ts'
+
+export function usePostDetailQuery(postId: number) {
+  return useQuery({
+    queryKey: ['postDetail', postId],
+    queryFn: async () => {
+      const res = await postApi.getPost(postId)
+      return toPostDetailData(res.data)
+    },
+    enabled: !!postId,
+  })
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #122

## ✨ 변경 내용

- 게시글 상세 조회 API 연결
- React Query 기반 게시글 상세 데이터 fetching 추가
- API 응답을 프론트 타입으로 변환하는 mapper 추가
- 게시글 상세 페이지에서 mock 데이터 대신 API/MSW 응답 데이터 사용
- 프로필 이미지가 없을 때 img를 렌더링하지 않도록 처리
- 중복 PostDetailPage 파일 정리

## 📸 스크린샷(선택)

## 📚 참고사항

- 댓글 API, 투표 API, 좋아요/북마크/신고 액션은 별도 이슈로 분리 예정입니다.
- 목표 영역은 API 응답 데이터를 단순 표시하는 수준으로만 연결했습니다.
- API 404/에러 상태 화면은 별도 이슈에서 정리 예정
- 기존 lint warning은 이번 작업 범위가 아니라 수정하지 않았습니다.