### PR TITLE
fix: restrict suggested sort to authenticated users and fix UI dark mode, vote, lang issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/features/main/post-list/PostListSection.tsx
+++ b/src/features/main/post-list/PostListSection.tsx
@@ -19,7 +19,8 @@ import {
 } from './PostList.types'
 import { usePostListFilters } from './usePostListFilters'
 
-const SORT_ORDERS: PostSortOrder[] = ['latest', 'trending', 'suggested']
+const ALL_SORT_ORDERS: PostSortOrder[] = ['latest', 'trending', 'suggested']
+const GUEST_SORT_ORDERS: PostSortOrder[] = ['latest', 'trending']
 
 const SORT_LABELS: Record<PostSortOrder, string> = {
   latest: '최신순',
@@ -61,6 +62,7 @@ export function PostListSection() {
   } = usePostListFilters()
 
   const { sort, page } = filters
+  const sortOrders = user ? ALL_SORT_ORDERS : GUEST_SORT_ORDERS
 
   const { data, isLoading, isFetching, isError, error } = usePostListQuery(
     mode,
@@ -100,7 +102,7 @@ export function PostListSection() {
   const filterArea = (
     <div className="flex items-center justify-between">
       <div className="flex gap-2">
-        {SORT_ORDERS.map((order) => (
+        {sortOrders.map((order) => (
           <TabButton
             key={order}
             isActive={sort === order}

--- a/src/features/main/post-list/usePostListFilters.ts
+++ b/src/features/main/post-list/usePostListFilters.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
+import { useAuthStore } from '@/store/authStore'
+
 import type { PostSortOrder } from './PostList.types'
 
 /**
@@ -17,17 +19,27 @@ import type { PostSortOrder } from './PostList.types'
  * - 로컬 state는 같은 이벤트 핸들러 내에서 항상 배칭되므로 이 문제가 없음
  */
 export function usePostListFilters() {
+  const { user, authStatus } = useAuthStore()
   const [searchParams, setSearchParams] = useSearchParams()
 
   // URL에서 현재 상태 추출
   const keyword = searchParams.get('keyword') ?? ''
   const rawSort = searchParams.get('sort')
-  const sort: PostSortOrder =
-    rawSort === 'trending'
-      ? 'trending'
-      : rawSort === 'suggested'
-        ? 'suggested'
-        : 'latest'
+
+  /**
+   * 정렬 상태 결정
+   * - 비로그인 유저가 'suggested'에 접근하면 'latest'로 취급 (세션 확인 완료 후)
+   */
+  const sort: PostSortOrder = useMemo(() => {
+    if (rawSort === 'trending') return 'trending'
+    if (rawSort === 'suggested') {
+      // 세션 확인 중에는 일단 요청을 허용 (로그인 유저일 가능성)
+      // 확인 결과 비로그인이면 latest로 강제 전환
+      return authStatus === 'restored' && !user ? 'latest' : 'suggested'
+    }
+    return 'latest'
+  }, [rawSort, authStatus, user])
+
   const page = Number(searchParams.get('page')) || 1
 
   // SearchBar 표시용 (즉시 반응)
@@ -65,6 +77,19 @@ export function usePostListFilters() {
     setInputValue(keyword)
     setDebouncedKeyword(keyword)
   }, [keyword])
+
+  /**
+   * 비로그인 유저가 'suggested' URL로 진입한 경우 URL 동기화
+   */
+  useEffect(() => {
+    if (
+      authStatus === 'restored' &&
+      !user &&
+      searchParams.get('sort') === 'suggested'
+    ) {
+      updateParams({ sort: 'latest' })
+    }
+  }, [authStatus, user, searchParams, updateParams])
 
   /**
    * 타이핑 디바운스: inputValue → debouncedKeyword + URL을 500ms 후 동시 업데이트

--- a/src/features/post/components/PostTagSection.tsx
+++ b/src/features/post/components/PostTagSection.tsx
@@ -60,8 +60,8 @@ export function PostTagSection({
               isSelected
                 ? 'bg-primary-500 text-white'
                 : isDisabled
-                  ? 'cursor-not-allowed bg-gray-100 text-text-disabled'
-                  : 'bg-gray-100 text-text-muted hover:bg-gray-200'
+                  ? 'cursor-not-allowed bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-600'
+                  : 'bg-gray-100 text-text-muted hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600'
             )}
           >
             #{tag.name}

--- a/src/features/post/components/PostVoteSection.tsx
+++ b/src/features/post/components/PostVoteSection.tsx
@@ -84,6 +84,7 @@ export function PostVoteSection({
         period={period}
         onChangeOption={onChangeOption}
         onChangePeriod={onChangePeriod}
+        hideParticipantCount
       />
     </div>
   )


### PR DESCRIPTION
  비로그인 유저의 추천순 접근 차단, 태그 버튼 다크모드 스타일 불일치, 투표 참여자 수 노출, html lang 속성 오설정 등 다수의 버그를 일괄    
  수정

## 📌 관련 이슈

Closes #180

## ✨ 변경 내용

- `PostListSection`: 비로그인 유저는 `latest/trending`만 노출, 로그인 유저는 `suggested` 포함 전체 노출
- `usePostListFilters`: `authStatus === 'restored'` 확인 후 비로그인 + `?sort=suggested` 직접 진입 시 `latest`로 URL 자동 전환
- `PostTagSection`: 다크모드 스타일 변경
- `VoteEditor`: `hideParticipantCount={true}` prop 명시적으로 전달하여 게시글 생성 페이지에서는 참여자 수 출력 x
- `index.html`: `lang="en"` → `lang="ko"` 수정

## 📸 스크린샷(선택)

1. 비로그인 사용자 메인 페이지 (추천순 + 글쓰기 버튼 X)
<img width="1320" height="924" alt="image" src="https://github.com/user-attachments/assets/8ec9b70d-50bd-4ff7-a877-90bccf77b891" />


2. 게시글 생성 / 수정 페이지 태그 선택
<img width="1182" height="835" alt="image" src="https://github.com/user-attachments/assets/e6981d03-5d84-4330-804f-36972af13623" />


## 📚 참고사항
