### PR TITLE
fix: bug pupular post list

### DIFF
--- a/src/features/post/components/PostFormLayout.tsx
+++ b/src/features/post/components/PostFormLayout.tsx
@@ -35,7 +35,7 @@ export function PostFormLayout({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-6 p-6">
+    <form onSubmit={handleSubmit} className="flex flex-col gap-6 p-3 sm:p-6">
       {/* 이미지 업로드 */}
       <div className="flex flex-col gap-2">
         <SectionLabel label="이미지 선택" />

--- a/src/pages/PostCreatePage.tsx
+++ b/src/pages/PostCreatePage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useNavigate } from 'react-router'
 
 import { useToast } from '@/components/common/ui'
@@ -7,6 +8,10 @@ import { useCreatePostMutation } from '@/query/post'
 export function PostCreatePage() {
   const navigate = useNavigate()
   const toast = useToast()
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
 
   const { mutate: createPost, isPending } = useCreatePostMutation({
     onSuccess: () => {

--- a/src/pages/PostEditPage.tsx
+++ b/src/pages/PostEditPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router'
 
 import { useQueryClient } from '@tanstack/react-query'
@@ -16,6 +17,10 @@ export function PostEditPage() {
   const toast = useToast()
   const { id } = useParams<{ id: string }>()
   const postId = Number(id)
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
 
   const { data: post, isLoading, isError } = usePostQuery(postId)
 

--- a/src/query/post/useLikeMutation.ts
+++ b/src/query/post/useLikeMutation.ts
@@ -34,7 +34,6 @@ export function useLikeMutation({
       setLikeCount(context.prevCount)
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['posts'] })
       queryClient.invalidateQueries({ queryKey: ['postDetail', postId] })
     },
   })


### PR DESCRIPTION
## 📌 관련 이슈

Closes #190 

## ✨ 변경 내용

- useLikeMutation에 `['posts']` invalidation 제거
-->   좋아요 상태/카운트는 이미 `useLikeMutation` 내부의 local state(`useState`)로 관리되고 있어 캐시 동기화 없이도 UI가 즉시 반영되어 해결 가능하며 refetch 되어 목록 재정렬은 다른 탭이나 화면 전환 이후 복귀시 적용 됩니다.

 + 게시글 생성 / 수정 페이지 진입 시 자연스럽게 화면 상단이 보일 수 있도록 top:0 으로 스크롤 이동
 + 게시글 생성 / 수정 레이아웃에 padding 값 조절

## 📸 스크린샷(선택)

## 📚 참고사항
이제 인기순에서 좋아요 눌러도 게시글 재정렬이 되어 새로 보여지지 않고 다른 화면 이동시 다시 돌아왔을때 최신 게시글 정렬 순으로 보여 집니다.