### PR TITLE
feat: add post share button and enable like on my posts (#172)

### DIFF
--- a/src/components/common/ui/card/PostCard.tsx
+++ b/src/components/common/ui/card/PostCard.tsx
@@ -44,6 +44,17 @@ export function PostCard({
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
+  const handleCopyShareUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(
+        `${window.location.origin}/post/${postId}`
+      )
+      toast.success('게시글 링크가 복사되었습니다.')
+    } catch {
+      toast.error('게시글 링크 복사에 실패했습니다.')
+    }
+  }
+
   const {
     liked,
     scrapped,
@@ -51,7 +62,13 @@ export function PostCard({
     toggleLike,
     toggleScrap,
     handleShare,
-  } = usePostCardActions({ postId, likeCount, isLiked, isScrapped, onShare })
+  } = usePostCardActions({
+    postId,
+    likeCount,
+    isLiked,
+    isScrapped,
+    onShare: onShare ?? handleCopyShareUrl,
+  })
 
   const {
     showReportForm,

--- a/src/features/my-posts/myPosts.api.types.ts
+++ b/src/features/my-posts/myPosts.api.types.ts
@@ -15,6 +15,7 @@ export type ApiMyPostListItem = {
   tags: string[]
   content_preview: string
   like_count: number
+  is_liked: boolean
   comment_count: number
   is_scrapped: boolean
 }

--- a/src/features/post-detail/components/PostDetailActions.tsx
+++ b/src/features/post-detail/components/PostDetailActions.tsx
@@ -1,6 +1,7 @@
 import { Bookmark, Heart, MessageCircle, Share2 } from 'lucide-react'
 
 import { Button } from '@/components/common/ui'
+import { useToast } from '@/components/common/ui/toast/useToast'
 import {
   useTogglePostLikeMutation,
   useTogglePostScrapMutation,
@@ -24,6 +25,7 @@ export function PostDetailActions({
 }: PostDetailActionsProps) {
   const likeMutation = useTogglePostLikeMutation(postId)
   const scrapMutation = useTogglePostScrapMutation({ postId, isScrapped })
+  const toast = useToast()
 
   const handleLike = () => {
     likeMutation.mutate()
@@ -37,9 +39,12 @@ export function PostDetailActions({
 
   const handleShare = async () => {
     try {
-      await navigator.clipboard.writeText(window.location.href)
+      await navigator.clipboard.writeText(
+        `${window.location.origin}/post/${postId}`
+      )
+      toast.success('게시글 링크가 복사되었습니다.')
     } catch {
-      // TODO: 토스트 연결 시 공유 실패 메시지 노출
+      toast.error('게시글 링크 복사에 실패했습니다.')
     }
   }
 

--- a/src/pages/MyPostsPage.tsx
+++ b/src/pages/MyPostsPage.tsx
@@ -22,7 +22,7 @@ function toMyPostListItem(post: ApiMyPostListItem): PostListItem {
     contentPreview: post.content_preview,
     likeCount: post.like_count,
     commentCount: post.comment_count,
-    isLiked: false,
+    isLiked: post.is_liked,
     isScrapped: post.is_scrapped,
     isOwner: true,
   }


### PR DESCRIPTION
## 📌 관련 이슈

Closes #172

## ✨ 변경 내용

  - 내가 쓴 게시글 목록에서 좋아요 여부가 서버 응답의 is_liked 값으로 표시되도록 수정
  - 게시글 카드와 상세페이지의 공유하기 버튼 클릭 시 게시글 상세 URL이 클립보드에 복사되도록 구현
  - 공유 성공/실패 시 토스트 메시지 노출

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/70ddf6ed-feba-497b-b987-8befb3488aeb


## 📚 참고사항
