### PR TITLE
feat: add post detail image viewer modal (#185)

### DIFF
--- a/src/features/post-detail/components/PostDetailBody.tsx
+++ b/src/features/post-detail/components/PostDetailBody.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import { PostImageViewerModal } from './PostImageViewerModal'
+
 type PostDetailBodyProps = {
   title: string
   content: string
@@ -35,9 +37,28 @@ export function PostDetailBody({
 }: PostDetailBodyProps) {
   const visibleImages = images.slice(0, 3)
   const [failedImages, setFailedImages] = useState<Set<number>>(new Set())
+  const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(
+    null
+  )
 
   const handleImageError = (index: number) => {
     setFailedImages((prev) => new Set(prev).add(index))
+  }
+
+  const handleCloseImageViewer = () => {
+    setSelectedImageIndex(null)
+  }
+
+  const handlePrevImage = () => {
+    setSelectedImageIndex((prev) =>
+      prev === null ? prev : (prev - 1 + images.length) % images.length
+    )
+  }
+
+  const handleNextImage = () => {
+    setSelectedImageIndex((prev) =>
+      prev === null ? prev : (prev + 1) % images.length
+    )
   }
 
   return (
@@ -46,7 +67,11 @@ export function PostDetailBody({
       {visibleImages.length === 3 ? (
         <div className="flex h-72 gap-2">
           {/* 왼쪽 큰 이미지 */}
-          <div className="flex-1 overflow-hidden rounded-xl bg-gray-100">
+          <button
+            type="button"
+            className="flex-1 overflow-hidden rounded-xl bg-gray-100"
+            onClick={() => setSelectedImageIndex(0)}
+          >
             {!failedImages.has(0) ? (
               <img
                 src={visibleImages[0]}
@@ -58,14 +83,16 @@ export function PostDetailBody({
             ) : (
               <ImageFallback />
             )}
-          </div>
+          </button>
 
           {/* 오른쪽 작은 이미지 2개 */}
           <div className="flex w-1/3 flex-col gap-2">
             {[1, 2].map((index) => (
-              <div
+              <button
+                type="button"
                 key={`img-${index}`}
                 className="flex-1 overflow-hidden rounded-xl bg-gray-100"
+                onClick={() => setSelectedImageIndex(index)}
               >
                 {!failedImages.has(index) ? (
                   <img
@@ -78,7 +105,7 @@ export function PostDetailBody({
                 ) : (
                   <ImageFallback />
                 )}
-              </div>
+              </button>
             ))}
           </div>
         </div>
@@ -88,9 +115,11 @@ export function PostDetailBody({
             className={`grid gap-3 ${getImageGridClass(visibleImages.length)}`}
           >
             {visibleImages.map((image, index) => (
-              <div
+              <button
+                type="button"
                 key={`img-${index}`}
                 className="h-72 w-full overflow-hidden rounded-xl bg-gray-100"
+                onClick={() => setSelectedImageIndex(index)}
               >
                 {!failedImages.has(index) ? (
                   <img
@@ -103,7 +132,7 @@ export function PostDetailBody({
                 ) : (
                   <ImageFallback />
                 )}
-              </div>
+              </button>
             ))}
           </div>
         )
@@ -123,11 +152,24 @@ export function PostDetailBody({
       {tags.length > 0 && (
         <div className="mt-4 flex flex-wrap gap-1 text-xs text-text-muted">
           {tags.map((tag, index) => (
-            <span key={`${tag}-${index}`} className="break-all">
+            <span
+              key={`${tag}-${index}`}
+              className="max-w-fit break-all rounded-md bg-gray-100 px-2 py-1 text-xs text-text-muted dark:bg-white/10"
+            >
               #{tag}
             </span>
           ))}
         </div>
+      )}
+
+      {selectedImageIndex !== null && (
+        <PostImageViewerModal
+          images={images}
+          currentIndex={selectedImageIndex}
+          onClose={handleCloseImageViewer}
+          onPrev={handlePrevImage}
+          onNext={handleNextImage}
+        />
       )}
     </div>
   )

--- a/src/features/post-detail/components/PostImageViewerModal.tsx
+++ b/src/features/post-detail/components/PostImageViewerModal.tsx
@@ -1,0 +1,76 @@
+import { ChevronLeft, ChevronRight, X } from 'lucide-react'
+
+type PostImageViewerModalProps = {
+  images: string[]
+  currentIndex: number
+  onClose: () => void
+  onPrev: () => void
+  onNext: () => void
+}
+
+export function PostImageViewerModal({
+  images,
+  currentIndex,
+  onClose,
+  onPrev,
+  onNext,
+}: PostImageViewerModalProps) {
+  const hasMultipleImages = images.length > 1
+
+  return (
+    <div
+      className="group fixed inset-0 z-50 flex items-center justify-center bg-overlay px-4 pb-20 pt-10 sm:px-12"
+      onClick={onClose}
+    >
+      {/* 닫기 버튼 */}
+      <button
+        type="button"
+        className="fixed right-4 top-4 z-20 flex size-9 items-center justify-center rounded-full bg-overlay text-text-inverse transition active:scale-90 sm:right-6 sm:top-6"
+        aria-label="이미지 전체보기 닫기"
+        onClick={onClose}
+      >
+        <X size={22} />
+      </button>
+
+      {/* 이미지 영역 */}
+      <div className="flex w-full items-center justify-center">
+        <img
+          src={images[currentIndex]}
+          alt={`게시글 이미지 ${currentIndex + 1}`}
+          className="max-h-[80vh] w-full rounded-xl object-contain"
+          onClick={(event) => event.stopPropagation()}
+        />
+      </div>
+
+      {/* 하단 이미지 이동 컨트롤 */}
+      {hasMultipleImages && (
+        <div
+          className="fixed bottom-6 left-1/2 z-20 flex -translate-x-1/2 items-center gap-3 rounded-full px-3 py-1.5 text-text-inverse transition md:opacity-0 md:group-hover:opacity-100"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <button
+            type="button"
+            className="flex size-8 items-center justify-center rounded-full bg-overlay transition active:scale-90"
+            aria-label="이전 이미지 보기"
+            onClick={onPrev}
+          >
+            <ChevronLeft size={20} />
+          </button>
+
+          <span className="min-w-10 text-center text-sm">
+            {currentIndex + 1} / {images.length}
+          </span>
+
+          <button
+            type="button"
+            className="flex size-8 items-center justify-center rounded-full bg-overlay transition active:scale-90"
+            aria-label="다음 이미지 보기"
+            onClick={onNext}
+          >
+            <ChevronRight size={20} />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #185
## ✨ 변경 내용

-게시글 상세 이미지 전체보기 모달 구현
- 이미지 클릭 시 전체보기 모달 오픈
- 여러 이미지 이전/다음 이동 기능 추가
- 배경 클릭 시 모달 닫힘 처리
- 이미지 1장일 경우 하단 컨트롤 숨김 처리
- 모바일/웹 반응형 이미지 뷰어 UI 적용
- 웹 환경에서 hover 시 하단 이미지 컨트롤 표시

## 📸 스크린샷(선택)
<img width="807" height="1064" alt="스크린샷 2026-05-06 오후 8 48 51" src="https://github.com/user-attachments/assets/b53f1628-e828-49d6-befa-99a422d774cb" />

https://github.com/user-attachments/assets/cd0e9a98-625a-4ec9-9d8a-34ab5d44ba8c



## 📚 참고사항

1. 모바일 스와이프 전환 기능은 UX상 유용하지만, 터치 이벤트 안정화 및 QA 시간이 추가로 필요해 이번 작업 범위에서는 제외했습니다.
2. 가로로 긴 이미지의 확대/줌 기능은 후속 UX 개선 범위로 제외했습니다.

- 이미지 전체보기는 object-contain 기반으로 구현되어 이미지 잘림 없이 전체가 보이도록 처리했습니다.