### PR TITLE
feat: improve post api error detail

### DIFF
--- a/src/apis/api.utils.ts
+++ b/src/apis/api.utils.ts
@@ -1,10 +1,29 @@
 import type { ApiErrorResponse } from './api.types'
 
+// error_detail은 string 또는 중첩 객체일 수 있음
+// 예) "이미 신고한 게시글입니다." -> "이미 신고한 게시글입니다."
+// 예) { vote: { non_field_errors: ["투표 입력값이 올바르지 않습니다."] } } -> "투표 입력값이 올바르지 않습니다."
+// 이렇게 나와야함
+// 재귀적으로 트리를 탐색하여 leaf 문자열만 수집
+// - string -> 그대로 반환
+// - array -> 각 요소를 재귀 처리
+// - object -> 모든 값(value)을 재귀 처리 (key는 무시)
+// - 그 외 -> 빈 배열 (null, number 등 예상 외 타입 방어)
+function extractMessages(value: unknown): string[] {
+  if (typeof value === 'string') return [value]
+  if (Array.isArray(value)) return value.flatMap(extractMessages)
+  if (value !== null && typeof value === 'object') {
+    return Object.values(value).flatMap(extractMessages)
+  }
+  return []
+}
+
+// API 에러 응답의 error_detail을 사용자에게 보여줄 문자열로 변환
+// - string이면 그대로 반환
+// - 객체면 extractMessages로 모든 메시지를 추출해 줄바꿈으로 합침.
 export function formatError(
   errorDetail: ApiErrorResponse['error_detail']
 ): string {
-  if (typeof errorDetail === 'string') {
-    return errorDetail
-  }
-  return Object.values(errorDetail).flat().join('\n')
+  if (typeof errorDetail === 'string') return errorDetail
+  return extractMessages(errorDetail).join('\n')
 }

--- a/src/components/common/ui/card/PostCard.tsx
+++ b/src/components/common/ui/card/PostCard.tsx
@@ -62,20 +62,18 @@ export function PostCard({
     reportReasons,
   } = usePostCardReport(postId)
 
-  const { mutate: deletePost } = useDeletePostMutation()
+  const { mutate: deletePost } = useDeletePostMutation({
+    onSuccess: () => {
+      toast.success('게시글이 삭제되었습니다.')
+      setShowDeleteConfirm(false)
+    },
+    onError: (message) => {
+      toast.error(message)
+      setShowDeleteConfirm(false)
+    },
+  })
 
-  const handleDelete = () => {
-    deletePost(postId, {
-      onSuccess: () => {
-        toast.success('게시글이 삭제되었습니다.')
-        setShowDeleteConfirm(false)
-      },
-      onError: () => {
-        toast.error('게시글 삭제에 실패했습니다.')
-        setShowDeleteConfirm(false)
-      },
-    })
-  }
+  const handleDelete = () => deletePost(postId)
 
   const ownerMenuItems = [
     { label: '수정', onClick: () => navigate(`/post/${postId}/edit`) },

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -27,7 +27,13 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
   const navigate = useNavigate()
   const toast = useToast()
 
-  const deleteMutation = useDeletePostMutation()
+  const deleteMutation = useDeletePostMutation({
+    onSuccess: () => {
+      setIsDeleteModalOpen(false)
+      navigate('/')
+    },
+    onError: (message) => toast.error(message),
+  })
   const reportMutation = useReportPostMutation()
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
@@ -42,20 +48,7 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
   }
 
   const handleConfirmDelete = () => {
-    deleteMutation.mutate(post.postId, {
-      onSuccess: () => {
-        setIsDeleteModalOpen(false)
-        navigate('/')
-      },
-      onError: (error) => {
-        const axiosError = error as AxiosError<ApiErrorResponse>
-        const detail = axiosError.response?.data.error_detail
-
-        toast.error(
-          detail ? formatError(detail) : '게시글 삭제에 실패했습니다.'
-        )
-      },
-    })
+    deleteMutation.mutate(post.postId)
   }
 
   const handleReport = () => {

--- a/src/pages/PostCreatePage.tsx
+++ b/src/pages/PostCreatePage.tsx
@@ -13,7 +13,7 @@ export function PostCreatePage() {
       toast.success('게시글이 등록되었습니다.')
       navigate('/')
     },
-    onError: () => toast.error('게시글 생성에 실패했습니다.'),
+    onError: (message) => toast.error(message),
   })
 
   return (

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -28,7 +28,7 @@ export function PostEditPage() {
       toast.success('게시글이 수정되었습니다.')
       navigate(`/post/${postId}`)
     },
-    onError: () => toast.error('게시글 수정에 실패했습니다.'),
+    onError: (message) => toast.error(message),
   })
 
   if (!Number.isFinite(postId)) return <Navigate to="/not-found" replace />

