### PR TITLE
feat: connect post detail api

### DIFF
--- a/src/apis/post/endpoints.ts
+++ b/src/apis/post/endpoints.ts
@@ -2,7 +2,9 @@ export const POST_ENDPOINTS = {
   goals: '/goals',
   tags: '/tags',
   posts: '/posts',
-  // 스웨거 기준으로 trailing slash 적용 (/posts/{id}/)
-  // Django REST API 표준에 맞춤
+
   post: (postId: number | string) => `/posts/${postId}/`,
+  postLikes: (postId: number | string) => `/posts/${postId}/likes/`,
+  postScraps: (postId: number | string) => `/posts/${postId}/scraps`,
+  postReports: (postId: number | string) => `/posts/${postId}/reports/`,
 } as const

--- a/src/apis/post/endpoints.ts
+++ b/src/apis/post/endpoints.ts
@@ -2,5 +2,7 @@ export const POST_ENDPOINTS = {
   goals: '/goals',
   tags: '/tags',
   posts: '/posts',
-  post: (postId: number | string) => `/posts/${postId}`,
+  // 스웨거 기준으로 trailing slash 적용 (/posts/{id}/)
+  // Django REST API 표준에 맞춤
+  post: (postId: number | string) => `/posts/${postId}/`,
 } as const

