### PR TITLE
feat: 게시글 상세 투표 조회/참여 API 연결

### DIFF
--- a/src/apis/post/endpoints.ts
+++ b/src/apis/post/endpoints.ts
@@ -15,4 +15,7 @@ export const POST_ENDPOINTS = {
     `/posts/${postId}/comments/${commentId}`,
   commentLikes: (commentId: number) => `/posts/comments/${commentId}/likes`,
   commentReport: (commentId: number) => `/posts/comments/${commentId}/report`,
+  voteParticipations: (voteId: number | string) =>
+    `/votes/${voteId}/participations/`,
+  vote: (voteId: number | string) => `/votes/${voteId}/`,
 } as const

--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -90,4 +90,11 @@ export const postApi = {
     apiClient.get<ApiTrendingResponse>(POST_ENDPOINTS.postSuggestions, {
       params,
     }),
+
+  // 투표 참여
+  vote: (voteId: number, body: { vote_option_id: number }) =>
+    apiClient.post<void>(POST_ENDPOINTS.voteParticipations(voteId), body),
+
+  // 투표 조회
+  getVote: (voteId: number) => apiClient.get(POST_ENDPOINTS.vote(voteId)),
 } as const

--- a/src/components/common/ui/vote/components/VoteOptionItem.tsx
+++ b/src/components/common/ui/vote/components/VoteOptionItem.tsx
@@ -76,7 +76,8 @@ export function VoteOptionItem({
       <div className="h-14 overflow-hidden rounded-full bg-gray-100 shadow-sm">
         <div
           className={cn(
-            'flex h-full items-center rounded-full px-6 text-xs',
+            'flex h-full items-center overflow-hidden rounded-full text-xs',
+            percentage > 0 && 'px-6',
             index === 0
               ? optionVariants.gauge.first
               : optionVariants.gauge.second

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -9,9 +9,16 @@ import { ConfirmModal } from '@/components/common/overlay/modal/confirm/ConfirmM
 import { ReportFormModal } from '@/components/common/overlay/modal/form/ReportFormModal'
 import { POST_REPORT_REASONS } from '@/components/common/ui/card/usePostCardReport'
 import { useToast } from '@/components/common/ui/toast/useToast'
+import { VoteDisplay } from '@/components/common/ui/vote/VoteDisplay'
 import type { PostDetailData } from '@/features/post/post.types'
+import {
+  getVoteMode,
+  toVoteDisplayOptions,
+} from '@/features/post-detail/utils/voteDisplayMapper'
 import { useDeletePostMutation } from '@/query/post/useDeletePostMutation'
 import { useReportPostMutation } from '@/query/post/useReportPostMutation'
+import { useVoteMutation } from '@/query/post/useVoteMutaion'
+import { useVoteQuery } from '@/query/post/useVoteQuery'
 
 import { PostDetailActions } from './PostDetailActions'
 import { PostDetailBody } from './PostDetailBody'
@@ -35,11 +42,16 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
     onError: (message) => toast.error(message),
   })
   const reportMutation = useReportPostMutation()
+  const voteMutation = useVoteMutation()
+  const { data: voteData } = useVoteQuery(post.voteInfo?.voteId ?? 0)
 
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [isReportModalOpen, setIsReportModalOpen] = useState(false)
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null)
 
-  // TODO: 백엔드에서 userId 또는 isOwner 내려주면 교체 필요
+  const voteDetail = voteData?.data.detail
+
+  // TODO: is_owner 반영 후 작성자 판별 교체 예정
   const currentUserNickname = '테스트유저1'
   const isOwner = post.nickname === currentUserNickname
 
@@ -77,6 +89,43 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
         },
       }
     )
+  }
+
+  const handleVoteSubmit = () => {
+    // 이미 투표한 사용자는 재투표 불가
+    if (voteDetail?.is_voted) return
+    if (!selectedOptionId || !post.voteInfo) return
+
+    voteMutation.mutate(
+      {
+        postId: post.postId,
+        voteId: post.voteInfo.voteId,
+        voteOptionId: Number(selectedOptionId),
+      },
+      {
+        onSuccess: () => {
+          toast.success('투표가 완료되었습니다.')
+        },
+        onError: (error) => {
+          const axiosError = error as AxiosError<ApiErrorResponse>
+          const detail = axiosError.response?.data.error_detail
+
+          if (axiosError.response?.status === 409) {
+            toast.error('이미 참여한 투표입니다.')
+            return
+          }
+
+          toast.error(detail ? formatError(detail) : '투표에 실패했습니다.')
+        },
+      }
+    )
+  }
+
+  const handleVoteOptionSelect = (optionId: string) => {
+    // 이미 투표한 사용자는 선택 변경 불가
+    if (voteDetail?.is_voted) return
+
+    setSelectedOptionId(optionId)
   }
 
   const ownerMenuItems = [
@@ -125,6 +174,22 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
           </div>
         )}
 