--- a/src/query/post/useCreatePostMutation.ts
+++ b/src/query/post/useCreatePostMutation.ts
@@ -1,11 +1,14 @@
 import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
 
+import type { ApiErrorResponse } from '@/apis/api.types'
+import { formatError } from '@/apis/api.utils'
 import { postApi } from '@/apis/post'
 import { type PostFormData, toApiCreateRequest } from '@/features/post'
 
 type Options = {
   onSuccess: () => void
-  onError: () => void
+  onError: (message: string) => void
 }
 
 export function useCreatePostMutation(options: Options) {
@@ -18,6 +21,11 @@ export function useCreatePostMutation(options: Options) {
     // staleTime=0 기본값에 의해 목록을 자동으로 다시 fetch한다.
     // 별도 invalidate 없이도 최신 목록을 보여줄 수 있다.
     onSuccess: options.onSuccess,
-    onError: options.onError,
+    onError: (error: AxiosError<ApiErrorResponse>) => {
+      const detail = error.response?.data.error_detail
+      options.onError(
+        detail ? formatError(detail) : '게시글 생성에 실패했습니다.'
+      )
+    },
   })
 }

--- a/src/query/post/useDeletePostMutation.ts
+++ b/src/query/post/useDeletePostMutation.ts
@@ -1,8 +1,16 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
 
+import type { ApiErrorResponse } from '@/apis/api.types'
+import { formatError } from '@/apis/api.utils'
 import { postApi } from '@/apis/post'
 
-export function useDeletePostMutation() {
+type Options = {
+  onSuccess: () => void
+  onError: (message: string) => void
+}
+
+export function useDeletePostMutation(options: Options) {
   const queryClient = useQueryClient()
 
   return useMutation({
@@ -12,6 +20,13 @@ export function useDeletePostMutation() {
       // 하지만 목록 조회는 캐싱을 하지 않으므로 (staleTime=0),
       // 현재 마운트된 (화면에 보이는) 쿼리만 즉시 다시 불러오는 refetchQueries를 사용한다.
       queryClient.refetchQueries({ queryKey: ['posts'] })
+      options.onSuccess()
+    },
+    onError: (error: AxiosError<ApiErrorResponse>) => {
+      const detail = error.response?.data.error_detail
+      options.onError(
+        detail ? formatError(detail) : '게시글 삭제에 실패했습니다.'
+      )
     },
   })
 }

--- a/src/query/post/useUpdatePostMutation.ts
+++ b/src/query/post/useUpdatePostMutation.ts
@@ -1,11 +1,14 @@
 import { useMutation } from '@tanstack/react-query'
+import type { AxiosError } from 'axios'
 
+import type { ApiErrorResponse } from '@/apis/api.types'
+import { formatError } from '@/apis/api.utils'
 import { postApi } from '@/apis/post'
 import { type PostFormData, toApiUpdateRequest } from '@/features/post'
 
 type Options = {
   onSuccess: () => void
-  onError: () => void
+  onError: (message: string) => void
 }
 
 export function useUpdatePostMutation(postId: number, options: Options) {
@@ -18,6 +21,11 @@ export function useUpdatePostMutation(postId: number, options: Options) {
     // staleTime=0 기본값에 의해 목록을 자동으로 다시 fetch한다.
     // 별도 invalidate 없이도 최신 목록을 보여줄 수 있다.
     onSuccess: options.onSuccess,
-    onError: options.onError,
+    onError: (error: AxiosError<ApiErrorResponse>) => {
+      const detail = error.response?.data.error_detail
+      options.onError(
+        detail ? formatError(detail) : '게시글 수정에 실패했습니다.'
+      )
+    },
   })
 }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #156 

## ✨ 변경 내용

- API 에러 응답의 `error_detail`이 중첩 객체일 경우 `[object Object]`로 표시되는 버그를 수정 -> formatError 중첩 객체도 처리시켜 문자열로 뽑아낼 수 있도록 수정
- post 관련 mutation의 에러 처리 방식을 훅 내부로 통일 - useCreatePost, useUpdatePost, useDeletePost 모두 훅 내부에서 formatError를 호출 하도록 변경하여 사용처에서는 (message) => toast.error(message) 로 한 줄로 단순화


## 📸 스크린샷(선택)

## 📚 참고사항
useDeletePostMutation을 수정하다보니 예린님 파일인 PostDetailLayout에서 Delete 처리도 수정된 흐름으로 함께 수정한 부분이 있는데 확인 부탁드립니다!