### PR TITLE
feat: post detail actions

### DIFF
--- a/src/apis/post/endpoints.ts
+++ b/src/apis/post/endpoints.ts
@@ -2,7 +2,9 @@ export const POST_ENDPOINTS = {
   goals: '/goals',
   tags: '/tags',
   posts: '/posts',
-  // 스웨거 기준으로 trailing slash 적용 (/posts/{id}/)
-  // Django REST API 표준에 맞춤
+
   post: (postId: number | string) => `/posts/${postId}/`,
+  postLikes: (postId: number | string) => `/posts/${postId}/likes/`,
+  postScraps: (postId: number | string) => `/posts/${postId}/scraps`,
+  postReports: (postId: number | string) => `/posts/${postId}/reports/`,
 } as const

--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -33,6 +33,20 @@ export const postApi = {
   getPosts: (params?: ApiPostListParams) =>
     apiClient.get<ApiPostListResponse>(POST_ENDPOINTS.posts, { params }),
 
+  // 게시글 수정
   updatePost: (postId: number, body: ApiPostUpdateRequest) =>
     apiClient.patch<void>(POST_ENDPOINTS.post(postId), body),
+
+  // 게시글 좋아요 토글
+  toggleLike: (postId: number) => apiClient.post(`/posts/${postId}/likes/`),
+
+  // 게시글 스크랩
+  scrapPost: (postId: number) => apiClient.post(`/posts/${postId}/scraps`),
+
+  // 게시글 스크랩 취소
+  unscrapPost: (postId: number) => apiClient.delete(`/posts/${postId}/scraps`),
+
+  // 게시글 신고
+  reportPost: (postId: number) =>
+    apiClient.post<void>(`/posts/${postId}/reports/`),
 } as const

--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -38,15 +38,18 @@ export const postApi = {
     apiClient.patch<void>(POST_ENDPOINTS.post(postId), body),
 
   // 게시글 좋아요 토글
-  toggleLike: (postId: number) => apiClient.post(`/posts/${postId}/likes/`),
+  toggleLike: (postId: number) =>
+    apiClient.post<void>(POST_ENDPOINTS.postLikes(postId)),
 
   // 게시글 스크랩
-  scrapPost: (postId: number) => apiClient.post(`/posts/${postId}/scraps`),
+  scrapPost: (postId: number) =>
+    apiClient.post<void>(POST_ENDPOINTS.postScraps(postId)),
 
   // 게시글 스크랩 취소
-  unscrapPost: (postId: number) => apiClient.delete(`/posts/${postId}/scraps`),
+  unscrapPost: (postId: number) =>
+    apiClient.delete<void>(POST_ENDPOINTS.postScraps(postId)),
 
   // 게시글 신고
   reportPost: (postId: number) =>
-    apiClient.post<void>(`/posts/${postId}/reports/`),
+    apiClient.post<void>(POST_ENDPOINTS.postReports(postId)),
 } as const

--- a/src/features/post-detail/components/PostDetailActions.tsx
+++ b/src/features/post-detail/components/PostDetailActions.tsx
@@ -1,10 +1,46 @@
 import { Bookmark, Heart, MessageCircle, Share2 } from 'lucide-react'
 
