### PR TITLE
fix: bug post search ranking

### DIFF
--- a/src/features/main/post-list/PostListSection.tsx
+++ b/src/features/main/post-list/PostListSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Link } from 'react-router'
 
 import { PenLine, Sparkles } from 'lucide-react'
@@ -62,7 +62,7 @@ export function PostListSection() {
 
   const { sort, page } = filters
 
-  const { data, isLoading, isError, error } = usePostListQuery(
+  const { data, isLoading, isFetching, isError, error } = usePostListQuery(
     mode,
     POSTS_PAGE_SIZE
   )
@@ -83,6 +83,12 @@ export function PostListSection() {
       ),
     [data?.total_count, data?.size]
   )
+
+  useEffect(() => {
+    if (!isFetching && data?.posts.length === 0 && page > 1) {
+      handlePageChange(page - 1)
+    }
+  }, [data, isFetching, page, handlePageChange])
 
   const errorMessage = useMemo(() => {
     const detail = error?.response?.data.error_detail

--- a/src/features/main/ranking/components/RankingItem.tsx
+++ b/src/features/main/ranking/components/RankingItem.tsx
@@ -11,8 +11,7 @@ type RankingItemProps = {
 }
 
 export function RankingItem({ user }: RankingItemProps) {
-  // profile_img_url 추후에 사용
-  const { rank, nickname, cert_count } = user
+  const { rank, nickname, cert_count, profile_img_url } = user
 
   const isTop3 = rank <= 3
   const {
@@ -41,7 +40,6 @@ export function RankingItem({ user }: RankingItemProps) {
         {isTop3 ? <Medal size={22} className="shrink-0" /> : `${rank}위`}
       </span>
 
-      {/* 프로필 이미지 TODO: 나중에 profile_img_url 사용 */}
       <div className="relative shrink-0">
         {rank === 1 && (
           <Crown
@@ -55,7 +53,7 @@ export function RankingItem({ user }: RankingItemProps) {
           className={cn('size-8 rounded-full border-2 overflow-hidden', border)}
         >
           <img
-            src={pinkCharacterImage}
+            src={profile_img_url || pinkCharacterImage}
             alt="기본 프로필"
             className="size-full object-cover"
           />

--- a/src/query/main/usePostListQuery.ts
+++ b/src/query/main/usePostListQuery.ts
@@ -15,6 +15,7 @@ type PostListMode =
 export function usePostListQuery(mode: PostListMode, size = POSTS_PAGE_SIZE) {
   return useQuery<ApiPostListResponse, AxiosError<ApiErrorResponse>>({
     queryKey: ['posts', mode],
+    retry: false,
     queryFn: async () => {
       if (mode.type === 'search') {
         const res = await postApi.searchPosts({


### PR DESCRIPTION
## 📌 관련 이슈

Closes #143

## ✨ 변경 내용

- 게시글 삭제 후 현재 페이지가 비었을 때 이전 페이지로 자동 이동
- 게시글 검색 API 400 에러 시 재시도 없이 즉시 에러 표시 (`retry: false`)
- 랭킹 프로필 이미지를 API 응답값으로 적용

## 📸 스크린샷(선택)
1. 게시글 삭제 후 이전 페이지로 이동
- Before

https://github.com/user-attachments/assets/674c6cac-ad32-4d49-946f-517bdbeef9b2

- After

https://github.com/user-attachments/assets/19658b54-db29-485e-93bb-dac51e9b3fa4



2. 게시글 검색 400 에러 발생 시 즉시 에러 표시
- Before

https://github.com/user-attachments/assets/3e8c3ddf-647e-4934-ac17-01c10ee92e72



- After

https://github.com/user-attachments/assets/149ce5c4-2327-4002-bcc0-7098e87d85b7



3. 랭킹 프로필 이미지 API 응답값으로 적용 -> 완료
## 📚 참고사항



