### PR TITLE
fix: post detail dark mode UI

### DIFF
--- a/src/components/common/ui/comment/CommentInput.tsx
+++ b/src/components/common/ui/comment/CommentInput.tsx
@@ -48,7 +48,7 @@ export function CommentInput({
       <div className="flex flex-1 flex-col gap-2">
         <div className="relative">
           <Textarea
-            className="h-14 min-h-14 max-h-30 overflow-hidden bg-gray-100 pr-20 pb-6 focus:bg-white"
+            className="h-14 min-h-14 max-h-30 overflow-hidden bg-gray-100 pr-20 pb-6 focus:bg-white dark:border-white/15 dark:bg-white/5 dark:focus:bg-white/10"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder={placeholder}

--- a/src/components/common/ui/vote/VoteDisplay.tsx
+++ b/src/components/common/ui/vote/VoteDisplay.tsx
@@ -47,7 +47,7 @@ export function VoteDisplay({
 
       <section
         className={cn(
-          'relative mx-auto min-h-62 w-full max-w-267.5 rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main',
+          'relative mx-auto min-h-62 w-full max-w-267.5 rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main dark:bg-white/10',
           isClosed && 'opacity-50'
         )}
       >

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -13,11 +13,14 @@ const inputVariants = {
   base: 'h-14 w-full rounded-full px-5 text-sm outline-none placeholder:text-text-muted',
 
   enabled: {
-    first: 'border border-gray-300 bg-gray-300 text-text-primary',
-    second: 'border border-primary-100 bg-primary-100 text-text-primary',
+    first:
+      'border border-gray-300 bg-gray-300 text-text-primary dark:border-white/15 dark:bg-white/10',
+    second:
+      'border border-primary-100 bg-primary-100 text-text-primary dark:border-primary-400/30 dark:bg-primary-600/20',
   },
 
-  disabled: 'border border-border-default bg-gray-100 text-text-muted',
+  disabled:
+    'border border-border-default bg-gray-100 text-text-muted dark:bg-white/10',
 }
 
 export function VoteEditor({
@@ -47,7 +50,7 @@ export function VoteEditor({
         />
       </div>
 
-      <section className="w-full rounded-2xl border border-border-default bg-gray-100 px-6 py-6">
+      <section className="w-full rounded-2xl border border-border-default bg-gray-100 px-6 py-6 dark:bg-white/10">
         <div className="flex flex-col gap-4">
           {options.map((option, index) => {
             const inputStyle = hasPeriod

--- a/src/components/common/ui/vote/components/VoteOptionItem.tsx
+++ b/src/components/common/ui/vote/components/VoteOptionItem.tsx
@@ -17,20 +17,21 @@ const optionVariants = {
   base: 'grid w-full grid-cols-[20px_minmax(0,1fr)_44px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]',
 
   text: {
-    selected: 'text-primary-500',
+    selected: 'text-white',
     result: 'text-text-primary',
     default: 'text-text-muted',
   },
 
   gauge: {
-    first: 'bg-gray-300',
-    second: 'bg-primary-100',
+    first: 'bg-gray-400 dark:bg-white/15',
+    second: 'bg-primary-500 dark:bg-primary-400',
   },
 
   indicator: {
     selected:
       'flex size-4 items-center justify-center rounded-sm bg-primary-500 text-white',
-    default: 'flex size-4 items-center justify-center rounded-sm bg-gray-300',
+    default:
+      'flex size-4 items-center justify-center rounded-sm bg-gray-300 dark:bg-white/20',
   },
 }
 
@@ -45,7 +46,6 @@ export function VoteOptionItem({
   const percentage = Math.min(100, Math.max(0, option.percentage ?? 0))
   const displayPercentage = Math.round(percentage)
 
-  // 선택 → 파란색 / 나머지 상태 유지
   const textColor = isSelected
     ? optionVariants.text.selected
     : showResult
@@ -73,7 +73,7 @@ export function VoteOptionItem({
       </span>
 
       {/* 게이지 */}
-      <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm sm:h-14">
+      <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm dark:bg-white/5 sm:h-14">
         {showResult && percentage > 0 && (
           <div
             className={cn(

--- a/src/features/post-detail/components/PostDetailBody.tsx
+++ b/src/features/post-detail/components/PostDetailBody.tsx
@@ -125,7 +125,7 @@ export function PostDetailBody({
           {tags.map((tag, index) => (
             <span
               key={`${tag}-${index}`}
-              className="max-w-fit break-all rounded-md bg-gray-100 px-2 py-1 text-xs text-text-muted"
+              className="max-w-fit break-all rounded-md bg-gray-100 dark:bg-white/10 px-2 py-1 text-xs text-text-muted"
             >
               #{tag}
             </span>

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -92,7 +92,7 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
 
   return (
     <>
-      <article className="w-full max-w-300 rounded-2xl border border-border-default bg-white px-8 py-6 shadow-card-main">
+      <article className="w-full max-w-300 rounded-2xl border border-border-default bg-surface px-8 py-6 shadow-card-main">
         <PostDetailHeader
           author={{
             nickname: post.nickname,
@@ -111,6 +111,8 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
           />
         </div>
 
+        <PostDetailVoteSection post={post} />
+
         {post.hasGoal && post.goalInfo && (
           <div className="mt-6">
             <PostGoalSection
@@ -122,8 +124,6 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
             />
           </div>
         )}
-
-        <PostDetailVoteSection post={post} />
 
         <div className="mt-8">
           <PostDetailActions

--- a/src/features/post-detail/components/PostDetailVoteSection.tsx
+++ b/src/features/post-detail/components/PostDetailVoteSection.tsx
@@ -62,7 +62,7 @@ export function PostDetailVoteSection({ post }: PostDetailVoteSectionProps) {
   }
   return (
     <div className="mt-6 overflow-x-auto">
-      <div className="min-w-80">
+      <div className="min-w-80 rounded-2xl border border-border-default bg-surface p-4">
         <VoteDisplay
           mode={getVoteMode(post.voteInfo, voteDetail?.is_voted)}
           options={toVoteDisplayOptions(voteDetail, selectedOptionId)}
@@ -80,7 +80,7 @@ export function PostDetailVoteSection({ post }: PostDetailVoteSectionProps) {
                   <button
                     type="button"
                     aria-label="투표 더보기"
-                    className="flex size-8 items-center justify-center rounded-full text-text-primary hover:bg-gray-100"
+                    className="flex size-8 items-center justify-center rounded-full text-text-primary hover:bg-gray-100 dark:hover:bg-white/10"
                   >
                     <MoreHorizontal size={20} />
                   </button>

--- a/src/features/post-detail/components/PostGoalSection.tsx
+++ b/src/features/post-detail/components/PostGoalSection.tsx
@@ -13,14 +13,20 @@ const goalStatusMap = {
   in_progress: {
     label: '진행중',
     badgeVariant: 'inProgress',
+    badgeClassName:
+      'min-w-0 border border-transparent px-3 py-1 text-xs bg-[#F1F0FF] text-[#845FFF] dark:bg-transparent dark:border-violet-200/50 dark:text-violet-200',
   },
   completed: {
     label: '완료',
     badgeVariant: 'success',
+    badgeClassName:
+      'min-w-0 border border-transparent px-3 py-1 text-xs bg-[#EAFBF3] text-[#75B965] dark:bg-transparent dark:border-emerald-200/50 dark:text-emerald-200',
   },
   failed: {
     label: '실패',
     badgeVariant: 'failed',
+    badgeClassName:
+      'min-w-0 border border-transparent px-3 py-1 text-xs bg-[#FFEEE2] text-[#FF5550] dark:bg-transparent dark:border-red-200/50 dark:text-red-200',
   },
 } as const
 
@@ -41,7 +47,12 @@ export function PostGoalSection({
           {/* 헤더 */}
           <div className="flex items-center justify-between">
             <h3 className="text-base font-bold text-text-primary">개별 목표</h3>
-            <Badge variant={statusInfo.badgeVariant}>{statusInfo.label}</Badge>
+            <Badge
+              variant={statusInfo.badgeVariant}
+              className={statusInfo.badgeClassName}
+            >
+              {statusInfo.label}
+            </Badge>
           </div>
 
           <p className="text-sm font-semibold text-text-primary">{title}</p>

--- a/src/features/post/components/PostVoteSection.tsx
+++ b/src/features/post/components/PostVoteSection.tsx
@@ -40,8 +40,7 @@ export function PostVoteSection({
             {formatDate(period?.start)} ~ {formatDate(period?.end)}
           </span>
         </div>
-
-        <section className="relative mx-auto min-h-62 w-full max-w-267.5 rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main">
+        <section className="relative mx-auto min-h-62 w-full max-w-267.5 rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main dark:bg-white/10">
           <div className="flex flex-col gap-4 pt-8">
             {options.map((option, index) => {
               const isFirst = index === 0
@@ -52,10 +51,10 @@ export function PostVoteSection({
                   className="grid w-full grid-cols-[20px_minmax(0,1fr)_44px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]"
                 >
                   <span className="flex items-center justify-center">
-                    <span className="flex size-4 items-center justify-center rounded-sm bg-gray-300" />
+                    <span className="flex size-4 items-center justify-center rounded-sm bg-gray-300 dark:bg-white/20" />
                   </span>
 
-                  <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm sm:h-14">
+                  <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm dark:bg-white/10 sm:h-14">
                     <div
                       className={cn(
                         'absolute inset-y-0 left-0 rounded-full',

--- a/src/features/post/hooks/usePostForm.ts
+++ b/src/features/post/hooks/usePostForm.ts
@@ -184,11 +184,22 @@ export function usePostForm(
     // 기존 투표가 없고, 새 투표 입력값이 유효할 때만 vote payload 전송
     const shouldSendVote = hasActiveVote && !initialHasVote
 
+    const toLocalDateString = (date: Date) => {
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      return `${year}-${month}-${day}`
+    }
+
     const vote: PostFormData['vote'] = shouldSendVote
       ? {
           options: validVoteOptions,
-          startDate: votePeriod?.start?.toISOString().split('T')[0],
-          endDate: votePeriod?.end?.toISOString().split('T')[0],
+          startDate: votePeriod?.start
+            ? toLocalDateString(votePeriod.start)
+            : undefined,
+          endDate: votePeriod?.end
+            ? toLocalDateString(votePeriod.end)
+            : undefined,
         }
       : undefined
 


### PR DESCRIPTION
## 📌 관련 이슈

Closes #171 

✨ 변경 내용
- 게시글 상세페이지 다크모드 스타일 보완
- VoteDisplay / VoteEditor 다크모드 대응
- 댓글 입력창 다크모드 스타일 적용
- 목표 상태 배지 다크모드 스타일 적용
- hover / border / background 다크모드 톤 정리
- 게시글 상세 목표 / 투표 섹션 순서 조정
- 투표 날짜 UTC 변환 문제 수정 (toISOString 제거)

## 📸 스크린샷(선택)

<img width="1098" height="1054" alt="스크린샷 2026-05-06 오후 1 43 04" src="https://github.com/user-attachments/assets/6b43ca1b-35d8-428c-a8cf-7ceae92feab2" />
<img width="987" height="788" alt="스크린샷 2026-05-06 오후 1 43 23" src="https://github.com/user-attachments/assets/f066bd33-1712-4520-a340-13be9e19274a" />
<img width="1089" height="935" alt="스크린샷 2026-05-06 오후 1 44 48" src="https://github.com/user-attachments/assets/5265dfd2-cda9-4c72-8169-db3d4d7f752e" />

## 📚 참고사항
- 기존 프로젝트 다크모드 패턴(bg-surface, dark:bg-white/10, dark:border-*) 기준으로 스타일을 맞췄습니다.
- GoalCard에서 사용 중인 배지 스타일 방식을 상세페이지 목표 섹션에도 동일하게 적용했습니다.
- 날짜 UTC 변환으로 인해 투표 종료일이 하루 밀리던 문제를 로컬 날짜 포맷 방식으로 수정했습니다.