### PR TITLE
feat: post detail followup

### DIFF
--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -24,6 +24,12 @@ import type {
 
 import { POST_ENDPOINTS } from './endpoints'
 
+type UpdateVoteBody = {
+  options: string[]
+  start_at?: string
+  end_at?: string
+}
+
 export const postApi = {
   // 진행 중인 목표 조회
   getGoals: () =>
@@ -111,4 +117,12 @@ export const postApi = {
 
   // 투표 조회
   getVote: (voteId: number) => apiClient.get(POST_ENDPOINTS.vote(voteId)),
+
+  // 투표 수정
+  updateVote: (voteId: number, body: UpdateVoteBody) =>
+    apiClient.patch(POST_ENDPOINTS.vote(voteId), body),
+
+  // 투표 삭제
+  deleteVote: (voteId: number) =>
+    apiClient.delete<void>(POST_ENDPOINTS.vote(voteId)),
 } as const

--- a/src/components/common/ui/vote/Vote.type.ts
+++ b/src/components/common/ui/vote/Vote.type.ts
@@ -54,6 +54,8 @@ export type VoteEditorProps = {
   mode: VoteEditorMode
   options: string[]
   disabled?: boolean
+  hideOptionLength?: boolean
+  hideParticipantCount?: boolean
   onChangeOption?: (index: number, value: string) => void
   onSubmit?: () => void
   onChangePeriod?: (date: DateRange | null) => void

--- a/src/components/common/ui/vote/VoteDisplay.tsx
+++ b/src/components/common/ui/vote/VoteDisplay.tsx
@@ -12,21 +12,24 @@ export function VoteDisplay({
   options,
   participantCount = 0,
   period,
-  actionLabel,
-  showMoreButton = false,
   actionSlot,
   onSelectOption,
   onActionClick,
 }: VoteDisplayProps) {
   const isClosed = mode === VoteViewerMode.CLOSED
   const isVoted = mode === VoteViewerMode.VOTED
-  const showResult = isVoted || isClosed
+  const showResult = true // 투표 결과 항상 보여주기
 
   const hasCheckedOption = options.some((option) => option.checked)
   const isActionDisabled =
-    isClosed || (mode === VoteViewerMode.MEMBER && !hasCheckedOption)
+    isClosed || isVoted || (mode === VoteViewerMode.MEMBER && !hasCheckedOption)
 
-  const buttonLabel = isClosed ? '투표 마감' : (actionLabel ?? '투표하기')
+  const buttonLabel = isClosed
+    ? '투표 마감'
+    : isVoted
+      ? '투표 완료'
+      : '투표하기'
+
   const statusLabel = isClosed ? '투표 마감' : '투표 진행중'
   const hasPeriod = Boolean(period?.start && period?.end)
 
@@ -44,21 +47,21 @@ export function VoteDisplay({
 
       <section
         className={cn(
-          'w-full rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main',
+          'relative mx-auto min-h-62 w-full max-w-267.5 rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main',
           isClosed && 'opacity-50'
         )}
       >
-        {(showMoreButton || actionSlot) && actionSlot && (
-          <div className="mb-4 flex justify-end">{actionSlot}</div>
+        {actionSlot && (
+          <div className="absolute top-4 right-4">{actionSlot}</div>
         )}
 
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 pt-8">
           {options.map((option, index) => (
             <VoteOptionItem
               key={option.id}
               option={option}
               index={index}
-              isClosed={isClosed}
+              isClosed={isClosed || isVoted}
               showResult={showResult}
               onSelectOption={onSelectOption}
             />
@@ -77,6 +80,7 @@ export function VoteDisplay({
           </Button>
         </div>
       </section>
+
       <div className="mt-4 flex items-center gap-2 text-sm text-text-muted">
         <Users className="h-4 w-4" />
         <span>{participantCount}명 참여중</span>

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -26,6 +26,8 @@ export function VoteEditor({
   options,
   participantCount = 0,
   disabled = false,
+  hideOptionLength = false,
+  hideParticipantCount = false,
   onChangeOption,
   onSubmit,
   onChangePeriod,
@@ -68,16 +70,26 @@ export function VoteEditor({
                   옵션 입력
                 </span>
 
-                <input
-                  value={option}
-                  onChange={(e) => onChangeOption?.(index, e.target.value)}
-                  placeholder="옵션을 입력하세요"
-                  className={cn(
-                    inputVariants.base,
-                    inputStyle,
-                    'focus:border-focus-border'
+                <div className="min-w-0">
+                  <input
+                    value={option}
+                    maxLength={12}
+                    disabled={disabled}
+                    onChange={(e) => onChangeOption?.(index, e.target.value)}
+                    placeholder="옵션을 입력하세요"
+                    className={cn(
+                      inputVariants.base,
+                      inputStyle,
+                      'focus:border-focus-border'
+                    )}
+                  />
+
+                  {!hideOptionLength && (
+                    <span className="mt-1 block text-right text-xs text-text-muted">
+                      {option.length}/12
+                    </span>
                   )}
-                />
+                </div>
               </div>
             )
           })}
@@ -98,10 +110,12 @@ export function VoteEditor({
         )}
       </section>
 
-      <div className="mt-4 flex items-center gap-2 text-sm text-text-muted">
-        <Users className="h-4 w-4" />
-        <span>{participantCount}명 참여중</span>
-      </div>
+      {!hideParticipantCount && (
+        <div className="mt-4 flex items-center gap-2 text-sm text-text-muted">
+          <Users className="h-4 w-4" />
+          <span>{participantCount}명 참여중</span>
+        </div>
+      )}
     </>
   )
 }

--- a/src/components/common/ui/vote/components/VoteOptionItem.tsx
+++ b/src/components/common/ui/vote/components/VoteOptionItem.tsx
@@ -14,10 +14,10 @@ type VoteOptionItemProps = {
 }
 
 const optionVariants = {
-  base: 'grid w-full grid-cols-[24px_64px_minmax(0,1fr)_56px] items-center gap-2 text-left',
+  base: 'grid w-full grid-cols-[20px_minmax(0,1fr)_44px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]',
 
   text: {
-    selected: 'text-primary-400',
+    selected: 'text-primary-500',
     result: 'text-text-primary',
     default: 'text-text-muted',
   },
@@ -29,7 +29,7 @@ const optionVariants = {
 
   indicator: {
     selected:
-      'flex size-4 items-center justify-center rounded-sm bg-primary-400 text-white',
+      'flex size-4 items-center justify-center rounded-sm bg-primary-500 text-white',
     default: 'flex size-4 items-center justify-center rounded-sm bg-gray-300',
   },
 }
@@ -43,7 +43,9 @@ export function VoteOptionItem({
 }: VoteOptionItemProps) {
   const isSelected = Boolean(option.checked)
   const percentage = Math.min(100, Math.max(0, option.percentage ?? 0))
+  const displayPercentage = Math.round(percentage)
 
+  // 선택 → 파란색 / 나머지 상태 유지
   const textColor = isSelected
     ? optionVariants.text.selected
     : showResult
@@ -57,6 +59,7 @@ export function VoteOptionItem({
       onClick={() => onSelectOption?.(option.id)}
       className={optionVariants.base}
     >
+      {/* 체크박스 */}
       <span className="flex items-center justify-center">
         <span
           className={cn(
@@ -69,29 +72,35 @@ export function VoteOptionItem({
         </span>
       </span>
 
-      <span className={cn('text-sm font-medium', textColor)}>
-        {option.optionLabel}
-      </span>
+      {/* 게이지 */}
+      <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm sm:h-14">
+        {showResult && percentage > 0 && (
+          <div
+            className={cn(
+              'absolute inset-y-0 left-0 rounded-full',
+              index === 0
+                ? optionVariants.gauge.first
+                : optionVariants.gauge.second
+            )}
+            style={{ width: `${percentage}%` }}
+          />
+        )}
 
-      <div className="h-14 overflow-hidden rounded-full bg-gray-100 shadow-sm">
-        <div
+        {/* 게이지 내부 텍스트 */}
+        <span
           className={cn(
-            'flex h-full items-center overflow-hidden rounded-full text-xs',
-            percentage > 0 && 'px-6',
-            index === 0
-              ? optionVariants.gauge.first
-              : optionVariants.gauge.second
+            'relative z-10 flex h-full min-w-0 items-center truncate px-3 text-sm font-medium sm:px-6',
+            textColor
           )}
-          style={{
-            width: showResult ? `${percentage}%` : '100%',
-          }}
+          title={option.valueLabel}
         >
-          <span className="truncate">{option.valueLabel}</span>
-        </div>
+          {option.valueLabel}
+        </span>
       </div>
 
-      <span className={cn('text-right text-xs', textColor)}>
-        {showResult ? `${percentage}%` : ''}
+      {/* 퍼센트 (색상 동일 + 스타일 통일) */}
+      <span className={cn('text-right text-sm font-medium', textColor)}>
+        {showResult ? `${displayPercentage}%` : ''}
       </span>
     </button>
   )

--- a/src/features/post-detail/components/PostDetailHeader.tsx
+++ b/src/features/post-detail/components/PostDetailHeader.tsx
@@ -1,4 +1,4 @@
-import { MoreVertical } from 'lucide-react'
+import { MoreHorizontal } from 'lucide-react'
 
 import { ActionMenu } from '@/components/common/overlay'
 import { formatRelativeTime } from '@/utils/formatRelativeTime'
@@ -51,7 +51,7 @@ export function PostDetailHeader({
       <ActionMenu
         trigger={
           <button type="button" className="text-text-primary">
-            <MoreVertical size={20} />
+            <MoreHorizontal size={20} />
           </button>
         }
         items={menuItems}

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -9,21 +9,15 @@ import { ConfirmModal } from '@/components/common/overlay/modal/confirm/ConfirmM
 import { ReportFormModal } from '@/components/common/overlay/modal/form/ReportFormModal'
 import { POST_REPORT_REASONS } from '@/components/common/ui/card/usePostCardReport'
 import { useToast } from '@/components/common/ui/toast/useToast'
-import { VoteDisplay } from '@/components/common/ui/vote/VoteDisplay'
 import type { PostDetailData } from '@/features/post/post.types'
-import {
-  getVoteMode,
-  toVoteDisplayOptions,
-} from '@/features/post-detail/utils/voteDisplayMapper'
 import { useDeletePostMutation } from '@/query/post/useDeletePostMutation'
 import { useReportPostMutation } from '@/query/post/useReportPostMutation'
-import { useVoteMutation } from '@/query/post/useVoteMutaion'
-import { useVoteQuery } from '@/query/post/useVoteQuery'
 
 import { PostDetailActions } from './PostDetailActions'
 import { PostDetailBody } from './PostDetailBody'
 import { PostDetailCommentSection } from './PostDetailCommentSection'
 import { PostDetailHeader } from './PostDetailHeader'
+import { PostDetailVoteSection } from './PostDetailVoteSection'
 import { PostGoalSection } from './PostGoalSection'
 
 type PostDetailLayoutProps = {
@@ -34,6 +28,9 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
   const navigate = useNavigate()
   const toast = useToast()
 
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  const [isReportModalOpen, setIsReportModalOpen] = useState(false)
+
   const deleteMutation = useDeletePostMutation({
     onSuccess: () => {
       setIsDeleteModalOpen(false)
@@ -41,17 +38,8 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
     },
     onError: (message) => toast.error(message),
   })
+
   const reportMutation = useReportPostMutation()
-  const voteMutation = useVoteMutation()
-  const { data: voteData } = useVoteQuery(post.voteInfo?.voteId ?? 0)
-
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
-  const [isReportModalOpen, setIsReportModalOpen] = useState(false)
-  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null)
-
-  const voteDetail = voteData?.data.detail
-
-  const isOwner = post.isOwner
 
   const handleDelete = () => {
     setIsDeleteModalOpen(true)
@@ -89,43 +77,6 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
     )
   }
 
-  const handleVoteSubmit = () => {
-    // 이미 투표한 사용자는 재투표 불가
-    if (voteDetail?.is_voted) return
-    if (!selectedOptionId || !post.voteInfo) return
-
-    voteMutation.mutate(
-      {
-        postId: post.postId,
-        voteId: post.voteInfo.voteId,
-        voteOptionId: Number(selectedOptionId),
-      },
-      {
-        onSuccess: () => {
-          toast.success('투표가 완료되었습니다.')
-        },
-        onError: (error) => {
-          const axiosError = error as AxiosError<ApiErrorResponse>
-          const detail = axiosError.response?.data.error_detail
-
-          if (axiosError.response?.status === 409) {
-            toast.error('이미 참여한 투표입니다.')
-            return
-          }
-
-          toast.error(detail ? formatError(detail) : '투표에 실패했습니다.')
-        },
-      }
-    )
-  }
-
-  const handleVoteOptionSelect = (optionId: string) => {
-    // 이미 투표한 사용자는 선택 변경 불가
-    if (voteDetail?.is_voted) return
-
-    setSelectedOptionId(optionId)
-  }
-
   const ownerMenuItems = [
     { label: '수정', onClick: () => navigate(`/post/${post.postId}/edit`) },
     {
@@ -137,11 +88,11 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
 
   const guestMenuItems = [{ label: '신고', onClick: handleReport }]
 
-  const menuItems = isOwner ? ownerMenuItems : guestMenuItems
+  const menuItems = post.isOwner ? ownerMenuItems : guestMenuItems
 
   return (
     <>
-      <article className="w-full max-w-4xl rounded-2xl border border-border-default bg-white px-8 py-6 shadow-card-main">
+      <article className="w-full max-w-300 rounded-2xl border border-border-default bg-white px-8 py-6 shadow-card-main">
         <PostDetailHeader
           author={{
             nickname: post.nickname,
@@ -172,21 +123,7 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
           </div>
         )}
 
-        {post.hasVote && post.voteInfo && (
-          <div className="mt-6">
-            <VoteDisplay
-              mode={getVoteMode(post.voteInfo, voteDetail?.is_voted)}
-              options={toVoteDisplayOptions(voteDetail, selectedOptionId)}
-              participantCount={voteDetail?.total_count ?? 0}
-              period={{
-                start: new Date(post.voteInfo.startAt),
-                end: new Date(post.voteInfo.endAt),
-              }}
-              onSelectOption={handleVoteOptionSelect}
-              onActionClick={handleVoteSubmit}
-            />
-          </div>
-        )}
+        <PostDetailVoteSection post={post} />
 
         <div className="mt-8">
           <PostDetailActions

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -51,9 +51,7 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
 
   const voteDetail = voteData?.data.detail
 
-  // TODO: is_owner 반영 후 작성자 판별 교체 예정
-  const currentUserNickname = '테스트유저1'
-  const isOwner = post.nickname === currentUserNickname
+  const isOwner = post.isOwner
 
   const handleDelete = () => {
     setIsDeleteModalOpen(true)

--- a/src/features/post-detail/components/PostDetailVoteSection.tsx
+++ b/src/features/post-detail/components/PostDetailVoteSection.tsx
@@ -1,0 +1,101 @@
+import { MoreHorizontal } from 'lucide-react'
+
+import { ActionMenu } from '@/components/common/overlay/dropdown/action-menu/ActionMenu'
+import { VoteDisplay } from '@/components/common/ui/vote/VoteDisplay'
+import { VoteEditor } from '@/components/common/ui/vote/VoteEditor'
+import type { PostDetailData } from '@/features/post/post.types'
+import { usePostDetailVoteSection } from '@/features/post-detail/hooks/usePostDetailVoteSection'
+import {
+  getVoteMode,
+  toVoteDisplayOptions,
+} from '@/features/post-detail/utils/voteDisplayMapper'
+
+type PostDetailVoteSectionProps = {
+  post: PostDetailData
+}
+
+export function PostDetailVoteSection({ post }: PostDetailVoteSectionProps) {
+  const {
+    voteDetail,
+    participantCount,
+    selectedOptionId,
+    isEditMode,
+    editOptions,
+    editPeriod,
+    handleVoteSubmit,
+    handleVoteOptionSelect,
+    handleEdit,
+    handleDelete,
+    handleChangeEditOption,
+    handleChangeEditPeriod,
+    handleUpdateVote,
+    handleCancelEdit,
+  } = usePostDetailVoteSection(post)
+
+  if (!post.hasVote || !post.voteInfo) return null
+
+  if (isEditMode) {
+    return (
+      <div className="mt-6 overflow-x-auto">
+        <div className="min-w-80 rounded-2xl border border-border-default bg-surface p-4">
+          <VoteEditor
+            mode="edit"
+            options={editOptions}
+            period={editPeriod}
+            onChangeOption={handleChangeEditOption}
+            onChangePeriod={handleChangeEditPeriod}
+            onSubmit={handleUpdateVote}
+          />
+
+          <div className="mt-3 flex justify-end gap-2">
+            <button
+              type="button"
+              className="text-sm text-text-muted"
+              onClick={handleCancelEdit}
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="mt-6 overflow-x-auto">
+      <div className="min-w-80">
+        <VoteDisplay
+          mode={getVoteMode(post.voteInfo, voteDetail?.is_voted)}
+          options={toVoteDisplayOptions(voteDetail, selectedOptionId)}
+          participantCount={participantCount}
+          period={{
+            start: new Date(post.voteInfo.startAt),
+            end: new Date(post.voteInfo.endAt),
+          }}
+          onSelectOption={handleVoteOptionSelect}
+          onActionClick={handleVoteSubmit}
+          actionSlot={
+            post.isOwner ? (
+              <ActionMenu
+                trigger={
+                  <button
+                    type="button"
+                    aria-label="투표 더보기"
+                    className="flex size-8 items-center justify-center rounded-full text-text-primary hover:bg-gray-100"
+                  >
+                    <MoreHorizontal size={20} />
+                  </button>
+                }
+                items={[
+                  { label: '수정', onClick: handleEdit },
+                  { label: '삭제', onClick: handleDelete, variant: 'danger' },
+                ]}
+                align="right"
+                size="sm"
+              />
+            ) : undefined
+          }
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/features/post-detail/hooks/usePostDetailVoteSection.ts
+++ b/src/features/post-detail/hooks/usePostDetailVoteSection.ts
@@ -1,0 +1,192 @@
+// 게시글 상세 투표 섹션 로직 훅
+// - 투표 참여 / 수정 / 삭제 처리
+// - VoteDisplay ↔ VoteEditor 상태 관리
+import { useState } from 'react'
+import { useNavigate } from 'react-router'
+
+import type { AxiosError } from 'axios'
+
+import type { ApiErrorResponse } from '@/apis/api.types'
+import { formatError } from '@/apis/api.utils'
+import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
+import { useToast } from '@/components/common/ui/toast/useToast'
+import type { PostDetailData } from '@/features/post/post.types'
+import { useDeleteVoteMutation } from '@/query/post/useDeleteVoteMutation'
+import { useUpdateVoteMutation } from '@/query/post/useUpdateVoteMutation'
+import { useVoteMutation } from '@/query/post/useVoteMutaion'
+import { useVoteQuery } from '@/query/post/useVoteQuery'
+import { useAuthStore } from '@/store/authStore'
+
+function toDateString(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}
+
+function getServerErrorMessage(error: unknown, fallbackMessage: string) {
+  const axiosError = error as AxiosError<ApiErrorResponse>
+  const errorDetail = axiosError.response?.data.error_detail
+
+  if (typeof errorDetail === 'string') return errorDetail
+  if (errorDetail) return formatError(errorDetail)
+
+  return fallbackMessage
+}
+
+export function usePostDetailVoteSection(post: PostDetailData) {
+  const toast = useToast()
+  const navigate = useNavigate()
+  const user = useAuthStore((state) => state.user)
+
+  const voteMutation = useVoteMutation()
+  const updateVoteMutation = useUpdateVoteMutation()
+  const deleteVoteMutation = useDeleteVoteMutation()
+  const { data: voteData } = useVoteQuery(post.voteInfo?.voteId ?? 0)
+
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null)
+  const [isEditMode, setIsEditMode] = useState(false)
+  const [editOptions, setEditOptions] = useState<string[]>([])
+  const [editPeriod, setEditPeriod] = useState<DateRange | undefined>()
+
+  const voteDetail = voteData?.data.detail
+  const participantCount = voteDetail?.total_count ?? 0
+
+  const handleVoteSubmit = () => {
+    if (!user) {
+      navigate('/login')
+      return
+    }
+
+    if (voteDetail?.is_voted) return
+    if (!selectedOptionId || !post.voteInfo) return
+
+    voteMutation.mutate(
+      {
+        postId: post.postId,
+        voteId: post.voteInfo.voteId,
+        voteOptionId: Number(selectedOptionId),
+      },
+      {
+        onSuccess: () => {
+          toast.success('투표가 완료되었습니다.')
+        },
+        onError: (error) => {
+          const axiosError = error as AxiosError<ApiErrorResponse>
+
+          if (axiosError.response?.status === 409) {
+            toast.error('이미 참여한 투표입니다.')
+            return
+          }
+
+          toast.error(getServerErrorMessage(error, '투표에 실패했습니다.'))
+        },
+      }
+    )
+  }
+
+  const handleVoteOptionSelect = (optionId: string) => {
+    if (voteDetail?.is_voted) return
+    setSelectedOptionId(optionId)
+  }
+
+  const handleEdit = () => {
+    if (!post.voteInfo) return
+
+    if (participantCount > 0) {
+      toast.error('이미 참여자가 있는 투표는 수정할 수 없습니다.')
+      return
+    }
+
+    setEditOptions(
+      [...post.voteInfo.options]
+        .sort((a, b) => a.sortOrder - b.sortOrder)
+        .map((option) => option.content)
+    )
+
+    setEditPeriod({
+      start: new Date(post.voteInfo.startAt),
+      end: new Date(post.voteInfo.endAt),
+    })
+
+    setIsEditMode(true)
+  }
+
+  const handleChangeEditOption = (index: number, value: string) => {
+    setEditOptions((prev) =>
+      prev.map((option, optionIndex) =>
+        optionIndex === index ? value : option
+      )
+    )
+  }
+
+  const handleChangeEditPeriod = (date: DateRange | null) => {
+    setEditPeriod(date ?? undefined)
+  }
+
+  const handleUpdateVote = () => {
+    if (!post.voteInfo) return
+
+    updateVoteMutation.mutate(
+      {
+        voteId: post.voteInfo.voteId,
+        body: {
+          options: editOptions, // ← 다시 이걸로
+          start_at: editPeriod?.start
+            ? toDateString(editPeriod.start)
+            : undefined,
+          end_at: editPeriod?.end ? toDateString(editPeriod.end) : undefined,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success('투표가 수정되었습니다.')
+          setIsEditMode(false)
+        },
+        onError: (error) => {
+          toast.error(getServerErrorMessage(error, '투표 수정에 실패했습니다.'))
+        },
+      }
+    )
+  }
+
+  const handleDelete = () => {
+    if (!post.voteInfo) return
+
+    if (participantCount > 0) {
+      toast.error('참여자가 있는 투표는 삭제할 수 없습니다.')
+      return
+    }
+
+    deleteVoteMutation.mutate(post.voteInfo.voteId, {
+      onSuccess: () => {
+        toast.success('투표가 삭제되었습니다.')
+      },
+      onError: (error) => {
+        toast.error(getServerErrorMessage(error, '투표 삭제에 실패했습니다.'))
+      },
+    })
+  }
+
+  const handleCancelEdit = () => {
+    setIsEditMode(false)
+  }
+
+  return {
+    voteDetail,
+    participantCount,
+    selectedOptionId,
+    isEditMode,
+    editOptions,
+    editPeriod,
+    handleVoteSubmit,
+    handleVoteOptionSelect,
+    handleEdit,
+    handleDelete,
+    handleChangeEditOption,
+    handleChangeEditPeriod,
+    handleUpdateVote,
+    handleCancelEdit,
+  }
+}

--- a/src/features/post-detail/utils/voteDisplayMapper.ts
+++ b/src/features/post-detail/utils/voteDisplayMapper.ts
@@ -1,5 +1,4 @@
 import { VoteViewerMode } from '@/components/common/ui/vote/Vote.type'
-
 type VoteResultOption = {
   vote_option_id: number
   content: string
@@ -15,6 +14,7 @@ type VoteDetail = {
   options: VoteResultOption[]
 }
 
+// 투표 상태 - ui 모드 변환
 export function getVoteMode(
   voteInfo: { status: string } | null,
   isVoted?: boolean
@@ -26,6 +26,7 @@ export function getVoteMode(
   return VoteViewerMode.MEMBER
 }
 
+// api 응답 -> VoteDisplay 옵션 반환
 export function toVoteDisplayOptions(
   voteDetail: VoteDetail | undefined,
   selectedOptionId: string | null
@@ -34,7 +35,7 @@ export function toVoteDisplayOptions(
     voteDetail?.options.map((opt) => ({
       id: String(opt.vote_option_id),
       optionLabel: opt.content,
-      valueLabel: `${opt.rate}%`,
+      valueLabel: opt.content,
       percentage: opt.rate,
       checked: voteDetail.is_voted
         ? voteDetail.voted_option_id === opt.vote_option_id

--- a/src/features/post/components/PostFormLayout.tsx
+++ b/src/features/post/components/PostFormLayout.tsx
@@ -110,6 +110,7 @@ export function PostFormLayout({
           period={form.votePeriod}
           onChangeOption={form.changeVoteOption}
           onChangePeriod={form.changeVotePeriod}
+          isExistingVoteLocked={form.isExistingVoteLocked}
         />
       </div>
 

--- a/src/features/post/components/PostVoteSection.tsx
+++ b/src/features/post/components/PostVoteSection.tsx
@@ -1,5 +1,6 @@
 import { VoteEditor } from '@/components/common/ui'
 import type { DateRange } from '@/components/common/ui/calendar/Calendar.type'
+import { cn } from '@/utils/cn'
 
 import type { PostFormMode } from '../post.types'
 
@@ -9,6 +10,12 @@ type PostVoteSectionProps = {
   period?: DateRange
   onChangeOption: (index: number, value: string) => void
   onChangePeriod: (date: DateRange | null) => void
+  isExistingVoteLocked?: boolean
+}
+
+function formatDate(date?: Date | null) {
+  if (!date) return ''
+  return date.toISOString().split('T')[0].replaceAll('-', '.')
 }
 
 export function PostVoteSection({
@@ -17,7 +24,59 @@ export function PostVoteSection({
   period,
   onChangeOption,
   onChangePeriod,
+  isExistingVoteLocked = false,
 }: PostVoteSectionProps) {
+  if (isExistingVoteLocked) {
+    return (
+      <>
+        <p className="text-sm text-text-muted">
+          기존 투표는 수정 페이지에서 변경할 수 없습니다. 투표 수정은
+          상세페이지에서 진행해주세요.
+        </p>
+
+        <div className="mb-2 flex items-center gap-2 text-sm">
+          <span className="text-text-primary">투표 진행중</span>
+          <span className="text-text-primary">
+            {formatDate(period?.start)} ~ {formatDate(period?.end)}
+          </span>
+        </div>
+
+        <section className="relative mx-auto min-h-62 w-full max-w-267.5 rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main">
+          <div className="flex flex-col gap-4 pt-8">
+            {options.map((option, index) => {
+              const isFirst = index === 0
+
+              return (
+                <div
+                  key={`${option}-${index}`}
+                  className="grid w-full grid-cols-[20px_minmax(0,1fr)_44px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]"
+                >
+                  <span className="flex items-center justify-center">
+                    <span className="flex size-4 items-center justify-center rounded-sm bg-gray-300" />
+                  </span>
+
+                  <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm sm:h-14">
+                    <div
+                      className={cn(
+                        'absolute inset-y-0 left-0 rounded-full',
+                        isFirst ? 'bg-gray-300' : 'bg-primary-100'
+                      )}
+                      style={{ width: '0%' }}
+                    />
+
+                    <span className="relative z-10 flex h-full min-w-0 items-center truncate px-3 text-sm font-medium text-text-primary sm:px-6">
+                      {option}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      </>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-3 rounded-2xl border border-border-default bg-surface p-4">
       <VoteEditor

--- a/src/features/post/hooks/usePostForm.ts
+++ b/src/features/post/hooks/usePostForm.ts
@@ -23,6 +23,11 @@ export function usePostForm(
   const [title, setTitle] = useState(defaultValues?.title ?? '')
   const [content, setContent] = useState(defaultValues?.content ?? '')
 
+  // edit 모드에서 기존 투표가 있으면 수정 페이지에서는 투표 수정 불가
+  // 기존 투표 수정은 게시글 상세페이지의 투표 더보기 메뉴에서 처리
+  const initialHasVote = mode === 'edit' && Boolean(defaultValues?.hasVote)
+  const isExistingVoteLocked = mode === 'edit' && initialHasVote
+
   // 이미지: edit 모드의 기존 이미지는 imageUrl이 이미 확정된 상태
   const [imageItems, setImageItems] = useState<PostImageItem[]>(
     (defaultValues?.images ?? []).map((url) => ({
@@ -30,6 +35,7 @@ export function usePostForm(
       imageUrl: url,
     }))
   )
+
   // 언마운트 시 revoke할 blob URL 추적
   const blobUrlsRef = useRef<string[]>([])
 
@@ -94,7 +100,9 @@ export function usePostForm(
       blobUrlsRef.current.push(previewUrl)
       return { previewUrl, imageUrl: null }
     })
+
     setImageItems((prev) => [...prev, ...newItems])
+
     return newItems.map((item) => item.previewUrl)
   }
 
@@ -115,6 +123,7 @@ export function usePostForm(
       URL.revokeObjectURL(url)
       blobUrlsRef.current = blobUrlsRef.current.filter((u) => u !== url)
     })
+
     setImageItems((prev) =>
       prev.filter((item) => !blobUrls.includes(item.previewUrl))
     )
@@ -123,12 +132,14 @@ export function usePostForm(
   // X 버튼으로 단일 이미지 제거
   function removeImage(index: number) {
     const item = imageItems[index]
+
     if (item?.previewUrl.startsWith('blob:')) {
       URL.revokeObjectURL(item.previewUrl)
       blobUrlsRef.current = blobUrlsRef.current.filter(
         (u) => u !== item.previewUrl
       )
     }
+
     setImageItems((prev) => prev.filter((_, i) => i !== index))
   }
 
@@ -143,12 +154,16 @@ export function usePostForm(
 
   // 투표
   function changeVoteOption(index: number, value: string) {
+    if (isExistingVoteLocked) return
+
     if (charLen(value) <= MAX_VOTE_OPTION) {
       setVoteOptions((prev) => prev.map((o, i) => (i === index ? value : o)))
     }
   }
 
   function changeVotePeriod(date: DateRange | null) {
+    if (isExistingVoteLocked) return
+
     setVotePeriod(date ?? undefined)
   }
 
@@ -158,15 +173,20 @@ export function usePostForm(
       .filter((item) => item.imageUrl !== null)
       .map((item) => item.imageUrl!)
 
+    const validVoteOptions = voteOptions
+      .filter((option) => option.trim() !== '')
+      .map((option) => option.trim())
+
     const hasActiveVote =
       Boolean(votePeriod?.start && votePeriod?.end) &&
-      voteOptions.filter((opt) => opt.trim() !== '').length >= 2
+      validVoteOptions.length >= 2
 
-    const vote: PostFormData['vote'] = hasActiveVote
+    // 기존 투표가 없고, 새 투표 입력값이 유효할 때만 vote payload 전송
+    const shouldSendVote = hasActiveVote && !initialHasVote
+
+    const vote: PostFormData['vote'] = shouldSendVote
       ? {
-          options: voteOptions
-            .filter((c) => c.trim() !== '')
-            .map((c) => c.trim()),
+          options: validVoteOptions,
           startDate: votePeriod?.start?.toISOString().split('T')[0],
           endDate: votePeriod?.end?.toISOString().split('T')[0],
         }
@@ -180,6 +200,7 @@ export function usePostForm(
       goalId: selectedGoalId,
       hasVote: hasActiveVote,
       vote,
+      canEditVote: shouldSendVote,
       tagIds: selectedTagIds,
     }
 
@@ -187,6 +208,7 @@ export function usePostForm(
       if (postId === undefined) {
         throw new Error('[usePostForm] edit 모드에서 postId는 필수입니다.')
       }
+
       return { postId, ...base }
     }
 
@@ -202,12 +224,15 @@ export function usePostForm(
     voteOptions,
     votePeriod,
     selectedGoalId,
+
     // 파생
     titleLen,
     contentLen,
     isSubmitDisabled,
     isUploading,
     canAddImage,
+    isExistingVoteLocked,
+
     // 액션
     changeTitle,
     changeContent,

--- a/src/features/post/post.api.types.ts
+++ b/src/features/post/post.api.types.ts
@@ -67,6 +67,7 @@ export type ApiPostResponse = {
   comment_count: number
   is_liked: boolean
   is_scrapped: boolean
+  is_owner: boolean
   has_goal: boolean
   goal_info: {
     goal_id: number

--- a/src/features/post/post.api.types.ts
+++ b/src/features/post/post.api.types.ts
@@ -111,7 +111,7 @@ export type ApiPostUpdateRequest = {
   images?: string[]
   has_goal: boolean
   goal_id?: number
-  has_vote: boolean
+  has_vote?: boolean
   vote?: VoteContent
   tag_ids?: number[]
 }

--- a/src/features/post/post.mappers.ts
+++ b/src/features/post/post.mappers.ts
@@ -34,6 +34,7 @@ export function toPostFormData(api: ApiPostResponse): PostFormData {
     hasGoal: api.has_goal,
     goalId: api.goal_info?.goal_id,
     hasVote: api.has_vote,
+    canEditVote: false,
     vote: api.vote_info
       ? {
           options: api.vote_info.options.map((o) => o.content),
@@ -117,6 +118,8 @@ export function toApiUpdateRequest(data: PostFormData): ApiPostUpdateRequest {
     throw new Error('postId는 필수')
   }
 
+  const shouldSendVote = data.canEditVote && data.vote
+
   return {
     post_id: data.postId,
     title: data.title,
@@ -124,8 +127,12 @@ export function toApiUpdateRequest(data: PostFormData): ApiPostUpdateRequest {
     images: data.images,
     has_goal: data.hasGoal,
     ...(data.goalId !== undefined && { goal_id: data.goalId }),
-    has_vote: data.hasVote,
-    vote: toApiVoteContent(data.vote),
+    ...(shouldSendVote
+      ? {
+          has_vote: true,
+          vote: toApiVoteContent(data.vote),
+        }
+      : {}),
     tag_ids: data.tagIds,
   }
 }

--- a/src/features/post/post.mappers.ts
+++ b/src/features/post/post.mappers.ts
@@ -61,6 +61,7 @@ export function toPostDetailData(api: ApiPostResponse): PostDetailData {
     commentCount: api.comment_count,
     isLiked: api.is_liked ?? false,
     isScrapped: api.is_scrapped,
+    isOwner: api.is_owner,
     hasGoal: api.has_goal,
     goalInfo: api.goal_info
       ? {

--- a/src/features/post/post.types.ts
+++ b/src/features/post/post.types.ts
@@ -24,6 +24,7 @@ export type PostFormData = {
   goalId?: number
   hasVote: boolean
   vote?: VoteFormData
+  canEditVote?: boolean
   tagNames?: string[]
   tagIds: number[]
 }

--- a/src/features/post/post.types.ts
+++ b/src/features/post/post.types.ts
@@ -66,6 +66,7 @@ export type PostDetailData = {
   isLiked: boolean
   commentCount: number
   isScrapped: boolean
+  isOwner: boolean
   hasGoal: boolean
   goalInfo: {
     goalId: number

--- a/src/mocks/data/post.ts
+++ b/src/mocks/data/post.ts
@@ -137,6 +137,7 @@ export const mockPost: ApiPostResponse = {
   comment_count: 3,
   is_liked: false,
   is_scrapped: false,
+  is_owner: true,
   has_goal: true,
   goal_info: {
     goal_id: 101,

--- a/src/query/post/useDeleteVoteMutation.ts
+++ b/src/query/post/useDeleteVoteMutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post/post.api'
+
+export function useDeleteVoteMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (voteId: number) => postApi.deleteVote(voteId),
+
+    onSuccess: () => {
+      // 삭제 후 상세 리패치
+      queryClient.invalidateQueries({
+        queryKey: ['postDetail'],
+      })
+    },
+  })
+}

--- a/src/query/post/useUpdateVoteMutation.ts
+++ b/src/query/post/useUpdateVoteMutation.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { postApi } from '@/apis/post/post.api'
+
+type UpdateVoteBody = {
+  options: string[]
+  start_at?: string
+  end_at?: string
+}
+
+type UpdateVoteVariables = {
+  voteId: number
+  body: UpdateVoteBody
+}
+
+export function useUpdateVoteMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ voteId, body }: UpdateVoteVariables) =>
+      postApi.updateVote(voteId, body),
+
+    onSuccess: (_, variables) => {
+      // 투표 수정 후 전체 리패치
+      queryClient.invalidateQueries({
+        queryKey: ['postDetail'],
+      })
+
+      queryClient.invalidateQueries({
+        queryKey: ['vote', variables.voteId],
+      })
+    },
+  })
+}

--- a/src/query/post/useVoteMutaion.ts
+++ b/src/query/post/useVoteMutaion.ts
@@ -14,6 +14,10 @@ export function useVoteMutation() {
   return useMutation({
     mutationFn: ({ voteId, voteOptionId }: VoteMutationParams) =>
       postApi.vote(voteId, { vote_option_id: voteOptionId }),
+    // 투표 참여 후 상세페이지 데이터 최신화
+    // - 게시글 상세 (likeCount 등 반영)
+    // - 투표 결과 (득표율, 참여 여부 반영)
+    // - 댓글 (동시 참여 상황 고려하여 최신화)
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: ['postDetail', variables.postId],
@@ -21,6 +25,10 @@ export function useVoteMutation() {
 
       queryClient.invalidateQueries({
         queryKey: ['vote', variables.voteId],
+      })
+
+      queryClient.invalidateQueries({
+        queryKey: ['comments', variables.postId],
       })
     },
   })


### PR DESCRIPTION
## 📌 관련 이슈

Closes #160 

## ✨ 변경 내용

- 백엔드 is_owner 응답 기반 작성자 판별 로직 적용
- 작성자 / 비작성자 ActionMenu 분기 정상화 (수정/삭제 vs 신고)
- 투표 수정 / 삭제 기능 구현 및 API 연동
- 참여자 존재 시 투표 삭제 제한 처리
- 투표 상태에 따른 UI 분기 및 동작 보완
- 수정 페이지에서 기존 투표 readOnly 처리
- 기존 투표는 수정 페이지에서 변경 불가하도록 정책 분리
- 퍼센트 / 참여자 수 제거 (잘못된 정보 노출 방지)
- 기존 투표 존재 시 vote payload 미전송 처리

## 📸 스크린샷(선택)

## 📚 참고사항
