### PR TITLE
feat: connect comment api

### DIFF
--- a/src/components/common/ui/comment/Comment.type.ts
+++ b/src/components/common/ui/comment/Comment.type.ts
@@ -1,10 +1,10 @@
 export type Comment = {
   id: number
-  user_id?: number
+  userId: number
   nickname: string
   content: string
-  created_at: string
-  like_count: number
-  is_liked: boolean
-  profile_image_url: string | null
+  createdAt: string
+  likeCount: number
+  isLiked: boolean
+  profileImageUrl: string | null
 }

--- a/src/components/common/ui/comment/CommentItem.tsx
+++ b/src/components/common/ui/comment/CommentItem.tsx
@@ -39,10 +39,10 @@ export function CommentItem({
     id,
     nickname,
     content,
-    created_at,
-    like_count,
-    is_liked,
-    profile_image_url,
+    createdAt,
+    likeCount,
+    isLiked,
+    profileImageUrl,
   } = comment
 
   return (
@@ -55,9 +55,9 @@ export function CommentItem({
     >
       {/* 프로필 */}
       <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full bg-gray-200">
-        {profile_image_url ? (
+        {profileImageUrl ? (
           <img
-            src={profile_image_url}
+            src={profileImageUrl}
             alt={`${nickname}의 프로필 이미지`}
             className="h-full w-full object-cover"
           />
@@ -73,7 +73,7 @@ export function CommentItem({
               {nickname}
             </span>
             <span className="text-xs text-text-muted">
-              {formatTime(created_at)}
+              {formatTime(createdAt)}
             </span>
           </div>
 
@@ -111,12 +111,12 @@ export function CommentItem({
             <Heart
               className={cn(
                 'h-4 w-4',
-                is_liked
+                isLiked
                   ? 'fill-primary-500 text-primary-500'
                   : 'text-text-muted'
               )}
             />
-            <span className="text-xs text-text-muted">{like_count}</span>
+            <span className="text-xs text-text-muted">{likeCount}</span>
           </button>
         </div>
       </div>

--- a/src/components/common/ui/comment/CommentList.tsx
+++ b/src/components/common/ui/comment/CommentList.tsx
@@ -42,7 +42,7 @@ export function CommentList({
         <CommentItem
           key={comment.id}
           comment={comment}
-          isOwner={!!currentUserId && currentUserId === comment.user_id}
+          isOwner={!!currentUserId && currentUserId === comment.userId}
           isSelected={selectedId === comment.id}
           onSelect={() => setSelectedId(comment.id)}
           onLike={onLike}

--- a/src/features/post-detail/components/PostDetailCommentSection.tsx
+++ b/src/features/post-detail/components/PostDetailCommentSection.tsx
@@ -1,80 +1,47 @@
-import { useState } from 'react'
+import { CommentInput, CommentList } from '@/components/common/ui/comment'
+import { useCommentsQuery } from '@/query/post/useCommentsQuery'
+import { useCreateCommentMutation } from '@/query/post/useCreateCommentMutation'
 
-import {
-  type Comment,
-  CommentInput,
-  CommentList,
-} from '@/components/common/ui/comment'
-
-const MOCK_COMMENTS: Comment[] = [
-  {
-    id: 1,
-    user_id: 2,
-    nickname: '하이룽',
-    content: '치맥이나 하자 ㅋㅋㅋㅋ',
-    created_at: new Date(Date.now() - 6 * 60 * 1000).toISOString(),
-    like_count: 0,
-    is_liked: false,
-    profile_image_url: null,
-  },
-  {
-    id: 2,
-    user_id: 3,
-    nickname: 'stt',
-    content: 'ㅋㅋㅋㅋ',
-    created_at: new Date(Date.now() - 6 * 60 * 1000).toISOString(),
-    like_count: 0,
-    is_liked: false,
-    profile_image_url: null,
-  },
-]
+type PostDetailCommentSectionProps = {
+  postId: number
+}
 
 const CURRENT_USER_ID = 1
 
-export function PostDetailCommentSection() {
-  const [comments, setComments] = useState<Comment[]>(MOCK_COMMENTS)
+export function PostDetailCommentSection({
+  postId,
+}: PostDetailCommentSectionProps) {
+  const { data: comments = [], isLoading, isError } = useCommentsQuery(postId)
+
+  const { mutate: createComment, isPending } = useCreateCommentMutation()
 
   const handleSubmitComment = (content: string) => {
-    const newComment: Comment = {
-      id: Date.now(),
-      user_id: CURRENT_USER_ID,
-      nickname: '나',
+    createComment({
+      postId,
       content,
-      created_at: new Date().toISOString(),
-      like_count: 0,
-      is_liked: false,
-      profile_image_url: null,
-    }
-
-    setComments((prevComments) => [newComment, ...prevComments])
+    })
   }
 
-  const handleLike = (id: number) => {
-    setComments((prevComments) =>
-      prevComments.map((comment) =>
-        comment.id === id
-          ? {
-              ...comment,
-              is_liked: !comment.is_liked,
-              like_count: comment.is_liked
-                ? comment.like_count - 1
-                : comment.like_count + 1,
-            }
-          : comment
-      )
+  if (isError) {
+    return (
+      <section>
+        <p className="py-6 text-center text-sm text-danger-500">
+          댓글을 불러오지 못했습니다.
+        </p>
+      </section>
     )
   }
 
   return (
     <section>
-      <div className="px-6"></div>
-      <CommentInput onSubmit={handleSubmitComment} />
+      <CommentInput isLoading={isPending} onSubmit={handleSubmitComment} />
 
       <div className="mt-8">
         <CommentList
           comments={comments}
           currentUserId={CURRENT_USER_ID}
-          onLike={handleLike}
+          isLoading={isLoading}
+          onLike={() => {}}
         />
       </div>
     </section>

--- a/src/features/post-detail/components/PostDetailCommentSection.tsx
+++ b/src/features/post-detail/components/PostDetailCommentSection.tsx
@@ -1,25 +1,21 @@
 import { CommentInput, CommentList } from '@/components/common/ui/comment'
 import { useCommentsQuery } from '@/query/post/useCommentsQuery'
 import { useCreateCommentMutation } from '@/query/post/useCreateCommentMutation'
+import { useAuthStore } from '@/store/authStore'
 
 type PostDetailCommentSectionProps = {
   postId: number
 }
 
-const CURRENT_USER_ID = 1
-
 export function PostDetailCommentSection({
   postId,
 }: PostDetailCommentSectionProps) {
+  const user = useAuthStore((state) => state.user)
   const { data: comments = [], isLoading, isError } = useCommentsQuery(postId)
-
   const { mutate: createComment, isPending } = useCreateCommentMutation()
 
   const handleSubmitComment = (content: string) => {
-    createComment({
-      postId,
-      content,
-    })
+    createComment({ postId, content })
   }
 
   if (isError) {
@@ -34,12 +30,17 @@ export function PostDetailCommentSection({
 
   return (
     <section>
-      <CommentInput isLoading={isPending} onSubmit={handleSubmitComment} />
+      <CommentInput
+        isLoading={isPending}
+        onSubmit={handleSubmitComment}
+        profileImageUrl={user?.profileImageUrl}
+        nickname={user?.nickname}
+      />
 
       <div className="mt-8">
         <CommentList
           comments={comments}
-          currentUserId={CURRENT_USER_ID}
+          currentUserId={0} // TODO: /accounts/me 연동 후 user?.id 로 교체
           isLoading={isLoading}
           onLike={() => {}}
         />

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -46,7 +46,7 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
         <PostDetailActions />
       </div>
 
-      <PostDetailCommentSection />
+      <PostDetailCommentSection postId={post.postId} />
     </article>
   )
 }

--- a/src/features/post/post.api.ts
+++ b/src/features/post/post.api.ts
@@ -1,0 +1,30 @@
+import { apiClient } from '@/apis/apiClient'
+
+import type {
+  CreateCommentApiRequest,
+  CreateCommentApiResponse,
+  GetCommentsApiResponse,
+} from './post.api.types'
+import {
+  mapCommentApiToComment,
+  mapCommentsApiToComments,
+} from './post.mappers'
+
+export const postApi = {
+  async getComments(postId: number) {
+    const { data } = await apiClient.get<GetCommentsApiResponse>(
+      `/posts/${postId}/comments`
+    )
+
+    return mapCommentsApiToComments(data)
+  },
+
+  async createComment(postId: number, body: CreateCommentApiRequest) {
+    const { data } = await apiClient.post<CreateCommentApiResponse>(
+      `/posts/${postId}/comments`,
+      body
+    )
+
+    return mapCommentApiToComment(data)
+  },
+}

--- a/src/features/post/post.api.types.ts
+++ b/src/features/post/post.api.types.ts
@@ -92,3 +92,25 @@ export type ApiPostUpdateRequest = {
   vote?: VoteContent
   tag_ids?: number[]
 }
+
+//댓글 api
+export type CommentApiResponse = {
+  id: number
+  user_id: number
+  nickname: string
+  content: string
+  created_at: string
+  like_count: number
+  is_liked: boolean
+  profile_image_url?: string | null
+}
+
+export type GetCommentsApiResponse = {
+  results: CommentApiResponse[]
+}
+
+export type CreateCommentApiRequest = {
+  content: string
+}
+
+export type CreateCommentApiResponse = CommentApiResponse

--- a/src/features/post/post.mappers.ts
+++ b/src/features/post/post.mappers.ts
@@ -1,8 +1,12 @@
+import type { Comment } from '@/components/common/ui/comment'
+
 import type {
   ApiGoalResponse,
   ApiPostCreateRequest,
   ApiPostResponse,
   ApiPostUpdateRequest,
+  CommentApiResponse,
+  GetCommentsApiResponse,
 } from './post.api.types'
 import type { GoalOption, PostDetailData, PostFormData } from './post.types'
 
@@ -128,4 +132,23 @@ export function toApiUpdateRequest(data: PostFormData): ApiPostUpdateRequest {
     vote: toApiVoteContent(data.vote),
     tag_ids: data.tagIds,
   }
+}
+
+export function mapCommentApiToComment(comment: CommentApiResponse): Comment {
+  return {
+    id: comment.id,
+    userId: comment.user_id ?? 0,
+    nickname: comment.nickname,
+    content: comment.content,
+    createdAt: comment.created_at,
+    likeCount: comment.like_count ?? 0,
+    isLiked: comment.is_liked ?? false,
+    profileImageUrl: comment.profile_image_url ?? null,
+  }
+}
+
+export function mapCommentsApiToComments(
+  response: GetCommentsApiResponse
+): Comment[] {
+  return response.results.map(mapCommentApiToComment)
 }

--- a/src/mocks/handlers/postHandler.ts
+++ b/src/mocks/handlers/postHandler.ts
@@ -3,7 +3,7 @@ import { delay, http, HttpResponse } from 'msw'
 import { toMswApiUrl } from '@/apis/apiPath'
 import { POST_ENDPOINTS } from '@/apis/post'
 
-import { mockPost, mockPostList, mockTags } from '../data/post'
+import { mockPostList, mockTags } from '../data/post'
 
 export const postHandler = [
   // GET /api/v1/tags — 태그 목록 조회
@@ -15,11 +15,9 @@ export const postHandler = [
   // GET /api/v1/posts — 게시글 목록 조회
   http.get(toMswApiUrl(POST_ENDPOINTS.posts), async ({ request }) => {
     await delay(400)
-
     const url = new URL(request.url)
     const page = Number(url.searchParams.get('page') ?? 0)
     const size = Number(url.searchParams.get('size') ?? 20)
-
     return HttpResponse.json(
       {
         posts: mockPostList,
@@ -32,20 +30,18 @@ export const postHandler = [
   }),
 
   // GET /api/v1/posts/:postId — 게시글 단건 조회
-  //mockPost.post_id(305) 외 ID 접근 시 404 반환 → isError 분기 동작 확인 가능
-  http.get(toMswApiUrl(POST_ENDPOINTS.post(':postId')), async ({ params }) => {
-    await delay(400)
-
-    const postId = Number(params.postId)
-    if (postId !== mockPost.post_id) {
-      return HttpResponse.json(
-        { detail: '해당 게시글을 찾을 수 없습니다.' },
-        { status: 404 }
-      )
-    }
-
-    return HttpResponse.json(mockPost, { status: 200 })
-  }),
+  // mockPost.post_id(305) 외 ID 접근 시 404 반환 → isError 분기 동작 확인 가능
+  // http.get(toMswApiUrl(POST_ENDPOINTS.post(':postId')), async ({ params }) => {
+  //   await delay(400)
+  //   const postId = Number(params.postId)
+  //   if (postId !== mockPost.post_id) {
+  //     return HttpResponse.json(
+  //       { detail: '해당 게시글을 찾을 수 없습니다.' },
+  //       { status: 404 }
+  //     )
+  //   }
+  //   return HttpResponse.json(mockPost, { status: 200 })
+  // }),
 
   // POST /api/v1/posts — 게시글 생성
   http.post(toMswApiUrl(POST_ENDPOINTS.posts), async () => {
@@ -59,7 +55,6 @@ export const postHandler = [
   // PATCH /api/v1/posts/:postId — 게시글 수정
   http.patch(toMswApiUrl(POST_ENDPOINTS.post(':postId')), async () => {
     await delay(600)
-
     return HttpResponse.json(
       { detail: '게시글이 성공적으로 수정되었습니다.' },
       { status: 200 }
@@ -69,7 +64,6 @@ export const postHandler = [
   // GET /api/v1/posts/:postId/comments — 댓글 목록 조회 (mock)
   http.get('/api/v1/posts/:postId/comments', async () => {
     await delay(300)
-
     return HttpResponse.json({
       results: [
         {
@@ -89,9 +83,7 @@ export const postHandler = [
   // POST /api/v1/posts/:postId/comments — 댓글 작성
   http.post('/api/v1/posts/:postId/comments', async ({ request }) => {
     await delay(300)
-
     const body = (await request.json()) as { content: string }
-
     return HttpResponse.json(
       {
         id: Date.now(),

--- a/src/mocks/handlers/postHandler.ts
+++ b/src/mocks/handlers/postHandler.ts
@@ -32,7 +32,7 @@ export const postHandler = [
   }),
 
   // GET /api/v1/posts/:postId — 게시글 단건 조회
-  // mockPost.post_id(305) 외 ID 접근 시 404 반환 → isError 분기 동작 확인 가능
+  //mockPost.post_id(305) 외 ID 접근 시 404 반환 → isError 분기 동작 확인 가능
   http.get(toMswApiUrl(POST_ENDPOINTS.post(':postId')), async ({ params }) => {
     await delay(400)
 
@@ -63,6 +63,44 @@ export const postHandler = [
     return HttpResponse.json(
       { detail: '게시글이 성공적으로 수정되었습니다.' },
       { status: 200 }
+    )
+  }),
+
+  // GET /api/v1/posts/:postId/comments — 댓글 목록 조회 (mock)
+  http.get('/api/v1/posts/:postId/comments', async () => {
+    await delay(300)
+
+    return HttpResponse.json({
+      results: [
+        {
+          id: 1,
+          user_id: 2,
+          nickname: '하이룽',
+          content: '치맥이나 하자 ㅋㅋㅋㅋ',
+          created_at: '2026-04-14 10:15:00',
+          like_count: 0,
+          is_liked: false,
+          profile_image_url: null,
+        },
+      ],
+    })
+  }),
+
+  // POST /api/v1/posts/:postId/comments — 댓글 작성
+  http.post('/api/v1/posts/:postId/comments', async ({ request }) => {
+    await delay(300)
+
+    const body = (await request.json()) as { content: string }
+
+    return HttpResponse.json(
+      {
+        id: Date.now(),
+        user_id: 1,
+        nickname: '나',
+        content: body.content,
+        created_at: new Date().toISOString(),
+      },
+      { status: 201 }
     )
   }),
 ]

--- a/src/pages/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage.tsx
@@ -1,9 +1,15 @@
+import { Navigate, useParams } from 'react-router'
+
 import { PostDetailLayout } from '@/features/post-detail/components/PostDetailLayout'
 import { usePostDetailQuery } from '@/query/post/usePostDetailQuery'
 
 export function PostDetailPage() {
-  const { data: post, isLoading, error } = usePostDetailQuery(305)
+  const { postId: postIdParam } = useParams<{ postId: string }>()
+  const postId = Number(postIdParam)
 
+  const { data: post, isLoading, error } = usePostDetailQuery(postId)
+
+  if (isNaN(postId)) return <Navigate to="/not-found" replace />
   if (isLoading) return <div>로딩중</div>
   if (error) return <div>에러</div>
   if (!post) return <div>게시글 없음</div>

--- a/src/query/post/useCommentsQuery.ts
+++ b/src/query/post/useCommentsQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { apiClient } from '@/apis/apiClient'
+import type { GetCommentsApiResponse } from '@/features/post/post.api.types'
+import { mapCommentsApiToComments } from '@/features/post/post.mappers'
+
+export function useCommentsQuery(postId: number) {
+  return useQuery({
+    queryKey: ['comments', postId],
+    queryFn: async () => {
+      const { data } = await apiClient.get<GetCommentsApiResponse>(
+        `/posts/${postId}/comments`
+      )
+
+      return mapCommentsApiToComments(data)
+    },
+  })
+}

--- a/src/query/post/useCreateCommentMutation.ts
+++ b/src/query/post/useCreateCommentMutation.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { apiClient } from '@/apis/apiClient'
+import type {
+  CreateCommentApiRequest,
+  CreateCommentApiResponse,
+} from '@/features/post/post.api.types'
+import { mapCommentApiToComment } from '@/features/post/post.mappers'
+
+export function useCreateCommentMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      postId,
+      content,
+    }: {
+      postId: number
+      content: string
+    }) => {
+      const { data } = await apiClient.post<CreateCommentApiResponse>(
+        `/posts/${postId}/comments`,
+        { content } satisfies CreateCommentApiRequest
+      )
+      return mapCommentApiToComment(data)
+    },
+
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['comments', variables.postId],
+      })
+    },
+  })
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #124

## ✨ 변경 내용
- 댓글 목록 조회 API 연동 (GET /api/v1/posts/{post_id}/comments)
- 댓글 작성 API 연동 (POST /api/v1/posts/{post_id}/comments)
- PostDetailPage URL 파라미터(postId) 연동
- 댓글 입력창에 로그인 유저 프로필 이미지/닉네임 표시

## 📸 스크린샷(선택)]
<img width="846" height="700" alt="스크린샷 2026-04-28 오후 7 16 22" src="https://github.com/user-attachments/assets/db48fc3f-9d00-4ee4-b7f1-f8671103c35f" />

## 📚 참고사항
- 실제 백엔드 연결 확인 완료 (댓글 조회/작성 200 OK)
- 댓글 목록 응답 구조 백엔드 수정 완료 (`results` 래핑)
- 로그인 유저 프로필은 /accounts/me API 연동 후 교체 예정