### PR TITLE
feat: post detail api actions

### DIFF
--- a/src/components/common/ui/comment/CommentInput.tsx
+++ b/src/components/common/ui/comment/CommentInput.tsx
@@ -48,7 +48,7 @@ export function CommentInput({
       <div className="flex flex-1 flex-col gap-2">
         <div className="relative">
           <Textarea
-            className="h-14 min-h-14 max-h-30 overflow-y-auto bg-gray-100 pr-20 pb-6 focus:bg-white"
+            className="h-14 min-h-14 max-h-30 overflow-hidden bg-gray-100 pr-20 pb-6 focus:bg-white"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder={placeholder}

--- a/src/components/common/ui/comment/CommentItem.tsx
+++ b/src/components/common/ui/comment/CommentItem.tsx
@@ -88,28 +88,41 @@ export function CommentItem({
           </div>
 
           {/* 액션 메뉴: 본인 댓글은 수정/삭제, 타인 댓글은 신고 */}
-          <ActionMenu
-            trigger={<MoreHorizontal className="h-4 w-4" />}
-            items={
-              isOwner
-                ? [
-                    {
-                      label: '수정',
-                      onClick: () => setIsEditing(true),
-                    },
-                    {
-                      label: '삭제',
-                      onClick: () => onDelete?.(id),
-                    },
-                  ]
-                : [
-                    {
-                      label: '신고',
-                      onClick: () => onReport?.(id),
-                    },
-                  ]
-            }
-          />
+          <div onClick={(e) => e.stopPropagation()}>
+            <ActionMenu
+              trigger={
+                <button
+                  type="button"
+                  className="text-text-primary"
+                  aria-label="댓글 더보기"
+                >
+                  <MoreHorizontal size={16} />
+                </button>
+              }
+              items={
+                isOwner
+                  ? [
+                      {
+                        label: '수정',
+                        onClick: () => setIsEditing(true),
+                      },
+                      {
+                        label: '삭제',
+                        onClick: () => onDelete?.(id),
+                        variant: 'danger' as const,
+                      },
+                    ]
+                  : [
+                      {
+                        label: '신고',
+                        onClick: () => onReport?.(id),
+                      },
+                    ]
+              }
+              align="right"
+              size="sm"
+            />
+          </div>
         </div>
 
         {/* 본문 / 수정 모드 */}

--- a/src/features/main/post-list/PostList.tsx
+++ b/src/features/main/post-list/PostList.tsx
@@ -8,12 +8,12 @@ import {
 } from '@/components/common/ui'
 import { cn } from '@/utils/cn'
 
-import type {
-  PostListItem,
-  PostListProps,
-  PostSortOrder,
+import {
+  type PostListItem,
+  type PostListProps,
+  POSTS_PAGE_SIZE,
+  type PostSortOrder,
 } from './PostList.types'
-import { POSTS_PAGE_SIZE } from './PostList.types'
 
 export type { PostListItem, PostSortOrder }
 

--- a/src/features/post-detail/components/PostDetailActions.tsx
+++ b/src/features/post-detail/components/PostDetailActions.tsx
@@ -1,5 +1,6 @@
 import { Bookmark, Heart, MessageCircle, Share2 } from 'lucide-react'
 
+import { Button } from '@/components/common/ui'
 import {
   useTogglePostLikeMutation,
   useTogglePostScrapMutation,
@@ -35,7 +36,11 @@ export function PostDetailActions({
   }
 
   const handleShare = async () => {
-    await navigator.clipboard.writeText(window.location.href)
+    try {
+      await navigator.clipboard.writeText(window.location.href)
+    } catch {
+      // TODO: 토스트 연결 시 공유 실패 메시지 노출
+    }
   }
 
   const handleBookmark = () => {
@@ -43,60 +48,86 @@ export function PostDetailActions({
   }
 
   return (
-    <div className="mb-6 flex items-center gap-4 border-b border-border-subtle pb-4">
-      {/* 좋아요 */}
-      <button
-        type="button"
-        onClick={handleLike}
-        disabled={likeMutation.isPending}
-        className="flex items-center gap-1 text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        <Heart
-          size={20}
-          className={cn(
-            isLiked ? 'fill-current text-error-500' : 'text-text-primary',
-            'transition-transform duration-200'
-          )}
-        />
-        <span className="text-sm">{likeCount}</span>
-      </button>
+    <div className="mb-6 flex items-center border-b border-border-subtle pb-4">
+      <div className="flex items-center gap-3">
+        {/* 좋아요 */}
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            aria-label="좋아요"
+            aria-pressed={isLiked}
+            className="group p-0 hover:bg-transparent"
+            onClick={handleLike}
+            disabled={likeMutation.isPending}
+          >
+            <Heart
+              size={20}
+              className={cn(
+                isLiked ? 'fill-current text-error-500' : 'text-text-primary',
+                'transition-transform duration-200 group-hover:scale-110'
+              )}
+            />
+          </Button>
+          <span className="tabular-nums text-sm text-text-primary">
+            {likeCount}
+          </span>
+        </div>
 
-      {/* 댓글 */}
-      <button
-        type="button"
-        onClick={handleComment}
-        className="flex items-center gap-1 text-text-primary"
-      >
-        <MessageCircle size={20} strokeWidth={1} />
-        <span className="text-sm">{commentCount}</span>
-      </button>
+        {/* 댓글 */}
+        <button
+          type="button"
+          onClick={handleComment}
+          className="flex items-center gap-1"
+          aria-label="댓글로 이동"
+        >
+          <MessageCircle
+            size={20}
+            className="text-text-primary transition-transform duration-200 hover:scale-110"
+          />
+          <span className="tabular-nums text-sm text-text-primary">
+            {commentCount}
+          </span>
+        </button>
 
-      {/* 공유 */}
-      <button
-        type="button"
-        onClick={handleShare}
-        className="text-text-primary"
-        aria-label="공유"
-      >
-        <Share2 size={20} strokeWidth={1} />
-      </button>
+        {/* 공유 */}
+        <Button
+          variant="ghost"
+          size="sm"
+          type="button"
+          aria-label="공유하기"
+          className="group p-0 hover:bg-transparent"
+          onClick={handleShare}
+        >
+          <Share2
+            size={20}
+            className="text-text-primary transition-transform duration-200 group-hover:scale-110"
+          />
+        </Button>
 
-      {/* 북마크 */}
-      <button
-        type="button"
-        onClick={handleBookmark}
-        disabled={scrapMutation.isPending}
-        className="text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
-        aria-label={isScrapped ? '스크랩 취소' : '스크랩'}
-      >
-        <Bookmark
-          size={20}
-          className={cn(
-            isScrapped ? 'fill-current text-primary-600' : 'text-text-primary',
-            'transition-transform duration-200'
-          )}
-        />
-      </button>
+        {/* 북마크 */}
+        <Button
+          variant="ghost"
+          size="sm"
+          type="button"
+          aria-label={isScrapped ? '스크랩 취소' : '스크랩'}
+          aria-pressed={isScrapped}
+          className="group p-0 hover:bg-transparent"
+          onClick={handleBookmark}
+          disabled={scrapMutation.isPending}
+        >
+          <Bookmark
+            size={20}
+            className={cn(
+              isScrapped
+                ? 'fill-current text-primary-600'
+                : 'text-text-primary',
+              'transition-transform duration-200 group-hover:scale-110'
+            )}
+          />
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/features/post-detail/components/PostDetailBody.tsx
+++ b/src/features/post-detail/components/PostDetailBody.tsx
@@ -8,9 +8,23 @@ type PostDetailBodyProps = {
 }
 
 function getImageGridClass(count: number): string {
-  if (count === 1) return 'grid-cols-1 max-w-xl'
+  if (count === 1) return 'mx-auto grid-cols-1 max-w-xl'
   if (count === 2) return 'grid-cols-2'
   return 'grid-cols-3'
+}
+
+type ImageFallbackProps = {
+  className?: string
+}
+
+function ImageFallback({ className = '' }: ImageFallbackProps) {
+  return (
+    <div
+      className={`flex h-full w-full items-center justify-center bg-gray-100 text-xs text-text-muted ${className}`}
+    >
+      이미지를 불러올 수 없습니다
+    </div>
+  )
 }
 
 export function PostDetailBody({
@@ -28,41 +42,96 @@ export function PostDetailBody({
 
   return (
     <div className="space-y-4">
-      {visibleImages.length > 0 && (
-        <div
-          className={`grid gap-3 ${getImageGridClass(visibleImages.length)}`}
-        >
-          {visibleImages.map((image, index) => {
-            if (failedImages.has(index)) return null
-
-            return (
+      {/* 이미지 영역 */}
+      {visibleImages.length === 3 ? (
+        <div className="flex h-72 gap-2">
+          {/* 왼쪽 큰 이미지 */}
+          <div className="flex-1 overflow-hidden rounded-xl bg-gray-100">
+            {!failedImages.has(0) ? (
               <img
-                key={image}
-                src={image}
-                alt={`게시글 이미지 ${index + 1}`}
-                className="aspect-4/3 w-full rounded-xl object-cover"
+                src={visibleImages[0]}
+                alt="게시글 이미지 1"
+                className="h-full w-full object-cover"
                 loading="lazy"
-                onError={() => handleImageError(index)}
+                onError={() => handleImageError(0)}
               />
-            )
-          })}
+            ) : (
+              <ImageFallback />
+            )}
+          </div>
+
+          {/* 오른쪽 작은 이미지 2개 */}
+          <div className="flex w-1/3 flex-col gap-2">
+            {[1, 2].map((index) => (
+              <div
+                key={`img-${index}`}
+                className="flex-1 overflow-hidden rounded-xl bg-gray-100"
+              >
+                {!failedImages.has(index) ? (
+                  <img
+                    src={visibleImages[index]}
+                    alt={`게시글 이미지 ${index + 1}`}
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                    onError={() => handleImageError(index)}
+                  />
+                ) : (
+                  <ImageFallback />
+                )}
+              </div>
+            ))}
+          </div>
         </div>
+      ) : (
+        visibleImages.length > 0 && (
+          <div
+            className={`grid gap-3 ${getImageGridClass(visibleImages.length)}`}
+          >
+            {visibleImages.map((image, index) => (
+              <div
+                key={`img-${index}`}
+                className="h-72 w-full overflow-hidden rounded-xl bg-gray-100"
+              >
+                {!failedImages.has(index) ? (
+                  <img
+                    src={image}
+                    alt={`게시글 이미지 ${index + 1}`}
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                    onError={() => handleImageError(index)}
+                  />
+                ) : (
+                  <ImageFallback />
+                )}
+              </div>
+            ))}
+          </div>
+        )
       )}
 
+      {/* 제목 */}
       <h1 className="text-xl font-semibold text-text-primary">{title}</h1>
 
-      <p className="text-sm leading-relaxed text-text-muted">{content}</p>
+      {/* 내용 (빈 값이면 렌더 안함) */}
+      {content && (
+        <p className="whitespace-pre-wrap break-all text-sm leading-relaxed text-text-muted">
+          {content}
+        </p>
+      )}
 
-      <div className="mt-4 flex flex-wrap gap-2">
-        {tags.map((tag, index) => (
-          <span
-            key={`${tag}-${index}`}
-            className="max-w-fit break-all rounded-md bg-gray-100 px-2 py-1 text-xs text-text-muted"
-          >
-            #{tag}
-          </span>
-        ))}
-      </div>
+      {/* 태그 */}
+      {tags.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {tags.map((tag, index) => (
+            <span
+              key={`${tag}-${index}`}
+              className="max-w-fit break-all rounded-md bg-gray-100 px-2 py-1 text-xs text-text-muted"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/features/post-detail/components/PostDetailCommentSection.tsx
+++ b/src/features/post-detail/components/PostDetailCommentSection.tsx
@@ -1,22 +1,21 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import type { AxiosError } from 'axios'
+
+import type { ApiErrorResponse } from '@/apis/api.types'
+import { formatError } from '@/apis/api.utils'
 import { ReportFormModal } from '@/components/common/overlay/modal/form/ReportFormModal'
 import { CommentInput, CommentList, useToast } from '@/components/common/ui'
+import { POST_REPORT_REASONS } from '@/components/common/ui/card/usePostCardReport'
 import { useCommentsQuery } from '@/query/post/useCommentsQuery'
 import { useCreateCommentMutation } from '@/query/post/useCreateCommentMutation'
 import { useDeleteCommentMutation } from '@/query/post/useDeleteCommentMutation'
+import { usePostDetailQuery } from '@/query/post/usePostDetailQuery'
 import { useReportCommentMutation } from '@/query/post/useReportCommentMutation'
 import { useToggleCommentLikeMutation } from '@/query/post/useToggleCommentLikeMutation'
 import { useUpdateCommentMutation } from '@/query/post/useUpdateCommentMutation'
 import { useAuthStore } from '@/store/authStore'
-
-const reportOptions = [
-  { label: '욕설/비방', value: 'abuse' },
-  { label: '스팸/광고', value: 'spam' },
-  { label: '부적절한 내용', value: 'inappropriate' },
-  { label: '기타', value: 'etc' },
-]
 
 type PostDetailCommentSectionProps = {
   postId: number
@@ -30,10 +29,13 @@ export function PostDetailCommentSection({
   const toast = useToast()
 
   const { data: comments = [], isLoading, isError } = useCommentsQuery(postId)
-  const { mutate: createComment, isPending } = useCreateCommentMutation()
+  const { refetch: refetchPostDetail } = usePostDetailQuery(postId)
+
+  const { mutateAsync: createComment, isPending } = useCreateCommentMutation()
   const { mutate: toggleCommentLike } = useToggleCommentLikeMutation(postId)
   const { mutate: deleteComment } = useDeleteCommentMutation(postId)
-  const { mutate: reportComment } = useReportCommentMutation()
+  const { mutate: reportComment, isPending: isReportPending } =
+    useReportCommentMutation()
   const { mutate: updateComment } = useUpdateCommentMutation(postId)
 
   const [reportCommentId, setReportCommentId] = useState<number | null>(null)
@@ -49,10 +51,15 @@ export function PostDetailCommentSection({
   }
 
   // 댓글 작성
-  const handleSubmitComment = (content: string) => {
+  const handleSubmitComment = async (content: string) => {
     if (requireLogin()) return
 
-    createComment({ postId, content })
+    try {
+      await createComment({ postId, content })
+      refetchPostDetail()
+    } catch {
+      toast.error('댓글 작성에 실패했습니다.')
+    }
   }
 
   // 댓글 좋아요
@@ -72,7 +79,11 @@ export function PostDetailCommentSection({
   const handleDeleteComment = (commentId: number) => {
     if (requireLogin()) return
 
-    deleteComment(commentId)
+    deleteComment(commentId, {
+      onSuccess: () => {
+        refetchPostDetail()
+      },
+    })
   }
 
   // 댓글 수정
@@ -111,15 +122,13 @@ export function PostDetailCommentSection({
           toast.success('신고가 접수되었습니다.')
           setReportCommentId(null)
         },
-        onError: (error: any) => {
-          const status = error?.response?.status
+        onError: (error) => {
+          const axiosError = error as AxiosError<ApiErrorResponse>
+          const detail = axiosError.response?.data.error_detail
 
-          if (status === 409) {
-            toast.error('이미 신고된 댓글입니다.')
-            return
-          }
-
-          toast.error('신고에 실패했습니다.')
+          toast.error(
+            detail ? formatError(detail) : '신고 접수에 실패했습니다.'
+          )
         },
       }
     )
@@ -161,7 +170,8 @@ export function PostDetailCommentSection({
       {reportCommentId ? (
         <ReportFormModal
           title="신고 선택 및 작성"
-          options={reportOptions}
+          options={POST_REPORT_REASONS}
+          isSubmitting={isReportPending}
           onClose={() => setReportCommentId(null)}
           onSubmit={handleSubmitReport}
         />

--- a/src/features/post-detail/components/PostDetailHeader.tsx
+++ b/src/features/post-detail/components/PostDetailHeader.tsx
@@ -1,30 +1,63 @@
+import { MoreVertical } from 'lucide-react'
+
+import { ActionMenu } from '@/components/common/overlay'
+
 type PostDetailHeaderProps = {
   author: {
     nickname: string
     profileImageUrl?: string | null
   }
   createdAt: string
+  isOwner: boolean
+  onDelete: () => void
+  onReport: () => void
 }
 
-export function PostDetailHeader({ author, createdAt }: PostDetailHeaderProps) {
+export function PostDetailHeader({
+  author,
+  createdAt,
+  isOwner,
+  onDelete,
+  onReport,
+}: PostDetailHeaderProps) {
   return (
-    <div className="mt-9 flex items-center gap-3">
-      <div className="h-10 w-10 overflow-hidden rounded-full bg-gray-200">
-        {author.profileImageUrl ? (
-          <img
-            src={author.profileImageUrl}
-            alt={`${author.nickname}의 프로필 이미지`}
-            className="h-full w-full object-cover"
-          />
-        ) : null}
+    <div className="mt-9 flex items-center justify-between">
+      {/* 왼쪽 (프로필) */}
+      <div className="flex items-center gap-3">
+        <div className="h-10 w-10 overflow-hidden rounded-full bg-gray-200">
+          {author.profileImageUrl ? (
+            <img
+              src={author.profileImageUrl}
+              alt={`${author.nickname}의 프로필 이미지`}
+              className="h-full w-full object-cover"
+            />
+          ) : null}
+        </div>
+
+        <div className="flex flex-col">
+          <span className="text-sm font-medium text-text-primary">
+            {author.nickname}
+          </span>
+          <span className="text-xs text-text-muted">{createdAt}</span>
+        </div>
       </div>
 
-      <div className="flex flex-col">
-        <span className="text-sm font-medium text-text-primary">
-          {author.nickname}
-        </span>
-        <span className="text-xs text-text-muted">{createdAt}</span>
-      </div>
+      {/* 오른쪽 (더보기 메뉴) */}
+      <ActionMenu
+        trigger={
+          <button type="button" className="text-text-primary">
+            <MoreVertical size={20} />
+          </button>
+        }
+        items={
+          isOwner
+            ? [
+                { label: '수정', onClick: () => {} },
+                { label: '삭제', onClick: onDelete },
+              ]
+            : [{ label: '신고', onClick: onReport }]
+        }
+      />
     </div>
   )
 }

--- a/src/features/post-detail/components/PostDetailHeader.tsx
+++ b/src/features/post-detail/components/PostDetailHeader.tsx
@@ -1,6 +1,13 @@
 import { MoreVertical } from 'lucide-react'
 
 import { ActionMenu } from '@/components/common/overlay'
+import { formatRelativeTime } from '@/utils/formatRelativeTime'
+
+type MenuItem = {
+  label: string
+  onClick: () => void
+  variant?: 'default' | 'danger'
+}
 
 type PostDetailHeaderProps = {
   author: {
@@ -8,17 +15,13 @@ type PostDetailHeaderProps = {
     profileImageUrl?: string | null
   }
   createdAt: string
-  isOwner: boolean
-  onDelete: () => void
-  onReport: () => void
+  menuItems: MenuItem[]
 }
 
 export function PostDetailHeader({
   author,
   createdAt,
-  isOwner,
-  onDelete,
-  onReport,
+  menuItems,
 }: PostDetailHeaderProps) {
   return (
     <div className="mt-9 flex items-center justify-between">
@@ -38,7 +41,9 @@ export function PostDetailHeader({
           <span className="text-sm font-medium text-text-primary">
             {author.nickname}
           </span>
-          <span className="text-xs text-text-muted">{createdAt}</span>
+          <span className="text-xs text-text-muted">
+            {formatRelativeTime(createdAt)}
+          </span>
         </div>
       </div>
 
@@ -49,14 +54,9 @@ export function PostDetailHeader({
             <MoreVertical size={20} />
           </button>
         }
-        items={
-          isOwner
-            ? [
-                { label: '수정', onClick: () => {} },
-                { label: '삭제', onClick: onDelete },
-              ]
-            : [{ label: '신고', onClick: onReport }]
-        }
+        items={menuItems}
+        align="right"
+        size="sm"
       />
     </div>
   )

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -1,7 +1,17 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 
+import type { AxiosError } from 'axios'
+
+import type { ApiErrorResponse } from '@/apis/api.types'
+import { formatError } from '@/apis/api.utils'
+import { ConfirmModal } from '@/components/common/overlay/modal/confirm/ConfirmModal'
+import { ReportFormModal } from '@/components/common/overlay/modal/form/ReportFormModal'
+import { POST_REPORT_REASONS } from '@/components/common/ui/card/usePostCardReport'
+import { useToast } from '@/components/common/ui/toast/useToast'
 import type { PostDetailData } from '@/features/post/post.types'
 import { useDeletePostMutation } from '@/query/post/useDeletePostMutation'
+import { useReportPostMutation } from '@/query/post/useReportPostMutation'
 
 import { PostDetailActions } from './PostDetailActions'
 import { PostDetailBody } from './PostDetailBody'
@@ -15,70 +25,149 @@ type PostDetailLayoutProps = {
 
 export function PostDetailLayout({ post }: PostDetailLayoutProps) {
   const navigate = useNavigate()
+  const toast = useToast()
+
   const deleteMutation = useDeletePostMutation()
+  const reportMutation = useReportPostMutation()
+
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  const [isReportModalOpen, setIsReportModalOpen] = useState(false)
+
+  // TODO: 백엔드에서 userId 또는 isOwner 내려주면 교체 필요
+  const currentUserNickname = '테스트유저1'
+  const isOwner = post.nickname === currentUserNickname
 
   const handleDelete = () => {
-    const ok = window.confirm('게시글을 삭제하시겠습니까?')
-    if (!ok) return
+    setIsDeleteModalOpen(true)
+  }
 
+  const handleConfirmDelete = () => {
     deleteMutation.mutate(post.postId, {
       onSuccess: () => {
+        setIsDeleteModalOpen(false)
         navigate('/')
+      },
+      onError: (error) => {
+        const axiosError = error as AxiosError<ApiErrorResponse>
+        const detail = axiosError.response?.data.error_detail
+
+        toast.error(
+          detail ? formatError(detail) : '게시글 삭제에 실패했습니다.'
+        )
       },
     })
   }
 
   const handleReport = () => {
-    // 팀원 useReportPostMutation 머지 후 여기 연결
+    setIsReportModalOpen(true)
   }
 
+  const handleReportSubmit = (data: { reason: string; content: string }) => {
+    reportMutation.mutate(
+      {
+        postId: post.postId,
+        reasonType: data.reason,
+        reasonDetail: data.content,
+      },
+      {
+        onSuccess: () => {
+          toast.success('신고가 접수되었습니다.')
+          setIsReportModalOpen(false)
+        },
+        onError: (error) => {
+          const axiosError = error as AxiosError<ApiErrorResponse>
+          const detail = axiosError.response?.data.error_detail
+
+          toast.error(
+            detail ? formatError(detail) : '신고 접수에 실패했습니다.'
+          )
+        },
+      }
+    )
+  }
+
+  const ownerMenuItems = [
+    { label: '수정', onClick: () => navigate(`/post/${post.postId}/edit`) },
+    {
+      label: '삭제',
+      onClick: handleDelete,
+      variant: 'danger' as const,
+    },
+  ]
+
+  const guestMenuItems = [{ label: '신고', onClick: handleReport }]
+
+  const menuItems = isOwner ? ownerMenuItems : guestMenuItems
+
   return (
-    <article className="rounded-2xl border border-border-default bg-white px-16 py-6 shadow-card-main">
-      <PostDetailHeader
-        author={{
-          nickname: post.nickname,
-          profileImageUrl: post.profileImageUrl,
-        }}
-        createdAt={post.createdAt}
-        isOwner={false}
-        onDelete={handleDelete}
-        onReport={handleReport}
-      />
-
-      <div className="mt-6">
-        <PostDetailBody
-          title={post.title}
-          content={post.content}
-          tags={post.tags}
-          images={post.images}
+    <>
+      <article className="w-full max-w-4xl rounded-2xl border border-border-default bg-white px-8 py-6 shadow-card-main">
+        <PostDetailHeader
+          author={{
+            nickname: post.nickname,
+            profileImageUrl: post.profileImageUrl,
+          }}
+          createdAt={post.createdAt}
+          menuItems={menuItems}
         />
-      </div>
 
-      {post.hasGoal && post.goalInfo && (
         <div className="mt-6">
-          <PostGoalSection
-            title={post.goalInfo.title}
-            startDate={post.goalInfo.startDate ?? ''}
-            endDate={post.goalInfo.endDate ?? ''}
-            progressRate={post.goalInfo.progressRate ?? 0}
-            status="in_progress"
+          <PostDetailBody
+            title={post.title}
+            content={post.content}
+            tags={post.tags}
+            images={post.images}
           />
         </div>
+
+        {post.hasGoal && post.goalInfo && (
+          <div className="mt-6">
+            <PostGoalSection
+              title={post.goalInfo.title}
+              startDate={post.goalInfo.startDate ?? ''}
+              endDate={post.goalInfo.endDate ?? ''}
+              progressRate={post.goalInfo.progressRate ?? 0}
+              status="in_progress"
+            />
+          </div>
+        )}
+
+        <div className="mt-8">
+          <PostDetailActions
+            postId={post.postId}
+            likeCount={post.likeCount}
+            commentCount={post.commentCount}
+            isLiked={post.isLiked}
+            isScrapped={post.isScrapped}
+          />
+        </div>
+
+        <div id="post-detail-comment-section">
+          <PostDetailCommentSection postId={post.postId} />
+        </div>
+      </article>
+
+      {/* 삭제 확인 모달 */}
+      {isDeleteModalOpen && (
+        <ConfirmModal
+          description="게시글을 삭제하시겠습니까? 삭제된 게시글은 복구할 수 없습니다."
+          confirmLabel="삭제"
+          cancelLabel="취소"
+          onConfirm={handleConfirmDelete}
+          onClose={() => setIsDeleteModalOpen(false)}
+        />
       )}
 
-      <div className="mt-8">
-        <PostDetailActions
-          postId={post.postId}
-          likeCount={post.likeCount}
-          commentCount={post.commentCount}
-          isLiked={post.isLiked}
-          isScrapped={post.isScrapped}
+      {/* 신고 모달 */}
+      {isReportModalOpen && (
+        <ReportFormModal
+          title="게시글 신고"
+          options={POST_REPORT_REASONS}
+          isSubmitting={reportMutation.isPending}
+          onSubmit={handleReportSubmit}
+          onClose={() => setIsReportModalOpen(false)}
         />
-      </div>
-
-      <div id="post-detail-comment-section">
-        <PostDetailCommentSection postId={post.postId} />
-      </div>
-    </article>
+      )}
+    </>
   )
 }

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -1,4 +1,7 @@
+import { useNavigate } from 'react-router'
+
 import type { PostDetailData } from '@/features/post/post.types'
+import { useDeletePostMutation } from '@/query/post/useDeletePostMutation'
 
 import { PostDetailActions } from './PostDetailActions'
 import { PostDetailBody } from './PostDetailBody'
@@ -11,6 +14,24 @@ type PostDetailLayoutProps = {
 }
 
 export function PostDetailLayout({ post }: PostDetailLayoutProps) {
+  const navigate = useNavigate()
+  const deleteMutation = useDeletePostMutation()
+
+  const handleDelete = () => {
+    const ok = window.confirm('게시글을 삭제하시겠습니까?')
+    if (!ok) return
+
+    deleteMutation.mutate(post.postId, {
+      onSuccess: () => {
+        navigate('/')
+      },
+    })
+  }
+
+  const handleReport = () => {
+    // 팀원 useReportPostMutation 머지 후 여기 연결
+  }
+
   return (
     <article className="rounded-2xl border border-border-default bg-white px-16 py-6 shadow-card-main">
       <PostDetailHeader
@@ -19,6 +40,9 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
           profileImageUrl: post.profileImageUrl,
         }}
         createdAt={post.createdAt}
+        isOwner={false}
+        onDelete={handleDelete}
+        onReport={handleReport}
       />
 
       <div className="mt-6">
@@ -52,7 +76,6 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
         />
       </div>
 
-      {/* 댓글 버튼 클릭 시 이 영역으로 스크롤 이동 */}
       <div id="post-detail-comment-section">
         <PostDetailCommentSection postId={post.postId} />
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -586,3 +586,9 @@ input:-webkit-autofill:focus {
     translate: 0 0;
   }
 }
+
+/* 스크롤바가 생길 때 레이아웃이 왼쪽으로 밀리는 현상 방지
+   → 스크롤바 공간을 항상 미리 확보해서 UI 흔들림 제거 */
+html {
+  scrollbar-gutter: stable;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import '@fontsource/pretendard/500.css'
 import '@fontsource/pretendard/700.css'
 import './index.css'
 
+/*
 async function enableMocking() {
   if (import.meta.env.DEV) {
     const { worker } = await import('./mocks/browser.ts')
@@ -16,3 +17,5 @@ async function enableMocking() {
 enableMocking().then(() => {
   createRoot(document.getElementById('root')!).render(<App />)
 })
+*/
+createRoot(document.getElementById('root')!).render(<App />)

--- a/src/pages/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage.tsx
@@ -1,5 +1,7 @@
 import { Navigate, useParams } from 'react-router'
 
+import type { AxiosError } from 'axios'
+
 import { PostDetailLayout } from '@/features/post-detail/components/PostDetailLayout'
 import { usePostDetailQuery } from '@/query/post/usePostDetailQuery'
 
@@ -11,13 +13,21 @@ export function PostDetailPage() {
 
   if (!Number.isFinite(postId)) return <Navigate to="/not-found" replace />
   if (isLoading) return <div>로딩중</div>
-  if (error) return <div>에러</div>
+
+  if (error) {
+    const axiosError = error as AxiosError
+
+    if (axiosError.response?.status === 404) {
+      return <Navigate to="/not-found" replace />
+    }
+
+    return <div>에러가 발생했습니다.</div>
+  }
+
   if (!post) return <div>게시글 없음</div>
 
-  console.log(post)
-
   return (
-    <div className="flex min-h-full justify-start">
+    <div className="flex min-h-full justify-center">
       <PostDetailLayout post={post} />
     </div>
   )

--- a/src/pages/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage.tsx
@@ -9,10 +9,12 @@ export function PostDetailPage() {
 
   const { data: post, isLoading, error } = usePostDetailQuery(postId)
 
-  if (isNaN(postId)) return <Navigate to="/not-found" replace />
+  if (!Number.isFinite(postId)) return <Navigate to="/not-found" replace />
   if (isLoading) return <div>로딩중</div>
   if (error) return <div>에러</div>
   if (!post) return <div>게시글 없음</div>
+
+  console.log(post)
 
   return (
     <div className="flex min-h-full justify-start">

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -1,5 +1,7 @@
 import { Navigate, useNavigate, useParams } from 'react-router'
 
+import { useQueryClient } from '@tanstack/react-query'
+
 import { useToast } from '@/components/common/ui'
 import {
   PostFormLayout,
@@ -10,6 +12,7 @@ import { usePostQuery, useUpdatePostMutation } from '@/query/post'
 
 export function PostEditPage() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const toast = useToast()
   const { id } = useParams<{ id: string }>()
   const postId = Number(id)
@@ -18,13 +21,17 @@ export function PostEditPage() {
 
   const { mutate: updatePost, isPending } = useUpdatePostMutation(postId, {
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['postDetail', postId] })
+      queryClient.invalidateQueries({ queryKey: ['post', postId] })
+      queryClient.invalidateQueries({ queryKey: ['posts'] })
+
       toast.success('게시글이 수정되었습니다.')
-      navigate('/')
+      navigate(`/post/${postId}`)
     },
     onError: () => toast.error('게시글 수정에 실패했습니다.'),
   })
 
-  if (isNaN(postId)) return <Navigate to="/not-found" replace />
+  if (!Number.isFinite(postId)) return <Navigate to="/not-found" replace />
   if (isLoading) return <PostFormSkeleton />
   if (isError || !post) return <Navigate to="/not-found" replace />
 

--- a/src/query/post/useDeleteCommentMutation.ts
+++ b/src/query/post/useDeleteCommentMutation.ts
@@ -13,8 +13,14 @@ export function useDeleteCommentMutation(postId: number) {
       apiClient.delete(POST_ENDPOINTS.comment(postId, commentId)),
 
     onSuccess: () => {
+      // 댓글 리스트 갱신
       queryClient.invalidateQueries({
         queryKey: ['comments', postId],
+      })
+
+      // 게시글 상세 다시 가져오기 (commentCount 갱신)
+      queryClient.invalidateQueries({
+        queryKey: ['postDetail', postId],
       })
     },
   })

--- a/src/query/post/usePostDetailActionsMutation.ts
+++ b/src/query/post/usePostDetailActionsMutation.ts
@@ -33,25 +33,9 @@ export function useTogglePostScrapMutation({
   })
 }
 
-<<<<<<< HEAD
-// TODO: 포스트 디테일 페이지에서 신고가 필요할 때는 src/query/post에서 useReportPostMutation을 import해서 사용하면 됩니다.
-
-// export function useReportPostMutation(postId: number) {
-//   return useMutation({
-//     mutationFn: (body: { reason_type: string; reason_detail: string }) =>
-//       postApi.reportPost(postId, body),
-//   })
-// }
-=======
-export function useDeletePostMutation(postId: number) {
-  const queryClient = useQueryClient()
-
+export function useReportPostMutation(postId: number) {
   return useMutation({
-    mutationFn: () => postApi.deletePost(postId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['posts'] })
-      queryClient.invalidateQueries({ queryKey: ['postDetail', postId] })
-    },
+    mutationFn: (body: { reason_type: string; reason_detail: string }) =>
+      postApi.reportPost(postId, body),
   })
 }
->>>>>>> 84abc54 (feat: connect post detail api (#138))

--- a/src/query/post/usePostDetailActionsMutation.ts
+++ b/src/query/post/usePostDetailActionsMutation.ts
@@ -33,6 +33,7 @@ export function useTogglePostScrapMutation({
   })
 }
 
+<<<<<<< HEAD
 // TODO: 포스트 디테일 페이지에서 신고가 필요할 때는 src/query/post에서 useReportPostMutation을 import해서 사용하면 됩니다.
 
 // export function useReportPostMutation(postId: number) {
@@ -41,3 +42,16 @@ export function useTogglePostScrapMutation({
 //       postApi.reportPost(postId, body),
 //   })
 // }
+=======
+export function useDeletePostMutation(postId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => postApi.deletePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['posts'] })
+      queryClient.invalidateQueries({ queryKey: ['postDetail', postId] })
+    },
+  })
+}
+>>>>>>> 84abc54 (feat: connect post detail api (#138))

--- a/src/query/post/usePostDetailQuery.ts
+++ b/src/query/post/usePostDetailQuery.ts
@@ -10,6 +10,6 @@ export function usePostDetailQuery(postId: number) {
       const res = await postApi.getPost(postId)
       return toPostDetailData(res.data)
     },
-    enabled: !Number.isNaN(postId),
+    enabled: Number.isFinite(postId),
   })
 }

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -77,6 +77,10 @@ export const router = createBrowserRouter([
     ),
   },
   {
+    path: '/not-found',
+    element: <NotFoundPage />,
+  },
+  {
     path: '*',
     element: <NotFoundPage />,
   },


### PR DESCRIPTION
## 📌 관련 이슈

Closes #138

## ✨ 변경 내용

- 게시글 상세 API 연결 및 데이터 렌더링 구현
- 게시글 좋아요 / 스크랩 기능 연결
- 게시글 삭제 및 신고 기능 구현
- 댓글 조회 / 작성 / 수정 / 삭제 / 좋아요 / 신고 기능 구현
- 댓글 작성/삭제 시 댓글 수 실시간 동기화 처리
- 게시글/댓글 더보기(ActionMenu) UI 및 동작 통일
- 게시글 상세 404 처리 추가
- 게시글 이미지 레이아웃 개선 (1~3장 대응)
  - 3장일 경우 1큰 + 2작은 레이아웃 적용
- 이미지 로드 실패 시 fallback UI 추가
- 댓글 입력/스크롤 시 레이아웃 흔들림 문제 해결
- 상대 시간 표시 (게시글/댓글 통일)

## 📸 스크린샷(선택)
<img width="1073" height="753" alt="스크린샷 2026-05-03 오전 2 28 37" src="https://github.com/user-attachments/assets/0b1980ef-ca1d-4462-ac2a-c89166f314ad" />

<img width="1090" height="737" alt="스크린샷 2026-05-03 오전 2 29 10" src="https://github.com/user-attachments/assets/5b50fc4f-9bd1-4c00-aceb-3ff04a937628" />

<img width="1109" height="833" alt="스크린샷 2026-05-03 오전 2 29 24" src="https://github.com/user-attachments/assets/cb6e6c56-4508-4845-8ea2-c368d615b1ca" />

(지금 용량이 부족해서 영상으로 못 올렸습니다.)

## 📚 참고사항

- 작성자 여부(isOwner)는 현재 nickname 기반 임시 로직으로 처리되어 있으며,
  백엔드에서 userId 또는 isOwner 필드 제공 시 교체 예정입니다.
- 게시글 북마크(스크랩) 기능은 별도 이슈로 분리하여 보완 예정입니다.
- 댓글 무한스크롤 및 다크모드는 별도 브랜치에서 진행 예정입니다.
- 이미지 개수에 따라 레이아웃을 분기했습니다. (선호하거나 추천하는 배치가 있다면 알려주십쇼..)
- 이미지 확대 보기(라이트박스)와 이미지 로딩 스켈레톤은 별도 UX 개선 이슈로 분리 예정입니다.