--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -25,7 +25,7 @@ export const postApi = {
   getPost: (postId: number) =>
     apiClient.get<ApiPostResponse>(POST_ENDPOINTS.post(postId)),
 
-  // 게시글 생성
+  // 게시글 생성a
   createPost: (body: ApiPostCreateRequest) =>
     apiClient.post<ApiPostCreateResponse>(POST_ENDPOINTS.posts, body),
 

--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -33,6 +33,23 @@ export const postApi = {
   getPosts: (params?: ApiPostListParams) =>
     apiClient.get<ApiPostListResponse>(POST_ENDPOINTS.posts, { params }),
 
+  // 게시글 수정
   updatePost: (postId: number, body: ApiPostUpdateRequest) =>
     apiClient.patch<void>(POST_ENDPOINTS.post(postId), body),
+
+  // 게시글 좋아요 토글
+  toggleLike: (postId: number) =>
+    apiClient.post<void>(POST_ENDPOINTS.postLikes(postId)),
+
+  // 게시글 스크랩
+  scrapPost: (postId: number) =>
+    apiClient.post<void>(POST_ENDPOINTS.postScraps(postId)),
+
+  // 게시글 스크랩 취소
+  unscrapPost: (postId: number) =>
+    apiClient.delete<void>(POST_ENDPOINTS.postScraps(postId)),
+
+  // 게시글 신고
+  reportPost: (postId: number) =>
+    apiClient.post<void>(POST_ENDPOINTS.postReports(postId)),
 } as const

--- a/src/features/main/post-list/PostList.tsx
+++ b/src/features/main/post-list/PostList.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router'
+
 import { AlertCircle, FileText } from 'lucide-react'
 
 import {
@@ -9,12 +11,12 @@ import {
 } from '@/components/common/ui'
 import { cn } from '@/utils/cn'
 
-import type {
-  PostListItem,
-  PostListProps,
-  PostSortOrder,
+import {
+  type PostListItem,
+  type PostListProps,
+  POSTS_PAGE_SIZE,
+  type PostSortOrder,
 } from './PostList.types'
-import { POSTS_PAGE_SIZE } from './PostList.types'
 
 export type { PostListItem, PostSortOrder }
 
@@ -134,7 +136,10 @@ const PostGrid = ({
         ))
       : posts.map(({ id, ...cardProps }) => (
           <li key={id}>
-            <PostCard {...cardProps} />
+            {/* TODO: 카드 클릭 → 상세 이동 로직 임시 연결 (추후 담당자 구현 시 제거/수정) */}
+            <Link to={`/post/${id}`} className="block">
+              <PostCard {...cardProps} />
+            </Link>
           </li>
         ))}
   </ul>

--- a/src/features/post-detail/components/PostDetailActions.tsx
+++ b/src/features/post-detail/components/PostDetailActions.tsx
@@ -1,10 +1,46 @@
 import { Bookmark, Heart, MessageCircle, Share2 } from 'lucide-react'
 
-export function PostDetailActions() {
-  const handleLike = () => console.log('like')
-  const handleComment = () => console.log('comment')
-  const handleShare = () => console.log('share')
-  const handleBookmark = () => console.log('bookmark')
+import {
+  useTogglePostLikeMutation,
+  useTogglePostScrapMutation,
+} from '@/query/post/usePostDetailActionsMutation'
+import { cn } from '@/utils/cn'
+
+type PostDetailActionsProps = {
+  postId: number
+  likeCount: number
+  commentCount: number
+  isLiked: boolean
+  isScrapped: boolean
+}
+
+export function PostDetailActions({
+  postId,
+  likeCount,
+  commentCount,
+  isLiked,
+  isScrapped,
+}: PostDetailActionsProps) {
+  const likeMutation = useTogglePostLikeMutation(postId)
+  const scrapMutation = useTogglePostScrapMutation({ postId, isScrapped })
+
+  const handleLike = () => {
+    likeMutation.mutate()
+  }
+
+  const handleComment = () => {
+    document
+      .getElementById('post-detail-comment-section')
+      ?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  const handleShare = async () => {
+    await navigator.clipboard.writeText(window.location.href)
+  }
+
+  const handleBookmark = () => {
+    scrapMutation.mutate()
+  }
 
   return (
     <div className="mb-6 flex items-center gap-4 border-b border-border-subtle pb-4">
@@ -12,27 +48,34 @@ export function PostDetailActions() {
       <button
         type="button"
         onClick={handleLike}
-        className="flex items-center gap-1 text-text-muted"
+        disabled={likeMutation.isPending}
+        className="flex items-center gap-1 text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
       >
-        <Heart size={20} strokeWidth={1} />
-        <span className="text-sm">0</span>
+        <Heart
+          size={20}
+          className={cn(
+            isLiked ? 'fill-current text-error-500' : 'text-text-primary',
+            'transition-transform duration-200'
+          )}
+        />
+        <span className="text-sm">{likeCount}</span>
       </button>
 
       {/* 댓글 */}
       <button
         type="button"
         onClick={handleComment}
-        className="flex items-center gap-1 text-text-muted"
+        className="flex items-center gap-1 text-text-primary"
       >
         <MessageCircle size={20} strokeWidth={1} />
-        <span className="text-sm">0</span>
+        <span className="text-sm">{commentCount}</span>
       </button>
 
       {/* 공유 */}
       <button
         type="button"
         onClick={handleShare}
-        className="text-text-muted"
+        className="text-text-primary"
         aria-label="공유"
       >
         <Share2 size={20} strokeWidth={1} />
@@ -42,10 +85,17 @@ export function PostDetailActions() {
       <button
         type="button"
         onClick={handleBookmark}
-        className="text-text-muted"
-        aria-label="북마크"
+        disabled={scrapMutation.isPending}
+        className="text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label={isScrapped ? '스크랩 취소' : '스크랩'}
       >
-        <Bookmark size={20} strokeWidth={1} />
+        <Bookmark
+          size={20}
+          className={cn(
+            isScrapped ? 'fill-current text-primary-600' : 'text-text-primary',
+            'transition-transform duration-200'
+          )}
+        />
       </button>
     </div>
   )

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -43,10 +43,19 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
       )}
 
       <div className="mt-8">
-        <PostDetailActions />
+        <PostDetailActions
+          postId={post.postId}
+          likeCount={post.likeCount}
+          commentCount={post.commentCount}
+          isLiked={post.isLiked}
+          isScrapped={post.isScrapped}
+        />
       </div>
 
-      <PostDetailCommentSection postId={post.postId} />
+      {/* 댓글 버튼 클릭 시 이 영역으로 스크롤 이동 */}
+      <div id="post-detail-comment-section">
+        <PostDetailCommentSection postId={post.postId} />
+      </div>
     </article>
   )
 }

--- a/src/features/post/hooks/useCommentsQuery.ts
+++ b/src/features/post/hooks/useCommentsQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { postApi } from '../post.api'
+
+export const commentsQueryKey = {
+  all: ['comments'] as const,
+  list: (postId: number) => [...commentsQueryKey.all, postId] as const,
+}
+
+export function useCommentsQuery(postId: number) {
+  return useQuery({
+    queryKey: commentsQueryKey.list(postId),
+    queryFn: () => postApi.getComments(postId),
+  })
+}

--- a/src/features/post/post.api.types.ts
+++ b/src/features/post/post.api.types.ts
@@ -57,6 +57,7 @@ export type ApiPostResponse = {
   tags: string[] | null
   like_count: number
   comment_count: number
+  is_liked: boolean
   is_scrapped: boolean
   has_goal: boolean
   goal_info: {

--- a/src/features/post/post.mappers.ts
+++ b/src/features/post/post.mappers.ts
@@ -62,6 +62,7 @@ export function toPostDetailData(api: ApiPostResponse): PostDetailData {
     tags: api.tags ?? [],
     likeCount: api.like_count,
     commentCount: api.comment_count,
+    isLiked: api.is_liked ?? false,
     isScrapped: api.is_scrapped,
     hasGoal: api.has_goal,
     goalInfo: api.goal_info

--- a/src/features/post/post.types.ts
+++ b/src/features/post/post.types.ts
@@ -68,6 +68,7 @@ export type PostDetailData = {
   content: string
   tags: string[]
   likeCount: number
+  isLiked: boolean
   commentCount: number
   isScrapped: boolean
   hasGoal: boolean

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,6 @@ import '@fontsource/pretendard/500.css'
 import '@fontsource/pretendard/700.css'
 import './index.css'
 
-/*
 async function enableMocking() {
   if (import.meta.env.DEV) {
     const { worker } = await import('./mocks/browser.ts')
@@ -17,6 +16,3 @@ async function enableMocking() {
 enableMocking().then(() => {
   createRoot(document.getElementById('root')!).render(<App />)
 })
-*/
-
-createRoot(document.getElementById('root')!).render(<App />)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import '@fontsource/pretendard/500.css'
 import '@fontsource/pretendard/700.css'
 import './index.css'
 
+/*
 async function enableMocking() {
   if (import.meta.env.DEV) {
     const { worker } = await import('./mocks/browser.ts')
@@ -16,3 +17,6 @@ async function enableMocking() {
 enableMocking().then(() => {
   createRoot(document.getElementById('root')!).render(<App />)
 })
+*/
+
+createRoot(document.getElementById('root')!).render(<App />)

--- a/src/mocks/data/post.ts
+++ b/src/mocks/data/post.ts
@@ -188,6 +188,7 @@ export const mockPost: ApiPostResponse = {
   tags: ['운동'],
   like_count: 5,
   comment_count: 3,
+  is_liked: false,
   is_scrapped: false,
   has_goal: true,
   goal_info: {

--- a/src/query/post/useCreateCommentMutation.ts
+++ b/src/query/post/useCreateCommentMutation.ts
@@ -26,8 +26,13 @@ export function useCreateCommentMutation() {
     },
 
     onSuccess: (_, variables) => {
+      //댓글 목록 갱신
       queryClient.invalidateQueries({
         queryKey: ['comments', variables.postId],
+      })
+      // 게시글 상세 같이 갱신 (commentCount 업데이트됨)
+      queryClient.invalidateQueries({
+        queryKey: ['postDetail', variables.postId],
       })
     },
   })

--- a/src/query/post/usePostDetailActionsMutation.ts
+++ b/src/query/post/usePostDetailActionsMutation.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post/post.api'
+
+export function useTogglePostLikeMutation(postId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => postApi.toggleLike(postId),
+    onSuccess: () => {
+      // 좋아요 변경 후 게시글 상세 데이터를 다시 조회
+      queryClient.invalidateQueries({ queryKey: ['postDetail', postId] })
+    },
+  })
+}
+
+export function useTogglePostScrapMutation({
+  postId,
+  isScrapped,
+}: {
+  postId: number
+  isScrapped: boolean
+}) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () =>
+      isScrapped ? postApi.unscrapPost(postId) : postApi.scrapPost(postId),
+    onSuccess: () => {
+      // 스크랩 상태 변경 후 게시글 상세 데이터를 다시 조회
+      queryClient.invalidateQueries({ queryKey: ['postDetail', postId] })
+    },
+  })
+}
+
+export function useReportPostMutation(postId: number) {
+  return useMutation({
+    mutationFn: () => postApi.reportPost(postId),
+  })
+}

--- a/src/query/post/usePostDetailQuery.ts
+++ b/src/query/post/usePostDetailQuery.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { postApi } from '@/apis/post/post.api'
-import { toPostDetailData } from '@/features/post/post.mappers.ts'
+import { toPostDetailData } from '@/features/post/post.mappers'
 
 export function usePostDetailQuery(postId: number) {
   return useQuery({
@@ -10,6 +10,6 @@ export function usePostDetailQuery(postId: number) {
       const res = await postApi.getPost(postId)
       return toPostDetailData(res.data)
     },
-    enabled: !!postId,
+    enabled: !Number.isNaN(postId),
   })
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #128

## ✨ 변경 내용

- 게시글 상세 API를 실제 서버와 연결
- MSW 게시글 상세 mock handler 비활성화
- usePostDetailQuery를 실제 API 기반으로 수정
- router params(postId)를 이용해 상세 조회하도록 변경
- trailing slash(`/posts/{id}/`) 적용으로 API 경로 수정
- 게시글 카드 → 상세 페이지 이동을 위해 임시 Link 추가

## 📸 스크린샷(선택)

<img width="963" height="1085" alt="스크린샷 2026-04-29 오전 12 17 36" src="https://github.com/user-attachments/assets/b77be57d-83bd-4f72-a6e5-f0626052bbd7" />


## 📚 참고사항

- 게시글 카드 클릭 이동은 테스트를 위해 임시로 Link를 추가했습니다.
- 투표 기능은 별도 API(`/votes`) 연동이 필요하여 현재 표시되지 않는 상태
- 콘솔에 발생하는 ranking API 404는 본 작업 범위와 무관한 별도 이슈