### PR TITLE
feat: handle guest comment input state

### DIFF
--- a/src/apis/post/post.api.ts
+++ b/src/apis/post/post.api.ts
@@ -1,13 +1,13 @@
 import { apiClient } from '@/apis/apiClient'
 import type {
   ApiPostListParams,
+  ApiPostListResponse,
   ApiPostListWrappedResponse,
   ApiPostSearchParams,
   ApiPostSearchWrappedResponse,
   ApiTrendingParams,
   ApiTrendingResponse,
 } from '@/features/main/post-list/PostList.api.types'
-import type { ApiPostListResponse } from '@/features/main/post-list/PostList.api.types'
 import type {
   ApiMyPostListParams,
   ApiMyPostListWrappedResponse,

--- a/src/components/common/ui/card/PostCard.tsx
+++ b/src/components/common/ui/card/PostCard.tsx
@@ -216,7 +216,7 @@ const PostCardProfile = ({
           className="size-7 rounded-full object-cover shrink-0"
         />
       ) : (
-        <div className="size-7 rounded-full bg-border-default shrink-0 flex items-center justify-center text-[10px] font-bold text-text-muted">
+        <div className="size-7 rounded-full bg-border-default shrink-0 flex items-center justify-center text-2xs font-bold text-text-muted">
           {nickname[0]}
         </div>
       )}

--- a/src/components/common/ui/comment/CommentInput.tsx
+++ b/src/components/common/ui/comment/CommentInput.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import { User } from 'lucide-react'
+
 import { Button } from '@/components/common/ui/button/Button'
 import { Textarea } from '@/components/common/ui/field/Textarea'
 
@@ -7,6 +9,7 @@ type CommentInputProps = {
   onSubmit: (content: string) => void
   maxLength?: number
   isLoading?: boolean
+  disabled?: boolean
   placeholder?: string
   profileImageUrl?: string | null
   nickname?: string
@@ -16,13 +19,14 @@ export function CommentInput({
   onSubmit,
   maxLength = 500,
   isLoading = false,
+  disabled = false,
   placeholder = '댓글을 입력해주세요',
   profileImageUrl,
   nickname,
 }: CommentInputProps) {
   const [value, setValue] = useState('')
 
-  const isDisabled = value.trim().length === 0 || isLoading
+  const isDisabled = disabled || value.trim().length === 0 || isLoading
 
   const handleSubmit = () => {
     if (isDisabled) return
@@ -33,35 +37,40 @@ export function CommentInput({
 
   return (
     <div className="flex items-start gap-3 sm:gap-4 sm:pl-4">
-      {/* 프로필 (나중에 사용자 정보로 교체 가능) */}
-      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full bg-surface sm:h-12 sm:w-12">
-        {profileImageUrl ? (
-          <img
-            src={profileImageUrl}
-            alt={nickname ? `${nickname}의 프로필 이미지` : '프로필 이미지'}
-            className="h-full w-full object-cover"
-          />
-        ) : null}
+      {/* 프로필 */}
+      <div className="flex h-14 items-center">
+        <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full bg-surface">
+          {profileImageUrl ? (
+            <img
+              src={profileImageUrl}
+              alt={nickname ? `${nickname}의 프로필 이미지` : '프로필 이미지'}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center rounded-full bg-gray-200 text-text-muted dark:bg-white/10">
+              <User size={22} />
+            </div>
+          )}
+        </div>
       </div>
 
       {/* 입력 영역 */}
       <div className="flex flex-1 flex-col gap-2">
         <div className="relative">
           <Textarea
-            className="h-14 min-h-14 max-h-30 overflow-hidden bg-gray-100 pr-20 pb-6 focus:bg-white dark:border-white/15 dark:bg-white/5 dark:focus:bg-white/10"
+            disabled={disabled}
+            className="h-14 min-h-14 max-h-30 overflow-hidden bg-gray-100 pr-20 pb-6 disabled:bg-gray-200 disabled:text-text-muted disabled:placeholder:text-gray-400 disabled:opacity-100 dark:border-white/15 dark:bg-white/5 dark:disabled:bg-white/5"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder={placeholder}
             maxLength={maxLength}
           />
 
-          {/* 글자수 */}
           <span className="absolute right-4 bottom-3 text-xs text-text-muted">
             {value.length}/{maxLength}
           </span>
         </div>
 
-        {/* 하단 영역 */}
         <div className="flex justify-end">
           <Button
             variant="submit"

--- a/src/components/common/ui/comment/CommentItem.tsx
+++ b/src/components/common/ui/comment/CommentItem.tsx
@@ -60,7 +60,7 @@ export function CommentItem({
     <div
       className={cn(
         'flex gap-3 rounded-xl px-3 py-3 sm:px-4',
-        isSelected && 'bg-primary-100/30'
+        isSelected && 'bg-primary-100/5'
       )}
       onClick={() => onSelect?.()}
     >

--- a/src/components/common/ui/comment/CommentItem.tsx
+++ b/src/components/common/ui/comment/CommentItem.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { Heart, MoreHorizontal } from 'lucide-react'
 
 import { ActionMenu } from '@/components/common/overlay'
+import { Button } from '@/components/common/ui'
 import { cn } from '@/utils/cn'
 import { formatRelativeTime } from '@/utils/formatRelativeTime'
 
@@ -126,30 +127,35 @@ export function CommentItem({
               value={editContent}
               onChange={(e) => setEditContent(e.target.value)}
               onClick={(e) => e.stopPropagation()}
-              className="min-h-20 w-full resize-none rounded-md border border-border-subtle bg-white px-3 py-2 text-sm text-text-primary outline-none focus:border-focus-border"
+              className="min-h-20 w-full resize-none rounded-md border border-border-subtle bg-white px-3 py-2 text-sm text-text-primary outline-none focus:border-focus-border dark:border-white/15 dark:bg-white/5 dark:text-text-primary"
             />
 
             <div className="flex justify-end gap-2">
-              <button
+              <Button
                 type="button"
+                variant="modal"
+                size="sm"
+                rounded="md"
                 onClick={(e) => {
                   e.stopPropagation()
                   handleCancelEdit()
                 }}
-                className="rounded-md px-3 py-1 text-xs text-text-muted hover:bg-gray-100"
               >
                 취소
-              </button>
-              <button
+              </Button>
+
+              <Button
                 type="button"
+                variant="primary"
+                size="sm"
+                rounded="md"
                 onClick={(e) => {
                   e.stopPropagation()
                   handleSaveEdit()
                 }}
-                className="rounded-md bg-primary-500 px-3 py-1 text-xs text-white hover:bg-primary-600"
               >
                 저장
-              </button>
+              </Button>
             </div>
           </div>
         ) : (
@@ -157,7 +163,6 @@ export function CommentItem({
             {content}
           </p>
         )}
-
         {/* 좋아요 */}
         <button
           type="button"

--- a/src/components/common/ui/comment/CommentItem.tsx
+++ b/src/components/common/ui/comment/CommentItem.tsx
@@ -91,13 +91,7 @@ export function CommentItem({
           <div onClick={(e) => e.stopPropagation()}>
             <ActionMenu
               trigger={
-                <button
-                  type="button"
-                  className="text-text-primary"
-                  aria-label="댓글 더보기"
-                >
-                  <MoreHorizontal size={16} />
-                </button>
+                <MoreHorizontal size={16} className="text-text-primary" />
               }
               items={
                 isOwner

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -14,10 +14,9 @@ const inputVariants = {
 
   enabled: {
     first:
-      'border border-gray-300 bg-gray-300 text-text-primary dark:border-white/15 dark:bg-white/20',
-
+      'border border-gray-300 bg-gray-300 text-text-primary dark:border-white/15 dark:bg-white/10',
     second:
-      'border border-primary-100 bg-primary-100 text-text-primary dark:border-primary-400 dark:bg-primary-400',
+      'border border-primary-100 bg-primary-100 text-text-primary dark:border-primary-400/30 dark:bg-primary-600/20',
   },
 
   disabled:

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -14,9 +14,10 @@ const inputVariants = {
 
   enabled: {
     first:
-      'border border-gray-300 bg-gray-300 text-text-primary dark:border-white/15 dark:bg-white/10',
+      'border border-gray-300 bg-gray-300 text-text-primary dark:border-white/15 dark:bg-white/20',
+
     second:
-      'border border-primary-100 bg-primary-100 text-text-primary dark:border-primary-400/30 dark:bg-primary-600/20',
+      'border border-primary-100 bg-primary-100 text-text-primary dark:border-primary-400 dark:bg-primary-400',
   },
 
   disabled:

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -14,7 +14,7 @@ const inputVariants = {
 
   enabled: {
     first:
-      'border border-gray-300 bg-gray-300 text-text-primary dark:border-white/15 dark:bg-white/10',
+      'border border-gray-300 bg-gray-300 text-text-primary dark:border-white/15 dark:bg-white/20',
     second:
       'border border-primary-100 bg-primary-100 text-text-primary dark:border-primary-400/30 dark:bg-primary-600/20',
   },

--- a/src/components/common/ui/vote/components/VoteOptionItem.tsx
+++ b/src/components/common/ui/vote/components/VoteOptionItem.tsx
@@ -16,15 +16,9 @@ type VoteOptionItemProps = {
 const optionVariants = {
   base: 'grid w-full grid-cols-[20px_minmax(0,1fr)_44px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]',
 
-  text: {
-    selected: 'text-white',
-    result: 'text-text-primary',
-    default: 'text-text-muted',
-  },
-
   gauge: {
-    first: 'bg-gray-400 dark:bg-white/15',
-    second: 'bg-primary-500 dark:bg-primary-400',
+    first: 'bg-gray-300',
+    second: 'bg-primary-100 dark:bg-primary-400',
   },
 
   indicator: {
@@ -46,11 +40,15 @@ export function VoteOptionItem({
   const percentage = Math.min(100, Math.max(0, option.percentage ?? 0))
   const displayPercentage = Math.round(percentage)
 
-  const textColor = isSelected
-    ? optionVariants.text.selected
-    : showResult
-      ? optionVariants.text.result
-      : optionVariants.text.default
+  // 옵션 텍스트 색상
+  const optionTextColor = isSelected
+    ? 'text-primary-500 dark:text-white'
+    : 'text-text-primary dark:text-white'
+
+  // 퍼센트 텍스트 색상
+  const percentageTextColor = isSelected
+    ? 'text-primary-500 dark:text-primary-400'
+    : 'text-text-primary dark:text-white'
 
   return (
     <button
@@ -90,7 +88,7 @@ export function VoteOptionItem({
         <span
           className={cn(
             'relative z-10 flex h-full min-w-0 items-center truncate px-3 text-sm font-medium sm:px-6',
-            textColor
+            optionTextColor
           )}
           title={option.valueLabel}
         >
@@ -98,8 +96,10 @@ export function VoteOptionItem({
         </span>
       </div>
 
-      {/* 퍼센트 (색상 동일 + 스타일 통일) */}
-      <span className={cn('text-right text-sm font-medium', textColor)}>
+      {/* 퍼센트 */}
+      <span
+        className={cn('text-right text-sm font-medium', percentageTextColor)}
+      >
         {showResult ? `${displayPercentage}%` : ''}
       </span>
     </button>

--- a/src/components/common/ui/vote/components/VoteOptionItem.tsx
+++ b/src/components/common/ui/vote/components/VoteOptionItem.tsx
@@ -23,8 +23,8 @@ const optionVariants = {
   },
 
   gauge: {
-    first: 'bg-gray-300 dark:bg-white/15',
-    second: 'bg-primary-100 dark:bg-primary-400',
+    first: 'bg-gray-300 dark:bg-white/20',
+    second: 'bg-primary-100 dark:bg-primary-600/20',
   },
 
   indicator: {

--- a/src/components/common/ui/vote/components/VoteOptionItem.tsx
+++ b/src/components/common/ui/vote/components/VoteOptionItem.tsx
@@ -16,8 +16,14 @@ type VoteOptionItemProps = {
 const optionVariants = {
   base: 'grid w-full grid-cols-[20px_minmax(0,1fr)_44px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]',
 
+  text: {
+    selected: 'text-primary-500 dark:text-white',
+    result: 'text-text-primary',
+    default: 'text-text-muted',
+  },
+
   gauge: {
-    first: 'bg-gray-300',
+    first: 'bg-gray-300 dark:bg-white/15',
     second: 'bg-primary-100 dark:bg-primary-400',
   },
 
@@ -40,15 +46,11 @@ export function VoteOptionItem({
   const percentage = Math.min(100, Math.max(0, option.percentage ?? 0))
   const displayPercentage = Math.round(percentage)
 
-  // 옵션 텍스트 색상
-  const optionTextColor = isSelected
-    ? 'text-primary-500 dark:text-white'
-    : 'text-text-primary dark:text-white'
-
-  // 퍼센트 텍스트 색상
-  const percentageTextColor = isSelected
-    ? 'text-primary-500 dark:text-primary-400'
-    : 'text-text-primary dark:text-white'
+  const textColor = isSelected
+    ? optionVariants.text.selected
+    : showResult
+      ? optionVariants.text.result
+      : optionVariants.text.default
 
   return (
     <button
@@ -88,7 +90,7 @@ export function VoteOptionItem({
         <span
           className={cn(
             'relative z-10 flex h-full min-w-0 items-center truncate px-3 text-sm font-medium sm:px-6',
-            optionTextColor
+            textColor
           )}
           title={option.valueLabel}
         >
@@ -96,10 +98,8 @@ export function VoteOptionItem({
         </span>
       </div>
 
-      {/* 퍼센트 */}
-      <span
-        className={cn('text-right text-sm font-medium', percentageTextColor)}
-      >
+      {/* 퍼센트 (색상 동일 + 스타일 통일) */}
+      <span className={cn('text-right text-sm font-medium', textColor)}>
         {showResult ? `${displayPercentage}%` : ''}
       </span>
     </button>

--- a/src/features/post-detail/components/PostDetailActions.tsx
+++ b/src/features/post-detail/components/PostDetailActions.tsx
@@ -57,7 +57,7 @@ export function PostDetailActions({
   }
 
   return (
-    <div className="mb-6 flex items-center border-b border-border-subtle pb-4">
+    <div className="mb-6 flex items-center border-b border-border-default pb-4">
       <div className="flex items-center gap-3">
         {/* 좋아요 */}
         <div className="flex items-center gap-1">

--- a/src/features/post-detail/components/PostDetailBody.tsx
+++ b/src/features/post-detail/components/PostDetailBody.tsx
@@ -121,12 +121,9 @@ export function PostDetailBody({
 
       {/* 태그 */}
       {tags.length > 0 && (
-        <div className="mt-4 flex flex-wrap gap-2">
+        <div className="mt-4 flex flex-wrap gap-1 text-xs text-text-muted">
           {tags.map((tag, index) => (
-            <span
-              key={`${tag}-${index}`}
-              className="max-w-fit break-all rounded-md bg-gray-100 dark:bg-white/10 px-2 py-1 text-xs text-text-muted"
-            >
+            <span key={`${tag}-${index}`} className="break-all">
               #{tag}
             </span>
           ))}

--- a/src/features/post-detail/components/PostDetailCommentSection.tsx
+++ b/src/features/post-detail/components/PostDetailCommentSection.tsx
@@ -149,9 +149,15 @@ export function PostDetailCommentSection({
       <section>
         <CommentInput
           isLoading={isPending}
+          disabled={!user}
           onSubmit={handleSubmitComment}
           profileImageUrl={user?.profileImageUrl}
           nickname={user?.nickname}
+          placeholder={
+            user
+              ? '댓글을 입력해주세요'
+              : '로그인 후 댓글을 작성할 수 있습니다.'
+          }
         />
 
         <div className="mt-8">

--- a/src/features/post-detail/components/PostDetailHeader.tsx
+++ b/src/features/post-detail/components/PostDetailHeader.tsx
@@ -49,11 +49,7 @@ export function PostDetailHeader({
 
       {/* 오른쪽 (더보기 메뉴) */}
       <ActionMenu
-        trigger={
-          <button type="button" className="text-text-primary">
-            <MoreHorizontal size={20} />
-          </button>
-        }
+        trigger={<MoreHorizontal size={20} className="text-text-primary" />}
         items={menuItems}
         align="right"
         size="sm"

--- a/src/features/post-detail/components/PostDetailVoteSection.tsx
+++ b/src/features/post-detail/components/PostDetailVoteSection.tsx
@@ -77,13 +77,7 @@ export function PostDetailVoteSection({ post }: PostDetailVoteSectionProps) {
             post.isOwner ? (
               <ActionMenu
                 trigger={
-                  <button
-                    type="button"
-                    aria-label="투표 더보기"
-                    className="flex size-8 items-center justify-center rounded-full text-text-primary hover:bg-gray-100 dark:hover:bg-white/10"
-                  >
-                    <MoreHorizontal size={20} />
-                  </button>
+                  <MoreHorizontal size={20} className="text-text-primary" />
                 }
                 items={[
                   { label: '수정', onClick: handleEdit },


### PR DESCRIPTION
## 📌 관련 이슈

Closes #177

## ✨ 변경 내용

- 비회원 상태에서 댓글 입력창 및 등록 버튼 disabled 처리
- placeholder를 `로그인 후 댓글을 작성할 수 있습니다.`로 변경
- 비회원 상태 fallback 프로필 UI 추가
- 댓글 입력 영역과 프로필 정렬/UI 보정
- 댓글 수정 textarea 다크모드 스타일 보정
- 댓글 수정 취소/저장 버튼을 공통 Button 컴포넌트로 변경
- ActionMenu trigger 중첩 button 구조 수정
- PostDetailActions divider border 색상 보정
- VoteDisplay / VoteEditor 다크모드 게이지 및 텍스트 색상 톤 정리
- 투표 선택 상태 텍스트/퍼센트 색상 가독성 보정
- 공통 Button disabled 다크모드 스타일 적용 확인 
-  댓글 선택 상태 배경 색상 채도 조정

## 📸 스크린샷(선택)

<img width="1087" height="943" alt="스크린샷 2026-05-06 오후 5 39 44" src="https://github.com/user-attachments/assets/27296dad-94a7-4c2d-9de1-4262e380dfc2" />

<img width="1071" height="955" alt="스크린샷 2026-05-06 오후 5 40 31" src="https://github.com/user-attachments/assets/9fb679f3-1ec6-4002-996a-ed18ebc6da32" />

<img width="944" height="311" alt="스크린샷 2026-05-06 오후 5 42 08" src="https://github.com/user-attachments/assets/d2c9c434-0d4d-4db6-a9b0-0d2f06c27f5b" />

<img width="991" height="590" alt="스크린샷 2026-05-06 오후 5 43 45" src="https://github.com/user-attachments/assets/285a7860-e8c5-4064-bbf2-870f8a34f3e0" />

<img width="644" height="942" alt="스크린샷 2026-05-06 오후 6 38 25" src="https://github.com/user-attachments/assets/38a2e5a4-73a1-405f-b99e-a947eb90ee4b" />



## 📚 참고사항
- 비회원 상태에서도 댓글 영역 구조를 유지해 UX 흐름이 끊기지 않도록 수정했습니다.
- 댓글 수정 버튼은 기존 프로젝트 공통 Button variant를 사용하도록 변경했습니다.
- 투표 영역은 기존 다크모드 패턴을 기준으로 VoteDisplay와 VoteEditor의 색상 톤을 맞췄습니다.
- 투표 모바일 반응형 padding/grid 축소는 디자인 확인 후 후속 반영 예정입니다.
- 오늘 날짜로 투표 생성/수정 시 첫 렌더링에서 투표가 바로 표시되지 않는 이슈는 별도 확인이 필요해 후속 작업으로 분리 예정입니다.- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 