### PR TITLE
feat: comment UI polish

### DIFF
--- a/src/components/common/ui/comment/CommentInput.tsx
+++ b/src/components/common/ui/comment/CommentInput.tsx
@@ -32,9 +32,9 @@ export function CommentInput({
   }
 
   return (
-    <div className="flex items-start gap-4 pl-4">
+    <div className="flex items-start gap-3 sm:gap-4 sm:pl-4">
       {/* 프로필 (나중에 사용자 정보로 교체 가능) */}
-      <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full bg-gray-200">
+      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full bg-surface sm:h-12 sm:w-12">
         {profileImageUrl ? (
           <img
             src={profileImageUrl}

--- a/src/components/common/ui/comment/CommentItem.tsx
+++ b/src/components/common/ui/comment/CommentItem.tsx
@@ -58,13 +58,13 @@ export function CommentItem({
   return (
     <div
       className={cn(
-        'flex gap-3 rounded-xl px-4 py-3',
+        'flex gap-3 rounded-xl px-3 py-3 sm:px-4',
         isSelected && 'bg-primary-100/30'
       )}
       onClick={() => onSelect?.()}
     >
       {/* 프로필 */}
-      <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full bg-gray-200">
+      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full bg-gray-200 sm:h-12 sm:w-12">
         {profileImageUrl ? (
           <img
             src={profileImageUrl}
@@ -159,33 +159,31 @@ export function CommentItem({
             </div>
           </div>
         ) : (
-          <p className="max-w-full break-all whitespace-pre-wrap text-sm text-text-primary">
+          <p className="max-w-full wrap-break-word whitespace-pre-wrap text-sm text-text-primary">
             {content}
           </p>
         )}
 
         {/* 좋아요 */}
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation()
-              onLike?.(id)
-            }}
-            className="flex items-center gap-1"
-            aria-label="댓글 좋아요"
-          >
-            <Heart
-              className={cn(
-                'h-4 w-4',
-                isLiked
-                  ? 'fill-primary-500 text-primary-500'
-                  : 'text-text-muted'
-              )}
-            />
-            <span className="text-xs text-text-muted">{likeCount}</span>
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onLike?.(id)
+          }}
+          className="group flex items-center gap-1"
+          aria-label="댓글 좋아요"
+        >
+          <Heart
+            className={cn(
+              'h-4 w-4 transition-transform duration-200 group-hover:scale-110',
+              isLiked ? 'fill-current text-error-500' : 'text-text-primary'
+            )}
+          />
+          <span className="text-xs text-text-primary tabular-nums">
+            {likeCount}
+          </span>
+        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## 📌 관련 이슈

Closes #168 

## ✨ 변경 내용

-댓글 좋아요(하트) 스타일을 PostDetailActions와 동일하게 통일
- 댓글 영역 반응형 보완 (모바일에서 간격 및 프로필 크기 조정)
- 긴 텍스트 줄바꿈 처리 개선 (wrap-break-word)
- 댓글 UI 전반 간격 및 가독성 개선

## 📸 스크린샷(선택)
<img width="911" height="1072" alt="스크린샷 2026-05-06 오전 3 07 04" src="https://github.com/user-attachments/assets/e1e0edce-cef4-442a-a3ba-925063567a67" />


## 📚 참고사항
- 댓글 컴포넌트 내 다크모드 관련 토큰 변경은 일부 적용 후 원복하여
현재는 기존 디자인 기준(라이트 기반 스타일)으로 유지했습니다.
- 다크모드에서 카드 배경과 댓글 영역의 톤이 맞지 않는 문제는
댓글 컴포넌트가 아닌 상위 PostDetail 카드 영역의 배경 스타일 문제로 확인되었으며,
별도 이슈/브랜치에서 처리 예정입니다.