### PR TITLE
fix: polish post detail vote mobile UI

### DIFF
--- a/src/components/common/ui/comment/CommentInput.tsx
+++ b/src/components/common/ui/comment/CommentInput.tsx
@@ -73,7 +73,7 @@ export function CommentInput({
 
         <div className="mt-1 flex justify-end">
           <Button
-            variant="submit"
+            variant="primary"
             size="sm"
             rounded="full"
             onClick={handleSubmit}

--- a/src/components/common/ui/comment/CommentInput.tsx
+++ b/src/components/common/ui/comment/CommentInput.tsx
@@ -55,23 +55,23 @@ export function CommentInput({
       </div>
 
       {/* 입력 영역 */}
-      <div className="flex flex-1 flex-col gap-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div className="relative">
           <Textarea
             disabled={disabled}
-            className="h-14 min-h-14 max-h-30 overflow-hidden bg-gray-100 pr-20 pb-6 disabled:bg-gray-200 disabled:text-text-muted disabled:placeholder:text-gray-400 disabled:opacity-100 dark:border-white/15 dark:bg-white/5 dark:disabled:bg-white/5"
+            className="h-20 min-h-20 max-h-30 overflow-y-auto bg-gray-100 pr-16 pb-7 disabled:bg-gray-200 disabled:text-text-muted disabled:placeholder:text-gray-400 disabled:opacity-100 dark:border-white/15 dark:bg-white/5 dark:disabled:bg-white/5"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder={placeholder}
             maxLength={maxLength}
           />
 
-          <span className="absolute right-4 bottom-3 text-xs text-text-muted">
+          <span className="absolute right-6 bottom-2 text-xs text-text-muted">
             {value.length}/{maxLength}
           </span>
         </div>
 
-        <div className="flex justify-end">
+        <div className="mt-1 flex justify-end">
           <Button
             variant="submit"
             size="sm"

--- a/src/components/common/ui/toast/Toast.tsx
+++ b/src/components/common/ui/toast/Toast.tsx
@@ -37,7 +37,7 @@ export function Toast({ message, type = 'success' }: ToastProps) {
   return (
     <div
       className={cn(
-        'inline-flex w-auto max-w-[min(420px,calc(100vw-32px))] items-start justify-start gap-2 rounded-xl border-2 px-4 py-3 shadow-card-main',
+        'pointer-events-auto inline-flex w-auto max-w-[min(420px,calc(100vw-32px))] items-start justify-start gap-2 rounded-xl border-2 px-4 py-3 shadow-card-main',
         className
       )}
     >

--- a/src/components/common/ui/vote/Vote.type.ts
+++ b/src/components/common/ui/vote/Vote.type.ts
@@ -56,6 +56,8 @@ export type VoteEditorProps = {
   disabled?: boolean
   hideOptionLength?: boolean
   hideParticipantCount?: boolean
+  periodError?: string
+  actionSlot?: React.ReactNode
   onChangeOption?: (index: number, value: string) => void
   onSubmit?: () => void
   onChangePeriod?: (date: DateRange | null) => void

--- a/src/components/common/ui/vote/VoteDisplay.tsx
+++ b/src/components/common/ui/vote/VoteDisplay.tsx
@@ -18,7 +18,7 @@ export function VoteDisplay({
 }: VoteDisplayProps) {
   const isClosed = mode === VoteViewerMode.CLOSED
   const isVoted = mode === VoteViewerMode.VOTED
-  const showResult = true // 투표 결과 항상 보여주기
+  const showResult = true
 
   const hasCheckedOption = options.some((option) => option.checked)
   const isActionDisabled =
@@ -30,32 +30,45 @@ export function VoteDisplay({
       ? '투표 완료'
       : '투표하기'
 
-  const statusLabel = isClosed ? '투표 마감' : '투표 진행중'
   const hasPeriod = Boolean(period?.start && period?.end)
 
   return (
     <>
-      <div className="mb-2 flex flex-wrap items-center gap-2 text-sm">
-        <span className="text-text-primary">{statusLabel}</span>
+      {/* 상단 헤더 */}
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex w-50">
+          <div className="inline-flex items-center justify-center gap-1 px-4 py-1.5">
+            {/* 상태 dot (토큰 사용) */}
+            <span className="flex size-4 items-center justify-center">
+              <span
+                className={cn(
+                  'inline-block size-2 rounded-full',
+                  isClosed ? 'bg-gray-400 dark:bg-white/25' : 'bg-success-500'
+                )}
+              />
+            </span>
 
-        {hasPeriod && (
-          <span className="text-text-primary">
-            {formatSelectedDate(period ?? { start: null, end: null }, '')}
-          </span>
-        )}
+            {/* 날짜 */}
+            {hasPeriod && (
+              <span className="text-xs font-semibold text-text-primary">
+                {formatSelectedDate(period ?? { start: null, end: null }, '')}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {actionSlot && <div>{actionSlot}</div>}
       </div>
 
+      {/* 투표 컨테이너 */}
       <section
         className={cn(
-          'relative mx-auto min-h-62 w-full max-w-full rounded-2xl border border-border-default bg-gray-100 px-4 py-5 shadow-card-main dark:bg-white/10 sm:max-w-267.5 sm:px-6 sm:py-6',
+          'w-full rounded-2xl border border-border-default bg-gray-100 px-3 py-3 dark:bg-white/10 sm:px-3.5 sm:py-3.5',
           isClosed && 'opacity-50'
         )}
       >
-        {actionSlot && (
-          <div className="absolute top-4 right-4">{actionSlot}</div>
-        )}
-
-        <div className="flex flex-col gap-4 pt-8">
+        {/* 옵션 리스트 */}
+        <div className="flex flex-col gap-2">
           {options.map((option, index) => (
             <VoteOptionItem
               key={option.id}
@@ -68,20 +81,22 @@ export function VoteDisplay({
           ))}
         </div>
 
-        <div className="mt-8 flex justify-center">
+        {/* 버튼 */}
+        <div className="mt-4 flex justify-center sm:mt-5">
           <Button
             type="button"
             variant="primary"
             onClick={onActionClick}
             disabled={isActionDisabled}
-            className="h-10 w-full text-md sm:max-w-md"
+            className="h-10 w-full text-md disabled:bg-gray-300 disabled:text-text-muted disabled:hover:bg-gray-300 dark:disabled:bg-white/15 dark:disabled:text-white/40 dark:disabled:hover:bg-white/15 sm:max-w-md"
           >
             {buttonLabel}
           </Button>
         </div>
       </section>
 
-      <div className="mt-4 flex items-center gap-2 text-sm text-text-muted">
+      {/* 참여자 */}
+      <div className="mt-3 flex items-center gap-2 text-sm text-text-muted">
         <Users className="h-4 w-4" />
         <span>{participantCount}명 참여중</span>
       </div>

--- a/src/components/common/ui/vote/VoteDisplay.tsx
+++ b/src/components/common/ui/vote/VoteDisplay.tsx
@@ -63,7 +63,7 @@ export function VoteDisplay({
       {/* 투표 컨테이너 */}
       <section
         className={cn(
-          'w-full rounded-2xl border border-border-default bg-gray-100 px-3 py-3 dark:bg-white/10 sm:px-3.5 sm:py-3.5',
+          'w-full rounded-2xl border border-border-default  bg-gray-100 px-3 py-3 dark:bg-white/10 sm:px-3.5 sm:py-3.5',
           isClosed && 'opacity-50'
         )}
       >

--- a/src/components/common/ui/vote/VoteDisplay.tsx
+++ b/src/components/common/ui/vote/VoteDisplay.tsx
@@ -35,7 +35,7 @@ export function VoteDisplay({
 
   return (
     <>
-      <div className="mb-2 flex items-center gap-2 text-sm">
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-sm">
         <span className="text-text-primary">{statusLabel}</span>
 
         {hasPeriod && (
@@ -47,7 +47,7 @@ export function VoteDisplay({
 
       <section
         className={cn(
-          'relative mx-auto min-h-62 w-full max-w-267.5 rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main dark:bg-white/10',
+          'relative mx-auto min-h-62 w-full max-w-full rounded-2xl border border-border-default bg-gray-100 px-4 py-5 shadow-card-main dark:bg-white/10 sm:max-w-267.5 sm:px-6 sm:py-6',
           isClosed && 'opacity-50'
         )}
       >
@@ -74,7 +74,7 @@ export function VoteDisplay({
             variant="primary"
             onClick={onActionClick}
             disabled={isActionDisabled}
-            className="h-10 w-full max-w-md text-md"
+            className="h-10 w-full text-md sm:max-w-md"
           >
             {buttonLabel}
           </Button>

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -31,6 +31,8 @@ export function VoteEditor({
   disabled = false,
   hideOptionLength = false,
   hideParticipantCount = false,
+  periodError,
+  actionSlot,
   onChangeOption,
   onSubmit,
   onChangePeriod,
@@ -48,9 +50,13 @@ export function VoteEditor({
           onChange={onChangePeriod}
           label="투표 기간을 선택하세요"
         />
+
+        {periodError && (
+          <p className="mt-2 text-xs text-status-danger-text">{periodError}</p>
+        )}
       </div>
 
-      <section className="w-full rounded-2xl border border-border-default bg-gray-100 px-6 py-6 dark:bg-white/10">
+      <section className="w-full rounded-2xl border border-border-default bg-gray-100 px-4 py-4 dark:bg-white/10 sm:px-6 sm:py-6">
         <div className="flex flex-col gap-4">
           {options.map((option, index) => {
             const inputStyle = hasPeriod
@@ -62,7 +68,7 @@ export function VoteEditor({
             return (
               <div
                 key={`vote-editor-option-${index}`}
-                className="grid grid-cols-[72px_minmax(0,1fr)] items-center gap-4"
+                className="grid grid-cols-[72px_minmax(0,1fr)] items-center gap-3 sm:gap-4"
               >
                 <span
                   className={cn(
@@ -73,7 +79,7 @@ export function VoteEditor({
                   옵션 입력
                 </span>
 
-                <div className="min-w-0">
+                <div className="relative w-full min-w-0">
                   <input
                     value={option}
                     maxLength={12}
@@ -83,12 +89,12 @@ export function VoteEditor({
                     className={cn(
                       inputVariants.base,
                       inputStyle,
-                      'focus:border-focus-border'
+                      'pr-14 focus:border-focus-border'
                     )}
                   />
 
                   {!hideOptionLength && (
-                    <span className="mt-1 block text-right text-xs text-text-muted">
+                    <span className="absolute right-5 bottom-2 text-2xs text-text-muted">
                       {option.length}/12
                     </span>
                   )}
@@ -99,13 +105,13 @@ export function VoteEditor({
         </div>
 
         {onSubmit && (
-          <div className="mt-8 flex justify-center">
+          <div className="mt-6 flex justify-center sm:mt-8">
             <Button
               type="button"
               variant="primary"
               onClick={onSubmit}
               disabled={isSubmitDisabled}
-              className="h-10 w-full max-w-md"
+              className="h-10 w-full sm:max-w-md"
             >
               {submitLabel}
             </Button>
@@ -114,9 +120,13 @@ export function VoteEditor({
       </section>
 
       {!hideParticipantCount && (
-        <div className="mt-4 flex items-center gap-2 text-sm text-text-muted">
-          <Users className="h-4 w-4" />
-          <span>{participantCount}명 참여중</span>
+        <div className="mt-4 flex items-center justify-between gap-2 text-sm text-text-muted">
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            <span>{participantCount}명 참여중</span>
+          </div>
+
+          {actionSlot}
         </div>
       )}
     </>

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -5,12 +5,14 @@ import { cn } from '@/utils/cn'
 
 import { VoteEditorMode, type VoteEditorProps } from './Vote.type'
 
+const VOTE_OPTION_MAX_LENGTH = 12
+
 function getSubmitLabel(mode: VoteEditorProps['mode']) {
   return mode === VoteEditorMode.EDIT ? '투표 수정하기' : '투표 생성하기'
 }
 
 const inputVariants = {
-  base: 'h-14 w-full rounded-full px-5 text-sm outline-none placeholder:text-text-muted',
+  base: 'h-10 w-full rounded-full px-4 text-sm outline-none placeholder:text-text-muted sm:h-10 sm:px-4',
 
   enabled: {
     first:
@@ -44,21 +46,26 @@ export function VoteEditor({
 
   return (
     <>
-      <div className="mb-4">
+      <div className="mb-3">
         <Calendar
           value={period}
           onChange={onChangePeriod}
           label="투표 기간을 선택하세요"
+          className="w-full"
         />
 
         {periodError && (
-          <p className="mt-2 text-xs text-status-danger-text">{periodError}</p>
+          <p className="mt-1.5 px-4 text-xs text-status-danger-text">
+            {periodError}
+          </p>
         )}
       </div>
 
-      <section className="w-full rounded-2xl border border-border-default bg-gray-100 px-4 py-4 dark:bg-white/10 sm:px-6 sm:py-6">
-        <div className="flex flex-col gap-4">
+      <section className="w-full rounded-2xl border border-border-default bg-gray-100 px-3 py-3 dark:bg-white/10 sm:px-3.5 sm:py-3.5">
+        <div className="flex flex-col gap-2">
           {options.map((option, index) => {
+            const safeOption = option.slice(0, VOTE_OPTION_MAX_LENGTH)
+
             const inputStyle = hasPeriod
               ? index === 0
                 ? inputVariants.enabled.first
@@ -68,7 +75,7 @@ export function VoteEditor({
             return (
               <div
                 key={`vote-editor-option-${index}`}
-                className="grid grid-cols-[72px_minmax(0,1fr)] items-center gap-3 sm:gap-4"
+                className="grid grid-cols-[60px_minmax(0,1fr)] items-center gap-2 sm:grid-cols-[64px_minmax(0,1fr)]"
               >
                 <span
                   className={cn(
@@ -81,10 +88,15 @@ export function VoteEditor({
 
                 <div className="relative w-full min-w-0">
                   <input
-                    value={option}
-                    maxLength={12}
+                    value={safeOption}
+                    maxLength={VOTE_OPTION_MAX_LENGTH}
                     disabled={disabled}
-                    onChange={(e) => onChangeOption?.(index, e.target.value)}
+                    onChange={(e) =>
+                      onChangeOption?.(
+                        index,
+                        e.target.value.slice(0, VOTE_OPTION_MAX_LENGTH)
+                      )
+                    }
                     placeholder="옵션을 입력하세요"
                     className={cn(
                       inputVariants.base,
@@ -94,8 +106,8 @@ export function VoteEditor({
                   />
 
                   {!hideOptionLength && (
-                    <span className="absolute right-5 bottom-2 text-2xs text-text-muted">
-                      {option.length}/12
+                    <span className="absolute right-5 bottom-1.5 text-2xs text-text-muted">
+                      {safeOption.length}/{VOTE_OPTION_MAX_LENGTH}
                     </span>
                   )}
                 </div>
@@ -105,13 +117,13 @@ export function VoteEditor({
         </div>
 
         {onSubmit && (
-          <div className="mt-6 flex justify-center sm:mt-8">
+          <div className="mt-4 flex justify-center sm:mt-5">
             <Button
               type="button"
               variant="primary"
               onClick={onSubmit}
               disabled={isSubmitDisabled}
-              className="h-10 w-full sm:max-w-md"
+              className="h-10 w-full disabled:bg-gray-300 disabled:text-text-muted disabled:hover:bg-gray-300 dark:disabled:bg-white/15 dark:disabled:text-white/40 dark:disabled:hover:bg-white/15 sm:max-w-md"
             >
               {submitLabel}
             </Button>
@@ -120,7 +132,7 @@ export function VoteEditor({
       </section>
 
       {!hideParticipantCount && (
-        <div className="mt-4 flex items-center justify-between gap-2 text-sm text-text-muted">
+        <div className="mt-3 flex items-center justify-between gap-2 text-sm text-text-muted">
           <div className="flex items-center gap-2">
             <Users className="h-4 w-4" />
             <span>{participantCount}명 참여중</span>

--- a/src/components/common/ui/vote/VoteEditor.tsx
+++ b/src/components/common/ui/vote/VoteEditor.tsx
@@ -12,7 +12,7 @@ function getSubmitLabel(mode: VoteEditorProps['mode']) {
 }
 
 const inputVariants = {
-  base: 'h-10 w-full rounded-full px-4 text-sm outline-none placeholder:text-text-muted sm:h-10 sm:px-4',
+  base: 'h-10 w-full rounded-full px-4 text-sm shadow-sm outline-none placeholder:text-text-muted sm:h-10 sm:px-4',
 
   enabled: {
     first:

--- a/src/components/common/ui/vote/components/VoteOptionItem.tsx
+++ b/src/components/common/ui/vote/components/VoteOptionItem.tsx
@@ -14,7 +14,7 @@ type VoteOptionItemProps = {
 }
 
 const optionVariants = {
-  base: 'grid w-full grid-cols-[20px_minmax(0,1fr)_44px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]',
+  base: 'grid w-full min-w-0 grid-cols-[16px_minmax(0,1fr)_40px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]',
 
   text: {
     selected: 'text-primary-500 dark:text-white',
@@ -98,7 +98,7 @@ export function VoteOptionItem({
         </span>
       </div>
 
-      {/* 퍼센트 (색상 동일 + 스타일 통일) */}
+      {/* 퍼센트 */}
       <span className={cn('text-right text-sm font-medium', textColor)}>
         {showResult ? `${displayPercentage}%` : ''}
       </span>

--- a/src/components/common/ui/vote/components/VoteOptionItem.tsx
+++ b/src/components/common/ui/vote/components/VoteOptionItem.tsx
@@ -14,7 +14,7 @@ type VoteOptionItemProps = {
 }
 
 const optionVariants = {
-  base: 'grid w-full min-w-0 grid-cols-[16px_minmax(0,1fr)_40px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]',
+  base: 'grid w-full min-w-0 grid-cols-[16px_minmax(0,1fr)_40px] items-center gap-2 text-left sm:grid-cols-[16px_minmax(0,1fr)_40px]',
 
   text: {
     selected: 'text-primary-500 dark:text-white',
@@ -73,7 +73,7 @@ export function VoteOptionItem({
       </span>
 
       {/* 게이지 */}
-      <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm dark:bg-white/5 sm:h-14">
+      <div className="relative h-10 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm dark:bg-white/5">
         {showResult && percentage > 0 && (
           <div
             className={cn(
@@ -89,7 +89,7 @@ export function VoteOptionItem({
         {/* 게이지 내부 텍스트 */}
         <span
           className={cn(
-            'relative z-10 flex h-full min-w-0 items-center truncate px-3 text-sm font-medium sm:px-6',
+            'relative z-10 flex h-full min-w-0 items-center truncate px-4 text-sm font-medium',
             textColor
           )}
           title={option.valueLabel}

--- a/src/features/post-detail/components/PostDetailBody.tsx
+++ b/src/features/post-detail/components/PostDetailBody.tsx
@@ -152,10 +152,7 @@ export function PostDetailBody({
       {tags.length > 0 && (
         <div className="mt-4 flex flex-wrap gap-1 text-xs text-text-muted">
           {tags.map((tag, index) => (
-            <span
-              key={`${tag}-${index}`}
-              className="max-w-fit break-all rounded-md bg-gray-100 px-2 py-1 text-xs text-text-muted dark:bg-white/10"
-            >
+            <span key={`${tag}-${index}`} className="break-all">
               #{tag}
             </span>
           ))}

--- a/src/features/post-detail/components/PostDetailLayout.tsx
+++ b/src/features/post-detail/components/PostDetailLayout.tsx
@@ -92,7 +92,7 @@ export function PostDetailLayout({ post }: PostDetailLayoutProps) {
 
   return (
     <>
-      <article className="w-full max-w-300 rounded-2xl border border-border-default bg-surface px-8 py-6 shadow-card-main">
+      <article className="w-full max-w-300 rounded-2xl border border-border-default bg-white dark:bg-gray-900 px-8 py-6 shadow-card-main">
         <PostDetailHeader
           author={{
             nickname: post.nickname,

--- a/src/features/post-detail/components/PostDetailVoteSection.tsx
+++ b/src/features/post-detail/components/PostDetailVoteSection.tsx
@@ -36,8 +36,8 @@ export function PostDetailVoteSection({ post }: PostDetailVoteSectionProps) {
 
   if (isEditMode) {
     return (
-      <div className="mt-6 overflow-x-auto">
-        <div className="min-w-80 rounded-2xl border border-border-default bg-surface p-4">
+      <div className="mt-6 w-full min-w-0">
+        <div className="w-full min-w-0 rounded-2xl border border-border-default bg-surface p-4">
           <VoteEditor
             mode="edit"
             options={editOptions}
@@ -45,24 +45,23 @@ export function PostDetailVoteSection({ post }: PostDetailVoteSectionProps) {
             onChangeOption={handleChangeEditOption}
             onChangePeriod={handleChangeEditPeriod}
             onSubmit={handleUpdateVote}
+            actionSlot={
+              <button
+                type="button"
+                className="text-sm text-text-muted"
+                onClick={handleCancelEdit}
+              >
+                취소
+              </button>
+            }
           />
-
-          <div className="mt-3 flex justify-end gap-2">
-            <button
-              type="button"
-              className="text-sm text-text-muted"
-              onClick={handleCancelEdit}
-            >
-              취소
-            </button>
-          </div>
         </div>
       </div>
     )
   }
   return (
-    <div className="mt-6 overflow-x-auto">
-      <div className="min-w-80 rounded-2xl border border-border-default bg-surface p-4">
+    <div className="mt-6 w-full min-w-0">
+      <div className="w-full min-w-0 rounded-2xl border border-border-default bg-surface p-4">
         <VoteDisplay
           mode={getVoteMode(post.voteInfo, voteDetail?.is_voted)}
           options={toVoteDisplayOptions(voteDetail, selectedOptionId)}

--- a/src/features/post-detail/components/PostGoalSection.tsx
+++ b/src/features/post-detail/components/PostGoalSection.tsx
@@ -41,9 +41,9 @@ export function PostGoalSection({
 
   return (
     <section className="mt-8">
-      <div className="relative min-h-60">
+      <div className="flex flex-col gap-6 sm:relative sm:min-h-60">
         {/* 왼쪽 영역 */}
-        <div className="flex w-64.75 flex-col gap-2">
+        <div className="flex w-full flex-col gap-2 sm:w-64.75">
           {/* 헤더 */}
           <div className="flex items-center justify-between">
             <h3 className="text-base font-bold text-text-primary">개별 목표</h3>
@@ -63,7 +63,7 @@ export function PostGoalSection({
         </div>
 
         {/* 그래프 */}
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        <div className="flex justify-center sm:absolute sm:left-1/2 sm:top-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2">
           <DonutChart progressRate={progressRate} status={status} size={220} />
         </div>
       </div>

--- a/src/features/post/components/PostFormLayout.tsx
+++ b/src/features/post/components/PostFormLayout.tsx
@@ -108,6 +108,7 @@ export function PostFormLayout({
           mode={mode}
           options={form.voteOptions}
           period={form.votePeriod}
+          periodError={form.votePeriodError}
           onChangeOption={form.changeVoteOption}
           onChangePeriod={form.changeVotePeriod}
           isExistingVoteLocked={form.isExistingVoteLocked}

--- a/src/features/post/components/PostVoteSection.tsx
+++ b/src/features/post/components/PostVoteSection.tsx
@@ -8,6 +8,7 @@ type PostVoteSectionProps = {
   mode: PostFormMode
   options: string[]
   period?: DateRange
+  periodError?: string
   onChangeOption: (index: number, value: string) => void
   onChangePeriod: (date: DateRange | null) => void
   isExistingVoteLocked?: boolean
@@ -22,6 +23,7 @@ export function PostVoteSection({
   mode,
   options,
   period,
+  periodError,
   onChangeOption,
   onChangePeriod,
   isExistingVoteLocked = false,
@@ -30,8 +32,9 @@ export function PostVoteSection({
     return (
       <>
         <p className="text-sm text-text-muted">
-          기존 투표는 수정 페이지에서 변경할 수 없습니다. 투표 수정은
-          상세페이지에서 진행해주세요.
+          기존 투표는 수정 페이지에서 변경할 수 없습니다.
+          <br />
+          투표 수정은 상세페이지에서 진행해주세요.
         </p>
 
         <div className="mb-2 flex items-center gap-2 text-sm">
@@ -82,6 +85,7 @@ export function PostVoteSection({
         mode={mode}
         options={options}
         period={period}
+        periodError={periodError}
         onChangeOption={onChangeOption}
         onChangePeriod={onChangePeriod}
         hideParticipantCount

--- a/src/features/post/components/PostVoteSection.tsx
+++ b/src/features/post/components/PostVoteSection.tsx
@@ -43,21 +43,22 @@ export function PostVoteSection({
             {formatDate(period?.start)} ~ {formatDate(period?.end)}
           </span>
         </div>
-        <section className="relative mx-auto min-h-62 w-full max-w-267.5 rounded-2xl border border-border-default bg-gray-100 px-6 py-6 shadow-card-main dark:bg-white/10">
-          <div className="flex flex-col gap-4 pt-8">
+
+        <section className="w-full rounded-2xl border border-border-default bg-gray-100 px-4 py-5 shadow-card-main dark:bg-white/10">
+          <div className="flex flex-col gap-4">
             {options.map((option, index) => {
               const isFirst = index === 0
 
               return (
                 <div
                   key={`${option}-${index}`}
-                  className="grid w-full grid-cols-[20px_minmax(0,1fr)_44px] items-center gap-2 text-left sm:grid-cols-[24px_minmax(0,1fr)_56px]"
+                  className="grid w-full grid-cols-[28px_minmax(0,1fr)] items-center gap-3 text-left sm:grid-cols-[32px_minmax(0,1fr)]"
                 >
-                  <span className="flex items-center justify-center">
+                  <span className="flex items-center justify-center pl-1">
                     <span className="flex size-4 items-center justify-center rounded-sm bg-gray-300 dark:bg-white/20" />
                   </span>
 
-                  <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 shadow-sm dark:bg-white/10 sm:h-14">
+                  <div className="relative h-12 min-w-0 overflow-hidden rounded-full bg-gray-100 dark:bg-white/10">
                     <div
                       className={cn(
                         'absolute inset-y-0 left-0 rounded-full',
@@ -66,7 +67,7 @@ export function PostVoteSection({
                       style={{ width: '0%' }}
                     />
 
-                    <span className="relative z-10 flex h-full min-w-0 items-center truncate px-3 text-sm font-medium text-text-primary sm:px-6">
+                    <span className="relative z-10 flex h-full min-w-0 items-center truncate px-4 text-sm font-medium text-text-primary">
                       {option}
                     </span>
                   </div>

--- a/src/features/post/hooks/usePostForm.ts
+++ b/src/features/post/hooks/usePostForm.ts
@@ -198,7 +198,7 @@ export function usePostForm(
     }
 
     if (hasStartedVoteInput && validVoteOptions.length < 2) {
-      setVotePeriodError('투표 옵션을 2개 이상 입력해주세요.')
+      setVotePeriodError('투표 옵션을 입력해주세요.')
       throw new Error('vote-options-required')
     }
 

--- a/src/features/post/hooks/usePostForm.ts
+++ b/src/features/post/hooks/usePostForm.ts
@@ -65,6 +65,7 @@ export function usePostForm(
     if (!startDate || !endDate) return undefined
     return { start: new Date(startDate), end: new Date(endDate) }
   })
+  const [votePeriodError, setVotePeriodError] = useState('')
 
   // 목표
   const [selectedGoalId, setSelectedGoalId] = useState<number | undefined>(
@@ -164,7 +165,17 @@ export function usePostForm(
   function changeVotePeriod(date: DateRange | null) {
     if (isExistingVoteLocked) return
 
-    setVotePeriod(date ?? undefined)
+    setVotePeriodError('')
+
+    if (!date) {
+      setVotePeriod(undefined)
+      return
+    }
+
+    setVotePeriod({
+      start: date.start,
+      end: date.end ?? date.start,
+    })
   }
 
   // 최종 payload 빌드 — imageUrl이 확정된 이미지만 포함
@@ -177,9 +188,21 @@ export function usePostForm(
       .filter((option) => option.trim() !== '')
       .map((option) => option.trim())
 
-    const hasActiveVote =
-      Boolean(votePeriod?.start && votePeriod?.end) &&
-      validVoteOptions.length >= 2
+    const hasEnteredVoteOptions = validVoteOptions.length > 0
+    const hasSelectedVotePeriod = Boolean(votePeriod?.start && votePeriod?.end)
+    const hasStartedVoteInput = hasEnteredVoteOptions || hasSelectedVotePeriod
+
+    if (hasStartedVoteInput && !hasSelectedVotePeriod) {
+      setVotePeriodError('투표 기간을 선택해주세요.')
+      throw new Error('vote-period-required')
+    }
+
+    if (hasStartedVoteInput && validVoteOptions.length < 2) {
+      setVotePeriodError('투표 옵션을 2개 이상 입력해주세요.')
+      throw new Error('vote-options-required')
+    }
+
+    const hasActiveVote = hasSelectedVotePeriod && validVoteOptions.length >= 2
 
     // 기존 투표가 없고, 새 투표 입력값이 유효할 때만 vote payload 전송
     const shouldSendVote = hasActiveVote && !initialHasVote
@@ -234,6 +257,7 @@ export function usePostForm(
     selectedTagIds,
     voteOptions,
     votePeriod,
+    votePeriodError,
     selectedGoalId,
 
     // 파생

--- a/src/index.css
+++ b/src/index.css
@@ -592,3 +592,13 @@ input:-webkit-autofill:focus {
 html {
   scrollbar-gutter: stable;
 }
+
+/* sonner toast의 fixed wrapper가 모바일에서 상단 클릭을 막는 문제 방지 */
+[data-sonner-toaster] {
+  pointer-events: none !important;
+}
+
+/* sonner toast li 자체도 모바일에서 넓은 클릭 영역을 만들기 때문에 클릭 통과 */
+[data-sonner-toast] {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
## 📌 관련 이슈

Closes #187

## ✨ 변경 내용

- 투표 수정/생성 UI 모바일 반응형 보완
- 댓글 입력 영역 줄바꿈 및 글자수 표시 위치 조정
- textarea 스크롤 UX 개선
- 투표 기간 validation 보완
- 당일 투표 등록 validation 추가
- 투표 수정 안내 문구 줄바꿈 처리
 
## 📸 스크린샷(선택)
<img width="963" height="220" alt="스크린샷 2026-05-07 오전 2 06 07" src="https://github.com/user-attachments/assets/315b1c49-2c6d-4ba6-98ca-bdd522501c29" />


<img width="970" height="321" alt="스크린샷 2026-05-07 오전 2 09 31" src="https://github.com/user-attachments/assets/2d509b50-3c93-47d1-9891-398cfe536f5e" />


<img width="544" height="908" alt="스크린샷 2026-05-07 오전 2 10 00" src="https://github.com/user-attachments/assets/18a452ff-d574-43ef-9bfc-8c6e5736abfb" />


## 📚 참고사항
- 상세 페이지 투표 수정 모드에서 모바일 UI 압축을 일부 조정했습니다.
- 모바일 UI 확인 부탁드립니다.
- 조회 모드와 수정 모드의 날짜/컨테이너 위치를 완전히 동일하게 맞추는 부분은 추가 조정 여지가 있습니다.
- 당일 종료 투표가 자정 이후에도 `in_progress`로 내려오는 문제는 백엔드 status 계산 이슈로 확인 중입니다.