### PR TITLE
feat: fetch profile images when opening signup modal (#152)

### DIFF
--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -104,6 +104,13 @@ export const authApi = {
     return authSchema.meResponseSchema.parse(data)
   },
 
+  getProfileImages: async (): Promise<authSchema.ProfileImagesResponse> => {
+    const { data } = await apiClient.get<authSchema.ProfileImagesResponse>(
+      AUTH_ENDPOINTS.profileImages
+    )
+    return authSchema.profileImagesResponseSchema.parse(data)
+  },
+
   login: async (
     payload: authSchema.LoginRequest
   ): Promise<authSchema.LoginResponse> => {

--- a/src/apis/auth/auth.schema.ts
+++ b/src/apis/auth/auth.schema.ts
@@ -127,6 +127,17 @@ export const meResponseSchema = z.object({
   profile_image_url: z.string(),
 })
 
+// REQ-AUTH-012: 프로필 이미지 목록
+// GET /api/v1/accounts/profile-images
+export const profileImageSchema = z.object({
+  code: z.string(),
+  image_url: z.string(),
+})
+
+export const profileImagesResponseSchema = z.object({
+  detail: z.array(profileImageSchema),
+})
+
 // Zod 스키마 기반 타입 추론
 // z.infer<typeof schema>를 사용하면,
 // Zod로 정의한 스키마를 기준으로 TypeScript 타입을 자동 생성
@@ -171,3 +182,5 @@ export type SessionExpiredResponse = z.infer<
 export type CheckNicknameRequest = z.infer<typeof checkNicknameRequestSchema>
 export type CheckNicknameResponse = z.infer<typeof checkNicknameResponseSchema>
 export type MeResponse = z.infer<typeof meResponseSchema>
+export type ProfileImage = z.infer<typeof profileImageSchema>
+export type ProfileImagesResponse = z.infer<typeof profileImagesResponseSchema>

--- a/src/apis/auth/endpoints.ts
+++ b/src/apis/auth/endpoints.ts
@@ -4,6 +4,7 @@ export const AUTH_ENDPOINTS = {
   login: '/accounts/login',
   logout: '/accounts/logout',
   me: '/accounts/me',
+  profileImages: '/accounts/profile-images',
   sendEmailVerification: '/accounts/verification/send-email',
   verifyEmail: '/accounts/verification/verify-email',
   checkNickname: '/accounts/check-nickname',

--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -10,6 +10,8 @@ export type {
   LoginUnauthorizedResponse,
   LogoutResponse,
   NaverLoginCallbackRequest,
+  ProfileImage,
+  ProfileImagesResponse,
   RefreshTokenResponse,
   SendEmailVerificationRequest,
   SendEmailVerificationResponse,

--- a/src/components/common/overlay/modal/character/CharacterSelectModal.stories.tsx
+++ b/src/components/common/overlay/modal/character/CharacterSelectModal.stories.tsx
@@ -1,9 +1,36 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import blueCharacterImage from '@/assets/images/blue_character.png'
+import orangeCharacterImage from '@/assets/images/orange_character.png'
+import pinkCharacterImage from '@/assets/images/pink_character.png'
+import yellowCharacterImage from '@/assets/images/yellow_character.png'
 import { useModal } from '@/hooks/useModal'
-import { PROFILE_AVATAR_OPTIONS } from '@/shared/profileAvatar'
+import type { ProfileAvatarOption } from '@/shared/profileAvatar'
 
 import { CharacterSelectModal } from './CharacterSelectModal'
+
+const profileAvatarOptions: ProfileAvatarOption[] = [
+  {
+    code: 'avatar_01',
+    imageUrl: pinkCharacterImage,
+    label: '캐릭터 1',
+  },
+  {
+    code: 'avatar_02',
+    imageUrl: yellowCharacterImage,
+    label: '캐릭터 2',
+  },
+  {
+    code: 'avatar_03',
+    imageUrl: blueCharacterImage,
+    label: '캐릭터 3',
+  },
+  {
+    code: 'avatar_04',
+    imageUrl: orangeCharacterImage,
+    label: '캐릭터 4',
+  },
+]
 
 const meta: Meta<typeof CharacterSelectModal> = {
   component: CharacterSelectModal,
@@ -40,7 +67,7 @@ export const Default: Story = {
     )
   },
   args: {
-    characters: PROFILE_AVATAR_OPTIONS,
+    characters: profileAvatarOptions,
     onSelect: () => {},
     onClose: () => {},
   },
@@ -56,7 +83,7 @@ export const Dark: Story = {
   ],
   render: (args) => <CharacterSelectModal {...args} />,
   args: {
-    characters: PROFILE_AVATAR_OPTIONS,
+    characters: profileAvatarOptions,
     onSelect: () => {},
     onClose: () => {},
   },

--- a/src/features/auth/signup/ProfileImageSelectField.tsx
+++ b/src/features/auth/signup/ProfileImageSelectField.tsx
@@ -1,11 +1,9 @@
 import { useMemo, useState } from 'react'
 
+import { pinkCharacterImage } from '@/assets/images'
 import { CharacterSelectModal } from '@/components/common/overlay'
-import {
-  DEFAULT_PROFILE_AVATAR,
-  getProfileAvatarImageUrl,
-  PROFILE_AVATAR_OPTIONS,
-} from '@/shared/profileAvatar'
+import { useProfileImagesQuery } from '@/query/auth/useProfileImagesQuery'
+import { getProfileAvatarImageUrl } from '@/shared/profileAvatar'
 import { cn } from '@/utils/cn'
 
 type ProfileImageSelectFieldProps = {
@@ -19,22 +17,46 @@ export function ProfileImageSelectField({
 }: ProfileImageSelectFieldProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [isActive, setIsActive] = useState(false)
+  const {
+    data: profileAvatarOptions = [],
+    isFetching,
+    refetch,
+  } = useProfileImagesQuery({ enabled: false })
 
   // 폼에는 서버로 보낼 profile_image (code)를 저장하고,
   // 화면에서는 해당 code로 avatar를 찾아서 보여줍니다.
   const selectedCharacter = useMemo(
     () =>
-      PROFILE_AVATAR_OPTIONS.find((character) => character.code === value) ??
-      DEFAULT_PROFILE_AVATAR,
-    [value]
+      profileAvatarOptions.find(
+        (character) => character.code === value || character.imageUrl === value
+      ) ?? profileAvatarOptions[0],
+    [profileAvatarOptions, value]
   )
+  const selectedImageUrl = getProfileAvatarImageUrl(
+    value ?? selectedCharacter?.imageUrl,
+    profileAvatarOptions
+  )
+  const previewImageUrl = selectedImageUrl || pinkCharacterImage
+  const isSelectDisabled = isFetching
 
   const handleSelectCharacter = (code: string) => {
-    const character = PROFILE_AVATAR_OPTIONS.find((item) => item.code === code)
+    const character = profileAvatarOptions.find((item) => item.code === code)
     if (!character) return
     onChange(character.code)
     setIsActive(true)
     setIsOpen(false)
+  }
+
+  const handleOpenCharacterModal = async () => {
+    if (profileAvatarOptions.length > 0) {
+      setIsOpen(true)
+      return
+    }
+
+    const { data } = await refetch()
+    if (data && data.length > 0) {
+      setIsOpen(true)
+    }
   }
 
   return (
@@ -44,11 +66,12 @@ export function ProfileImageSelectField({
         type="button"
         aria-label="프로필 선택"
         className="group relative size-16 cursor-pointer rounded-full transition-transform duration-200 ease-out hover:scale-110"
-        onClick={() => setIsOpen(true)}
+        disabled={isSelectDisabled}
+        onClick={handleOpenCharacterModal}
       >
         <img
-          src={getProfileAvatarImageUrl(selectedCharacter.imageUrl)}
-          alt={selectedCharacter.label}
+          src={previewImageUrl}
+          alt={selectedCharacter?.label ?? '프로필 캐릭터'}
           className="size-12 sm:size-16 rounded-full object-contain shrink-0"
         />
         <span
@@ -63,8 +86,8 @@ export function ProfileImageSelectField({
 
       {isOpen ? (
         <CharacterSelectModal
-          characters={PROFILE_AVATAR_OPTIONS}
-          defaultSelectedCode={selectedCharacter.code}
+          characters={profileAvatarOptions}
+          defaultSelectedCode={selectedCharacter?.code}
           onClose={() => setIsOpen(false)}
           onSelect={handleSelectCharacter}
         />

--- a/src/query/auth/index.ts
+++ b/src/query/auth/index.ts
@@ -5,4 +5,5 @@ export {
 } from './useEmailVerificationMutations'
 export { useLoginMutation } from './useLoginMutation'
 export { useLogoutMutation } from './useLogoutMutation'
+export { useProfileImagesQuery } from './useProfileImagesQuery'
 export { useSignupMutation } from './useSignupMutation'

--- a/src/query/auth/useProfileImagesQuery.ts
+++ b/src/query/auth/useProfileImagesQuery.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { authApi } from '@/apis/auth'
+import { toProfileAvatarOptions } from '@/shared/profileAvatar'
+
+type UseProfileImagesQueryOptions = {
+  enabled?: boolean
+}
+
+export function useProfileImagesQuery(options?: UseProfileImagesQueryOptions) {
+  return useQuery({
+    queryKey: ['profileImages'],
+    queryFn: async () => {
+      const response = await authApi.getProfileImages()
+      return toProfileAvatarOptions(response.detail)
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 60 * 10,
+  })
+}

--- a/src/shared/profileAvatar.ts
+++ b/src/shared/profileAvatar.ts
@@ -1,10 +1,4 @@
-// 백엔드에서 내려준 프로필 캐릭터 코드를 프론트에서도 그대로 사용
-// 선택 상태는 code로 관리하고, 실제 렌더링/전송에 필요한 이미지는 imageUrl로 매핑
-export type ProfileAvatarCode =
-  | 'avatar_1'
-  | 'avatar_2'
-  | 'avatar_3'
-  | 'avatar_4'
+export type ProfileAvatarCode = string
 
 export type ProfileAvatarOption = {
   code: ProfileAvatarCode
@@ -12,42 +6,28 @@ export type ProfileAvatarOption = {
   label: string
 }
 
-export const PROFILE_AVATAR_OPTIONS: ProfileAvatarOption[] = [
-  {
-    code: 'avatar_1',
-    imageUrl:
-      'https://jaksim-image-bucket-1.s3.ap-northeast-2.amazonaws.com/post_images/528f6967-3e29-4309-b57b-2c3ff3457794.png',
-    label: '캐릭터 1',
-  },
-  {
-    code: 'avatar_2',
-    imageUrl:
-      'https://jaksim-image-bucket-1.s3.ap-northeast-2.amazonaws.com/post_images/1faf9b4d-9a60-4fe2-9fe2-72e288cb4c65.png',
-    label: '캐릭터 2',
-  },
-  {
-    code: 'avatar_3',
-    imageUrl:
-      'https://jaksim-image-bucket-1.s3.ap-northeast-2.amazonaws.com/post_images/a169e590-203a-4ad6-a2bf-4bb05c73e4a2.png',
-    label: '캐릭터 3',
-  },
-  {
-    code: 'avatar_4',
-    imageUrl:
-      'https://jaksim-image-bucket-1.s3.ap-northeast-2.amazonaws.com/post_images/9b63cb03-9236-417f-99dc-9e69ce455f17.png',
-    label: '캐릭터 4',
-  },
-]
+type ProfileAvatarApiItem = {
+  code: string
+  image_url: string
+}
 
-export const DEFAULT_PROFILE_AVATAR = PROFILE_AVATAR_OPTIONS[0]
+export const toProfileAvatarOptions = (
+  profileImages: ProfileAvatarApiItem[]
+): ProfileAvatarOption[] =>
+  profileImages.map((profileImage, index) => ({
+    code: profileImage.code,
+    imageUrl: profileImage.image_url,
+    label: `캐릭터 ${index + 1}`,
+  }))
 
-// 서버 응답이 avatar 코드일 수도 있고, 이미 완성된 URL일 수도 있어서 둘 다 처리
-export const getProfileAvatarImageUrl = (value?: string | null) => {
-  if (!value) return DEFAULT_PROFILE_AVATAR.imageUrl
+// 서버 응답이 avatar 코드일 수도 있고, 이미 완성된 URL일 수도 있어서 둘 다 처리합니다.
+export const getProfileAvatarImageUrl = (
+  value?: string | null,
+  options: ProfileAvatarOption[] = []
+) => {
+  if (!value) return options[0]?.imageUrl ?? ''
 
-  const matchedAvatar = PROFILE_AVATAR_OPTIONS.find(
-    (avatar) => avatar.code === value
-  )
+  const matchedAvatar = options.find((avatar) => avatar.code === value)
 
   return matchedAvatar?.imageUrl ?? value
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #152

## ✨ 변경 내용

  - 회원가입 프로필 이미지 목록을 API에서 조회하도록 변경
  - 프로필 선택 모달을 열 때 프로필 이미지 API를 호출하도록 수정
  - 선택 전 초기 화면에는 기본 프로필 캐릭터 이미지를 표시하도록 처리

## 📸 스크린샷(선택)

## 📚 참고사항
