### PR TITLE
fix: improve mypage responsive layout

### DIFF
--- a/src/features/my-page/goal/MyPageGoalSection.tsx
+++ b/src/features/my-page/goal/MyPageGoalSection.tsx
@@ -70,71 +70,66 @@ function GoalListSection() {
   const skeletonCount = isCreateOpen ? 7 : 8
 
   return (
-    <section className="flex flex-col gap-8">
-      <div className="flex min-h-16 flex-wrap items-start justify-between gap-x-3 gap-y-2">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-x-[clamp(0.25rem,1vw,0.5rem)] gap-y-2 sm:gap-0.5">
-            {GOAL_FILTERS.map((filter) => (
-              <TabButton
-                key={filter}
-                type="button"
-                isActive={activeFilter === filter}
-                onClick={() => setFilter(filter)}
-                className="min-w-0 whitespace-nowrap px-2 py-1 text-xs sm:min-w-18 sm:text-sm"
-              >
-                {filter}
-              </TabButton>
-            ))}
-            <span
-              className="mt-1 hidden text-text-muted/35 min-[721px]:inline"
-              aria-hidden="true"
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-bold text-text-primary">목표 리스트</h2>
+        <Button
+          size="md"
+          rounded="full"
+          leftIcon={<Plus className="size-4" aria-hidden="true" />}
+          onClick={() => setIsCreateOpen(true)}
+          className="shrink-0 whitespace-nowrap"
+        >
+          목표 생성
+        </Button>
+      </div>
+
+      {/* 필터 영역 */}
+      <div className="mb-3 flex flex-wrap items-center">
+        <div className="mb-2 md:mb-0 flex items-center justify-between gap-1 sm:justify-start sm:gap-1.5">
+          {GOAL_FILTERS.map((filter) => (
+            <TabButton
+              key={filter}
+              type="button"
+              isActive={activeFilter === filter}
+              onClick={() => setFilter(filter)}
+              className="min-w-20 shrink-0 whitespace-nowrap px-3 py-1.5 text-sm"
             >
-              |
-            </span>
-            <div className="w-fit shrink-0">
-              <Calendar
-                className="w-full sm:w-fit"
-                panelClassName="left-auto right-0 translate-x-16 sm:left-0 sm:right-auto"
-                label="기간 설정"
-                ariaLabel="기간 설정"
-                hideLabelOnMobile
-                // 마이페이지 목표 필터는 과거 기간 조회가 가능해야 하므로 제한을 해제합니다.
-                allowPastDates
-                value={selectedPeriod}
-                onChange={(value) =>
-                  setPeriod(value ?? { start: null, end: null })
-                }
-              />
-            </div>
-            <span
-              className="mt-1 hidden text-text-muted/35 min-[721px]:inline"
-              aria-hidden="true"
-            >
-              |
-            </span>
+              {filter}
+            </TabButton>
+          ))}
+        </div>
+
+        {/* 날짜 초기화 필터링 영역 */}
+        <div className="flex w-full items-center gap-4 rounded-lg border border-border-default p-1 md:h-8 md:w-fit md:border-0 md:p-0">
+          <Calendar
+            className="w-full max-w-none md:w-fit md:max-w-54"
+            panelClassName="left-0 right-auto translate-x-0 px-0"
+            label="기간 설정"
+            ariaLabel="기간 설정"
+            // 마이페이지 목표 필터는 과거 기간 조회가 가능해야 하므로 제한을 해제합니다.
+            allowPastDates
+            value={selectedPeriod}
+            onChange={(value) => setPeriod(value ?? { start: null, end: null })}
+          />
+          <span
+            className="hidden text-text-muted/35 sm:inline"
+            aria-hidden="true"
+          >
+            |
+          </span>
+          <div className="shrink-0">
             <Button
               variant="ghost"
               rounded="full"
               aria-label="필터 초기화"
               leftIcon={<RotateCcw className="size-4" aria-hidden="true" />}
               onClick={resetFilters}
-              className="h-8 shrink-0 px-2 text-sm text-text-muted hover:bg-transparent hover:text-tab-active-text sm:px-3"
+              className="h-8 shrink-0 pr-2 text-sm text-text-muted hover:bg-transparent hover:text-tab-active-text"
             >
-              <span className="hidden min-[721px]:inline">초기화</span>
+              <span className="inline">초기화</span>
             </Button>
           </div>
-        </div>
-
-        <div className="flex basis-full justify-end sm:basis-auto">
-          <Button
-            size="md"
-            rounded="full"
-            leftIcon={<Plus className="size-4" aria-hidden="true" />}
-            onClick={() => setIsCreateOpen(true)}
-            className="shrink-0 whitespace-nowrap"
-          >
-            목표 생성
-          </Button>
         </div>
       </div>
 

--- a/src/features/my-page/heatmap/MyPageHeatmap.tsx
+++ b/src/features/my-page/heatmap/MyPageHeatmap.tsx
@@ -236,7 +236,7 @@ export function MyPageHeatmap({
         </div>
       </div>
 
-      <div className="mt-4 flex items-center justify-between gap-4 border-t border-border-default/70 pt-3 text-xs text-text-muted">
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-4 border-t border-border-default/70 pt-3 text-xs text-text-muted">
         <button type="button" className="shrink-0">
           활동량 집계 방식 알아보기
         </button>


### PR DESCRIPTION
## 📌 관련 이슈

Closes #165

## ✨ 변경 내용

  - 마이페이지 목표 리스트 영역에 타이틀과 목표 생성 버튼을 분리 배치
  - 목표 상태 필터와 날짜/초기화 필터의 반응형 레이아웃을 개선
  - 모바일/태블릿 구간에서 날짜 필터 영역이 박스 형태로 표시되도록 조정
  - 히트맵 하단 안내 영역이 좁은 화면에서 줄바꿈되도록 수정

## 📸 스크린샷(선택)
<img width="1624" height="698" alt="스크린샷 2026-05-06 오전 2 10 30" src="https://github.com/user-attachments/assets/4b47314b-bd65-4223-b84b-1f8c5b460017" />
<img width="497" height="678" alt="스크린샷 2026-05-06 오전 2 10 52" src="https://github.com/user-attachments/assets/096ea15f-1958-4977-904c-eaa89c94d9d2" />

## 📚 참고사항