-export function PostDetailActions() {
-  const handleLike = () => console.log('like')
-  const handleComment = () => console.log('comment')
-  const handleShare = () => console.log('share')
-  const handleBookmark = () => console.log('bookmark')
+import {
+  useTogglePostLikeMutation,
+  useTogglePostScrapMutation,
+} from '@/query/post/usePostDetailActionsMutation'
+import { cn } from '@/utils/cn'
+
+type PostDetailActionsProps = {
+  postId: number
+  likeCount: number
+  commentCount: number
+  isLiked: boolean
+  isScrapped: boolean
+}
+
+export function PostDetailActions({
+  postId,
+  likeCount,
+  commentCount,
+  isLiked,
+  isScrapped,
+}: PostDetailActionsProps) {
+  const likeMutation = useTogglePostLikeMutation(postId)
+  const scrapMutation = useTogglePostScrapMutation({ postId, isScrapped })
+
+  const handleLike = () => {
+    likeMutation.mutate()
+  }
+
+  const handleComment = () => {
+    document
+      .getElementById('post-detail-comment-section')
+      ?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  const handleShare = async () => {
+    await navigator.clipboard.writeText(window.location.href)
+  }
+
+  const handleBookmark = () => {
+    scrapMutation.mutate()
+  }
 
   return (
     <div className="mb-6 flex items-center gap-4 border-b border-border-subtle pb-4">
@@ -12,27 +48,34 @@ export function PostDetailActions() {
       <button
         type="button"
         onClick={handleLike}
-        className="flex items-center gap-1 text-text-muted"
+        disabled={likeMutation.isPending}
+        className="flex items-center gap-1 text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
       >
-        <Heart size={20} strokeWidth={1} />
-        <span className="text-sm">0</span>
+        <Heart
+          size={20}
+          className={cn(
+            isLiked ? 'fill-current text-error-500' : 'text-text-primary',
+            'transition-transform duration-200'
+          )}
+        />
+        <span className="text-sm">{likeCount}</span>
       </button>
 
       {/* 댓글 */}
       <button
         type="button"
         onClick={handleComment}
-        className="flex items-center gap-1 text-text-muted"
+        className="flex items-center gap-1 text-text-primary"
       >
         <MessageCircle size={20} strokeWidth={1} />
-        <span className="text-sm">0</span>
+        <span className="text-sm">{commentCount}</span>
       </button>
 
       {/* 공유 */}
       <button
         type="button"
         onClick={handleShare}
-        className="text-text-muted"
+        className="text-text-primary"
         aria-label="공유"
       >
         <Share2 size={20} strokeWidth={1} />
@@ -42,10 +85,17 @@ export function PostDetailActions() {
       <button
         type="button"
         onClick={handleBookmark}
-        className="text-text-muted"
-        aria-label="북마크"
+        disabled={scrapMutation.isPending}
+        className="text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+        aria-label={isScrapped ? '스크랩 취소' : '스크랩'}
       >
-        <Bookmark size={20} strokeWidth={1} />
+        <Bookmark
+          size={20}
+          className={cn(
+            isScrapped ? 'fill-current text-primary-600' : 'text-text-primary',
+            'transition-transform duration-200'
+          )}
+        />
       </button>
     </div>
   )

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -43,10 +43,19 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
       )}
 
       <div className="mt-8">
-        <PostDetailActions />
+        <PostDetailActions
+          postId={post.postId}
+          likeCount={post.likeCount}
+          commentCount={post.commentCount}
+          isLiked={post.isLiked}
+          isScrapped={post.isScrapped}
+        />
       </div>
 
-      <PostDetailCommentSection postId={post.postId} />
+      {/* 댓글 버튼 클릭 시 이 영역으로 스크롤 이동 */}
+      <div id="post-detail-comment-section">
+        <PostDetailCommentSection postId={post.postId} />
+      </div>
     </article>
   )
 }

--- a/src/features/post/hooks/useCommentsQuery.ts
+++ b/src/features/post/hooks/useCommentsQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { postApi } from '../post.api'
+
+export const commentsQueryKey = {
+  all: ['comments'] as const,
+  list: (postId: number) => [...commentsQueryKey.all, postId] as const,
+}
+
+export function useCommentsQuery(postId: number) {
+  return useQuery({
+    queryKey: commentsQueryKey.list(postId),
+    queryFn: () => postApi.getComments(postId),
+  })
+}

--- a/src/features/post/post.api.types.ts
+++ b/src/features/post/post.api.types.ts
@@ -57,6 +57,7 @@ export type ApiPostResponse = {
   tags: string[] | null
   like_count: number
   comment_count: number
+  is_liked: boolean
   is_scrapped: boolean
   has_goal: boolean
   goal_info: {

--- a/src/features/post/post.mappers.ts
+++ b/src/features/post/post.mappers.ts
@@ -62,6 +62,7 @@ export function toPostDetailData(api: ApiPostResponse): PostDetailData {
     tags: api.tags ?? [],
     likeCount: api.like_count,
     commentCount: api.comment_count,
+    isLiked: api.is_liked ?? false,
     isScrapped: api.is_scrapped,
     hasGoal: api.has_goal,
     goalInfo: api.goal_info

--- a/src/features/post/post.types.ts
+++ b/src/features/post/post.types.ts
@@ -68,6 +68,7 @@ export type PostDetailData = {
   content: string
   tags: string[]
   likeCount: number
+  isLiked: boolean
   commentCount: number
   isScrapped: boolean
   hasGoal: boolean

--- a/src/mocks/data/post.ts
+++ b/src/mocks/data/post.ts
@@ -188,6 +188,7 @@ export const mockPost: ApiPostResponse = {
   tags: ['운동'],
   like_count: 5,
   comment_count: 3,
+  is_liked: false,
   is_scrapped: false,
   has_goal: true,
   goal_info: {

--- a/src/query/post/useCreateCommentMutation.ts
+++ b/src/query/post/useCreateCommentMutation.ts
@@ -26,8 +26,13 @@ export function useCreateCommentMutation() {
     },
 
     onSuccess: (_, variables) => {
+      //댓글 목록 갱신
       queryClient.invalidateQueries({
         queryKey: ['comments', variables.postId],
+      })
+      // 게시글 상세 같이 갱신 (commentCount 업데이트됨)
+      queryClient.invalidateQueries({
+        queryKey: ['postDetail', variables.postId],
       })
     },
   })

--- a/src/query/post/usePostDetailActionsMutation.ts
+++ b/src/query/post/usePostDetailActionsMutation.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post/post.api'
+
+export function useTogglePostLikeMutation(postId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => postApi.toggleLike(postId),
+    onSuccess: () => {
+      // 좋아요 변경 후 게시글 상세 데이터를 다시 조회
+      queryClient.invalidateQueries({ queryKey: ['postDetail', postId] })
+    },
+  })
+}
+
+export function useTogglePostScrapMutation({
+  postId,
+  isScrapped,
+}: {
+  postId: number
+  isScrapped: boolean
+}) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () =>
+      isScrapped ? postApi.unscrapPost(postId) : postApi.scrapPost(postId),
+    onSuccess: () => {
+      // 스크랩 상태 변경 후 게시글 상세 데이터를 다시 조회
+      queryClient.invalidateQueries({ queryKey: ['postDetail', postId] })
+    },
+  })
+}
+
+export function useReportPostMutation(postId: number) {
+  return useMutation({
+    mutationFn: () => postApi.reportPost(postId),
+  })
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #130 

## ✨ 변경 내용
- 게시글 좋아요 토글 기능 구현
- 게시글 스크랩 토글 기능 구현
- 좋아요/스크랩 상태에 따른 아이콘 색상 반영
- 댓글 작성 후 게시글 상세 재조회로 댓글 수 동기화

## 📸 스크린샷(선택)
<img width="900" height="968" alt="스크린샷 2026-04-29 오전 2 47 04" src="https://github.com/user-attachments/assets/bd758c4a-9929-4c5f-9703-7a997041e96b" />


## 📚 참고사항
- 좋아요/스크랩은 로그인 상태에서만 동작
- 인증 토큰 만료 시 재로그인 필요
- postcard 색상과 동일하게 구현