### PR TITLE
feat: add scrap api and connect to bookmark page

### DIFF
--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -7,6 +7,7 @@ import type {
   ApiTrendingParams,
   ApiTrendingResponse,
 } from '@/features/main/post-list/PostList.api.types'
+import type { ApiPostListResponse } from '@/features/main/post-list/PostList.api.types'
 import type {
   ApiMyPostListParams,
   ApiMyPostListWrappedResponse,
@@ -55,9 +56,10 @@ export const postApi = {
     }),
 
   // 북마크(스크랩) 게시글 목록 조회
-  // TODO: API 수정 완료 시 아래 주석을 해제하고 북마크 조회에서 getPosts 호출 제거
-  // getScrappedPosts: (params?: ApiPostListParams) =>
-  //   apiClient.get<ApiPostListResponse>(POST_ENDPOINTS.postScrapsList, { params }),
+  getScrappedPosts: (params?: { page?: number; size?: number }) =>
+    apiClient.get<ApiPostListResponse>(POST_ENDPOINTS.postScrapsList, {
+      params,
+    }),
 
   // 내가 쓴 게시글 목록 조회
   getMyPosts: (params?: ApiMyPostListParams) =>

--- a/src/pages/BookmarkedPostsPage.tsx
+++ b/src/pages/BookmarkedPostsPage.tsx
@@ -1,18 +1,17 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useSearchParams } from 'react-router'
+import { Link, useSearchParams } from 'react-router'
 
 import { formatError } from '@/apis/api.utils'
+import { EmptyState } from '@/components/common/ui'
+import { buttonVariants } from '@/components/common/ui/button/Button.style'
 import { POSTS_PAGE_SIZE } from '@/features/main/post-list'
 import { PostList } from '@/features/main/post-list/PostList'
 import type { ApiPostListItem } from '@/features/main/post-list/PostList.api.types'
-import type { PostListItem } from '@/features/main/post-list/PostList.types'
 import { useBookmarkedPostsQuery } from '@/query/main/useBookmarkedPostsQuery'
 import { useAuthStore } from '@/store/authStore'
+import { cn } from '@/utils/cn'
 
