### PR TITLE
feat: integrate auth API and improve profile setup (#132)

### DIFF
--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -1,10 +1,15 @@
+// Axios 인스턴스 및 인증(interceptor) 설정 파일
 import axios, { type AxiosError, type AxiosRequestConfig } from 'axios'
 
+import type { RefreshTokenResponse } from '@/apis/auth/auth.schema'
 import { AUTH_ENDPOINTS } from '@/apis/auth/endpoints'
 import { useAuthStore } from '@/store/authStore'
 
 import { API_BASE_URL, MSW_BASE_URL } from './apiPath'
 
+// 공통 API 클라이언트 생성
+// - baseURL: 실제 서버 또는 MSW
+// - withCredentials: refresh token 쿠키 전송을 위해 필요
 export const apiClient = axios.create({
   // .env에 VITE_API_BASE_URL이 있으면 실제 API 서버를 사용하고, 없으면 MSW가 잡을 상대 경로를 사용
   baseURL: API_BASE_URL || MSW_BASE_URL,
@@ -18,7 +23,9 @@ export const apiClient = axios.create({
 })
 
 apiClient.interceptors.request.use((config) => {
-  // Zustand에 저장된 accessToken을 가져옴
+  // 요청 인터셉터
+  // - Zustand에 저장된 accessToken을 가져와서
+  // - 모든 요청 헤더에 Authorization을 자동으로 붙여줌
   const accessToken = useAuthStore.getState().accessToken
 
   // accessToken이 존재할 경우에만 Authorization 헤더에 Bearer 토큰을 추가
@@ -30,44 +37,67 @@ apiClient.interceptors.request.use((config) => {
   return config
 })
 
+// 응답 인터셉터
+// - 401 에러 발생 시 accessToken이 만료된 것으로 판단
+// - refresh token으로 새로운 accessToken을 재발급 시도
+// - 성공 시 원래 요청을 다시 실행
+// - 실패 시 세션을 초기화하고 로그인 페이지로 이동
 apiClient.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
     const status = error.response?.status
-    const requestUrl = error.config?.url ?? ''
-    const isLogoutRequest = requestUrl.includes(AUTH_ENDPOINTS.logout)
 
-    // 401: 인증 실패 (accessToken 만료 or 유효하지 않음)
-    // → refresh token으로 accessToken 재발급 시도
-    if (status === 401 && !isLogoutRequest) {
-      //무한루프 방지용
-      const originalRequest = error.config as AxiosRequestConfig & {
-        _retry?: boolean
-      }
+    const originalRequest = error.config as AxiosRequestConfig & {
+      _retry?: boolean
+    }
+
+    // 401 처리
+    if (status === 401) {
+      // 이미 한 번 재시도한 요청이면 무한루프 방지
       if (originalRequest?._retry) {
-        return Promise.reject(error)
-      }
-      originalRequest._retry = true
-
-      try {
-        // 1. refresh token을 이용해 새로운 accessToken 요청 (쿠키 기반)
-        await apiClient.post(
-          AUTH_ENDPOINTS.refreshToken,
-          {},
-          {
-            withCredentials: true,
-          }
-        )
-        // 2. refresh 성공 시, 원래 요청을 다시 실행
-        return apiClient.request(error.config!)
-      } catch {
-        // 3. refresh 실패 시 (세션 만료 등), 로그아웃 처리
         const { clearSession } = useAuthStore.getState()
         clearSession()
         window.location.href = '/login'
+        return Promise.reject(error)
+      }
+
+      // 재시도 플래그 설정
+      originalRequest._retry = true
+
+      try {
+        // refresh token으로 새로운 accessToken 요청
+        // (axios 기본 인스턴스를 사용하여 interceptor 영향 받지 않도록 함)
+        const refreshResponse = await axios.post<RefreshTokenResponse>(
+          (API_BASE_URL || MSW_BASE_URL) + AUTH_ENDPOINTS.refreshToken,
+          {},
+          { withCredentials: true }
+        )
+
+        const newAccessToken = refreshResponse.data.access_token
+
+        // 새 accessToken을 전역 상태(Zustand)에 저장
+        const { setAccessToken } = useAuthStore.getState()
+        setAccessToken(newAccessToken)
+
+        // 실패했던 요청에 새로운 토큰을 다시 주입
+        if (originalRequest.headers) {
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`
+        }
+
+        // 원래 요청을 새로운 토큰으로 재시도
+        return apiClient.request(originalRequest)
+      } catch (refreshError) {
+        // refresh도 실패한 경우 (refresh token 만료 등)
+        const { clearSession } = useAuthStore.getState()
+        // 세션 초기화 (로그아웃 처리)
+        clearSession()
+        // 로그인 페이지로 이동
+        window.location.href = '/login'
+        return Promise.reject(refreshError)
       }
     }
 
+    // 401이 아닌 에러는 그대로 반환
     return Promise.reject(error)
   }
 )

--- a/src/apis/auth/auth.schema.ts
+++ b/src/apis/auth/auth.schema.ts
@@ -18,7 +18,7 @@ export const signupRequestSchema = z.object({
   email,
   password,
   nickname,
-  profile_image_url: profileImageUrl,
+  profile_image: profileImageUrl,
   email_token: emailToken,
 })
 

--- a/src/features/auth/signup/ProfileImageSelectField.tsx
+++ b/src/features/auth/signup/ProfileImageSelectField.tsx
@@ -20,20 +20,19 @@ export function ProfileImageSelectField({
   const [isOpen, setIsOpen] = useState(false)
   const [isActive, setIsActive] = useState(false)
 
-  // 폼에는 서버로 보낼 profile_image_url을 저장하고,
-  // 화면 선택 상태는 공용 아바타 목록에서 다시 찾아서 보여줍니다.
+  // 폼에는 서버로 보낼 profile_image (code)를 저장하고,
+  // 화면에서는 해당 code로 avatar를 찾아서 보여줍니다.
   const selectedCharacter = useMemo(
     () =>
-      PROFILE_AVATAR_OPTIONS.find(
-        (character) => character.imageUrl === value
-      ) ?? DEFAULT_PROFILE_AVATAR,
+      PROFILE_AVATAR_OPTIONS.find((character) => character.code === value) ??
+      DEFAULT_PROFILE_AVATAR,
     [value]
   )
 
   const handleSelectCharacter = (code: string) => {
     const character = PROFILE_AVATAR_OPTIONS.find((item) => item.code === code)
     if (!character) return
-    onChange(character.imageUrl)
+    onChange(character.code)
     setIsActive(true)
     setIsOpen(false)
   }

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -55,7 +55,7 @@ export function SignupPage() {
       nickname: '',
       password: '',
       passwordConfirm: '',
-      profile_image_url: '',
+      profile_image: '',
       email_token: '',
     },
   })
@@ -66,7 +66,7 @@ export function SignupPage() {
     setError,
     setValue,
   } = methods
-  const profileImageUrl = useWatch({ control, name: 'profile_image_url' })
+  const profileImageUrl = useWatch({ control, name: 'profile_image' })
 
   const SignupField = AuthForm.FormField<SignupFormSchema>
   const passwordVisibility = usePasswordVisibility()
@@ -123,13 +123,13 @@ export function SignupPage() {
     email_token,
     password,
     nickname,
-    profile_image_url,
+    profile_image,
   }: SignupFormSchema) => {
     signupMutation.mutate({
       email,
       password,
       nickname,
-      profile_image_url,
+      profile_image,
       email_token,
     })
   }
@@ -160,8 +160,8 @@ export function SignupPage() {
           >
             <Button
               className={cn(
-                'py-1 min-w-17 px-0 bg-transparent hover:text-white disabled:bg-transparent disabled:text-white',
-                nicknameCheck.isChecked && 'text-white'
+                'py-1 min-w-17 px-0 bg-transparent hover:text-text-primary disabled:bg-transparent disabled:text-text-muted',
+                nicknameCheck.isChecked && 'text-text-primary'
               )}
               size={'sm'}
               variant="outline"
@@ -189,7 +189,7 @@ export function SignupPage() {
           >
             <Button
               className={cn(
-                'py-1 min-w-17 px-0 bg-transparent hover:text-white disabled:bg-transparent disabled:text-white',
+                'py-1 min-w-17 px-0 bg-transparent hover:text-text-primary disabled:bg-transparent disabled:text-text-muted',
                 emailVerification.isVerified && 'text-white'
               )}
               size={'sm'}
@@ -276,7 +276,7 @@ export function SignupPage() {
           <ProfileImageSelectField
             value={profileImageUrl}
             onChange={(value) =>
-              setValue('profile_image_url', value, {
+              setValue('profile_image', value, {
                 shouldDirty: true,
                 shouldValidate: true,
               })

--- a/src/query/auth/useLoginMutation.ts
+++ b/src/query/auth/useLoginMutation.ts
@@ -36,7 +36,6 @@ export function useLoginMutation(
   >({
     mutationFn: async (payload) => {
       const loginResponse = await authApi.login(payload)
-      console.log('🔥 login 시작', payload)
       // 먼저 accessToken을 store에 저장 (interceptor가 사용)
       const { setAccessToken } = useAuthStore.getState()
       setAccessToken(loginResponse.access_token)

--- a/src/schemas/auth/authForm.schema.ts
+++ b/src/schemas/auth/authForm.schema.ts
@@ -21,7 +21,7 @@ export const signupFormSchema = z
     password: signupPassword,
     passwordConfirm,
     nickname,
-    profile_image_url: profileImageUrl,
+    profile_image: profileImageUrl,
     email_token: emailToken,
   })
   .superRefine((data, ctx) => {


### PR DESCRIPTION
## 📌 관련 이슈

Closes #132

## ✨ 변경 내용

* 인증 API 연동 (회원가입 / 로그인 / 로그아웃)
* Access Token 기반 인증 흐름 적용 (Zustand 상태 관리)
* Axios 인터셉터 설정 (Authorization 헤더 자동 포함)
* 401 응답 시 세션 초기화 및 로그인 페이지 리다이렉트 처리
* 프로필 설정 로직 개선
    * 회원가입 시 닉네임 / 프로필 이미지 반영
    * 프로필 기본값 처리 로직 정리

## 📸 스크린샷(선택)
 
## 📚 참고사항