+        {post.hasVote && post.voteInfo && (
+          <div className="mt-6">
+            <VoteDisplay
+              mode={getVoteMode(post.voteInfo, voteDetail?.is_voted)}
+              options={toVoteDisplayOptions(voteDetail, selectedOptionId)}
+              participantCount={voteDetail?.total_count ?? 0}
+              period={{
+                start: new Date(post.voteInfo.startAt),
+                end: new Date(post.voteInfo.endAt),
+              }}
+              onSelectOption={handleVoteOptionSelect}
+              onActionClick={handleVoteSubmit}
+            />
+          </div>
+        )}
+
         <div className="mt-8">
           <PostDetailActions
             postId={post.postId}
@@ -140,7 +205,6 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
         </div>
       </article>
 
-      {/* 삭제 확인 모달 */}
       {isDeleteModalOpen && (
         <ConfirmModal
           description="게시글을 삭제하시겠습니까? 삭제된 게시글은 복구할 수 없습니다."
@@ -151,7 +215,6 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
         />
       )}
 
-      {/* 신고 모달 */}
       {isReportModalOpen && (
         <ReportFormModal
           title="게시글 신고"

--- a/src/features/post-detail/utils/voteDisplayMapper.ts
+++ b/src/features/post-detail/utils/voteDisplayMapper.ts
@@ -1,0 +1,44 @@
+import { VoteViewerMode } from '@/components/common/ui/vote/Vote.type'
+
+type VoteResultOption = {
+  vote_option_id: number
+  content: string
+  count: number
+  rate: number
+}
+
+type VoteDetail = {
+  status: string
+  total_count: number
+  is_voted?: boolean
+  voted_option_id?: number | null
+  options: VoteResultOption[]
+}
+
+export function getVoteMode(
+  voteInfo: { status: string } | null,
+  isVoted?: boolean
+) {
+  if (!voteInfo) return VoteViewerMode.GUEST
+  if (voteInfo.status === 'closed') return VoteViewerMode.CLOSED
+  if (isVoted) return VoteViewerMode.VOTED
+
+  return VoteViewerMode.MEMBER
+}
+
+export function toVoteDisplayOptions(
+  voteDetail: VoteDetail | undefined,
+  selectedOptionId: string | null
+) {
+  return (
+    voteDetail?.options.map((opt) => ({
+      id: String(opt.vote_option_id),
+      optionLabel: opt.content,
+      valueLabel: `${opt.rate}%`,
+      percentage: opt.rate,
+      checked: voteDetail.is_voted
+        ? voteDetail.voted_option_id === opt.vote_option_id
+        : selectedOptionId === String(opt.vote_option_id),
+    })) ?? []
+  )
+}

--- a/src/query/post/useVoteMutaion.ts
+++ b/src/query/post/useVoteMutaion.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post/post.api'
+
+type VoteMutationParams = {
+  postId: number
+  voteId: number
+  voteOptionId: number
+}
+
+export function useVoteMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ voteId, voteOptionId }: VoteMutationParams) =>
+      postApi.vote(voteId, { vote_option_id: voteOptionId }),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['postDetail', variables.postId],
+      })
+
+      queryClient.invalidateQueries({
+        queryKey: ['vote', variables.voteId],
+      })
+    },
+  })
+}

--- a/src/query/post/useVoteQuery.ts
+++ b/src/query/post/useVoteQuery.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post/post.api'
+
+export function useVoteQuery(voteId: number) {
+  return useQuery({
+    queryKey: ['vote', voteId],
+    queryFn: () => postApi.getVote(voteId),
+    enabled: voteId > 0,
+  })
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #155 

## ✨ 변경 내용

- [x] 투표 조회 API 연결 (GET /votes/{vote_id})
- [x] 투표 참여 API 연결 (POST /votes/{vote_id}/participations)
- [x] 투표 결과 퍼센트 및 참여자 수 표시
- [x] is_voted / voted_option_id 기반 UX 반영
- [x] 이미 투표한 사용자 재투표 방지 처리
- [x] 서버 상태 불일치 대비 409 Conflict fallback 처리
- [x] VoteDisplay 리팩토링 (mapper 분리)

## 📸 스크린샷(선택)
<img width="672" height="721" alt="스크린샷 2026-05-04 오후 4 37 03" src="https://github.com/user-attachments/assets/354fd41e-069c-4998-ac49-c403ffc51e98" />


## 📚 참고사항
- 투표 수정/삭제는 상세페이지에서 인라인 편집 방식으로 후속 작업 예정
- 투표 수정은 참여자가 1명 이상일 경우 불가능 (백엔드 정책 반영 필요)
- 게시글 작성자 판별(is_owner)은 별도 브랜치에서 반영 예정
- 409 Conflict 처리는 평소 노출되는 흐름이 아니라, 서버/프론트 상태 불일치에 대비한 fallback 처리