-function toPostListItem(
-  item: ApiPostListItem,
-  currentNickname: string | null
-): PostListItem {
+function toPostListItem(item: ApiPostListItem, currentNickname: string | null) {
   return {
     postId: item.post_id,
     images: item.images,
@@ -34,30 +33,16 @@ export function BookmarkedPostsPage() {
   const user = useAuthStore((state) => state.user)
   const [searchParams, setSearchParams] = useSearchParams()
   const page = Number(searchParams.get('page')) || 1
-  const [inputValue, setInputValue] = useState('')
+
+  const [searchInput, setSearchInput] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const hasSearchQuery = searchQuery.trim().length > 0
 
   const { data, isLoading, isFetching, isError, error } =
     useBookmarkedPostsQuery({
-      page: page - 1,
+      page: hasSearchQuery ? 0 : page - 1,
       size: POSTS_PAGE_SIZE,
     })
-
-  const posts = useMemo(
-    () =>
-      (data?.posts ?? []).map((item) =>
-        toPostListItem(item, user?.nickname ?? null)
-      ),
-    [data?.posts, user?.nickname]
-  )
-
-  const totalPages = useMemo(
-    () =>
-      Math.max(
-        1,
-        Math.ceil((data?.total_count ?? 0) / (data?.size ?? POSTS_PAGE_SIZE))
-      ),
-    [data?.total_count, data?.size]
-  )
 
   const handlePageChange = useCallback(
     (newPage: number) => {
@@ -74,29 +59,105 @@ export function BookmarkedPostsPage() {
     [setSearchParams]
   )
 
+  // 500ms debounce: 입력이 멈추면 searchQuery 반영 후 1페이지로 이동
+  useEffect(() => {
+    if (searchInput === searchQuery) return
+    const timer = window.setTimeout(() => {
+      setSearchQuery(searchInput)
+      handlePageChange(1)
+    }, 500)
+    return () => window.clearTimeout(timer)
+  }, [searchInput, searchQuery, handlePageChange])
+
+  // 삭제 후 현재 페이지가 비면 이전 페이지로 이동
   useEffect(() => {
     if (!isFetching && data?.posts.length === 0 && page > 1) {
       handlePageChange(page - 1)
     }
   }, [data, isFetching, page, handlePageChange])
 
-  const errorMessage = useMemo(() => {
-    const detail = error?.response?.data.error_detail
-    return detail ? formatError(detail) : undefined
-  }, [error])
+  const filteredPosts = useMemo(() => {
+    const normalizedQuery = searchQuery.trim().toLowerCase()
+    return (data?.posts ?? [])
+      .map((item) => toPostListItem(item, user?.nickname ?? null))
+      .filter((post) => {
+        if (!normalizedQuery) return true
+        return [post.title, post.contentPreview, post.nickname, ...post.tags]
+          .join(' ')
+          .toLowerCase()
+          .includes(normalizedQuery)
+      })
+  }, [data?.posts, user?.nickname, searchQuery])
+
+  const totalPages = useMemo(() => {
+    if (hasSearchQuery) {
+      return Math.max(1, Math.ceil(filteredPosts.length / POSTS_PAGE_SIZE))
+    }
+    return Math.max(
+      1,
+      Math.ceil((data?.total_count ?? 0) / (data?.size ?? POSTS_PAGE_SIZE))
+    )
+  }, [data?.total_count, data?.size, filteredPosts.length, hasSearchQuery])
+
+  const errorMessage = error?.response?.data.error_detail
+    ? formatError(error.response.data.error_detail)
+    : undefined
+
+  const emptyView = useMemo(
+    () => (
+      <EmptyState
+        title={
+          hasSearchQuery
+            ? '검색 결과가 없습니다.'
+            : '아직 스크랩한 게시글이 없습니다.'
+        }
+        description={
+          hasSearchQuery
+            ? '다른 검색어로 다시 찾아보세요.'
+            : '관심있는 게시글에 스크랩 버튼을 눌러보세요.'
+        }
+        action={
+          hasSearchQuery ? undefined : (
+            <Link
+              to="/"
+              className={cn(
+                buttonVariants({
+                  variant: 'primary',
+                  size: 'sm',
+                  rounded: 'full',
+                }),
+                'px-5 py-2 text-sm'
+              )}
+            >
+              메인으로 이동
+            </Link>
+          )
+        }
+        className="flex-1"
+      />
+    ),
+    [hasSearchQuery]
+  )
 
   return (
     <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-6">
+      <div className="px-4">
+        <h1 className="text-2xl font-semibold text-center">북마크</h1>
+      </div>
       <PostList
-        posts={posts}
+        posts={filteredPosts}
         totalPages={totalPages}
-        currentPage={page}
-        searchValue={inputValue}
+        currentPage={hasSearchQuery ? 1 : page}
+        searchValue={searchInput}
         isLoading={isLoading}
         isError={isError}
         errorMessage={errorMessage}
-        onSearch={setInputValue}
-        onSearchChange={setInputValue}
+        emptyView={emptyView}
+        onSearchChange={setSearchInput}
+        onSearch={(query) => {
+          setSearchQuery(query)
+          handlePageChange(1)
+        }}
         onPageChange={handlePageChange}
         stickPaginationToBottom
       />

--- a/src/query/main/useBookmarkedPostsQuery.ts
+++ b/src/query/main/useBookmarkedPostsQuery.ts
@@ -5,7 +5,6 @@ import type { ApiErrorResponse } from '@/apis/api.types'
 import { postApi } from '@/apis/post'
 import type { ApiPostListResponse } from '@/features/main/post-list/PostList.api.types'
 
-// TODO: API 수정 완료 시 postApi.getScrappedPosts(params)로 교체
 export function useBookmarkedPostsQuery(params: {
   page: number
   size: number
@@ -14,8 +13,8 @@ export function useBookmarkedPostsQuery(params: {
     queryKey: ['bookmarkedPosts', params],
     retry: false,
     queryFn: async () => {
-      const res = await postApi.getPosts(params)
-      return res.data.detail
+      const res = await postApi.getScrappedPosts(params)
+      return res.data
     },
     gcTime: 0,
   })

--- a/src/query/post/useScrapMutation.ts
+++ b/src/query/post/useScrapMutation.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { postApi } from '@/apis/post'
 
@@ -15,6 +15,7 @@ export function useScrapMutation({
   postId,
   initialScrapped,
 }: UseScrapMutationProps) {
+  const queryClient = useQueryClient()
   const [scrapped, setScrapped] = useState(initialScrapped)
 
   const { mutate, isPending } = useMutation({
@@ -23,6 +24,9 @@ export function useScrapMutation({
     onMutate: (currentScrapped) => {
       setScrapped(!currentScrapped)
       return { prevScrapped: currentScrapped }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['bookmarkedPosts'] })
     },
     onError: (_err, _vars, context) => {
       if (!context) return


### PR DESCRIPTION
## 📌 관련 이슈

Closes #174 

## ✨ 변경 내용

- 임시로 사용하던 `getPosts` → `getScrappedPosts`로 교체
- `useScrapMutation` 성공 시 `invalidateQueries(['bookmarkedPosts'])` 추가 하여 북마크 페이지에서도 북마크 취소 성공 시 목록 재조회
- 검색 로직 추가

## 📸 스크린샷(선택)


https://github.com/user-attachments/assets/b38f27e6-0d69-40b3-acfa-df478afe9838




## 📚 참고사항
북마크 조회 API에서 get요청으로 데이터를 받아온 뒤 검색 로직은 내가 작성한 게시글에서 처리되어 있는 로직을 받아와 사용하였습니다.