### PR TITLE
fix: clear user-specific query cache on auth changes

### DIFF
--- a/src/query/auth/useLoginMutation.ts
+++ b/src/query/auth/useLoginMutation.ts
@@ -1,7 +1,7 @@
 import type { UseFormSetError } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { type AxiosError, isAxiosError } from 'axios'
 
 import {
@@ -26,6 +26,7 @@ export function useLoginMutation(
   options?: UseLoginMutationOptions
 ) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const setSession = useAuthStore((state) => state.setSession)
 
   // 로그인은 성공 직후 /me 조회까지 끝내서 세션을 완성합니다.
@@ -44,6 +45,7 @@ export function useLoginMutation(
     },
     onSuccess: (data) => {
       setSession(data.accessToken, data.user)
+      queryClient.removeQueries()
 
       if (options?.onSuccess) {
         options.onSuccess()

--- a/src/query/auth/useLogoutMutation.ts
+++ b/src/query/auth/useLogoutMutation.ts
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router'
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { AxiosError } from 'axios'
 
 import {
@@ -23,6 +23,7 @@ import { useAuthStore } from '@/store/authStore'
 // 로그아웃 관련 로직을 캡슐화한 커스텀 훅
 export function useLogoutMutation() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const toast = useToast()
   const clearSession = useAuthStore((state) => state.clearSession)
 
@@ -31,6 +32,7 @@ export function useLogoutMutation() {
   // - 로그인 페이지로 이동
   const finishLogout = () => {
     clearSession()
+    queryClient.removeQueries()
     navigate('/')
   }
 

--- a/src/query/auth/useSignupMutation.ts
+++ b/src/query/auth/useSignupMutation.ts
@@ -1,7 +1,7 @@
 import type { UseFormSetError } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { type AxiosError, isAxiosError } from 'axios'
 
 import {
@@ -26,6 +26,7 @@ export function useSignupMutation(
   options?: UseSignupMutationOptions
 ) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const setSession = useAuthStore((state) => state.setSession)
 
   // 회원가입은 성공 직후 로그인과 /me 조회까지 끝내서 세션을 완성합니다.
@@ -49,6 +50,7 @@ export function useSignupMutation(
     },
     onSuccess: (data) => {
       setSession(data.accessToken, data.user)
+      queryClient.removeQueries()
 
       if (options?.onSuccess) {
         options.onSuccess()

--- a/src/query/heatmap/useHeatmapQuery.ts
+++ b/src/query/heatmap/useHeatmapQuery.ts
@@ -9,6 +9,7 @@ import type {
   HeatmapDetail,
   HeatmapRequestParams,
 } from '@/features/my-page/heatmap/heatmap.api.types'
+import { useAuthStore } from '@/store/authStore'
 
 // staleTime: 3분 동안은 fresh 상태로 간주 (재요청 방지)
 // - 같은 기간 데이터를 반복 조회할 때 불필요한 API 호출 줄이기
@@ -18,12 +19,17 @@ const HEATMAP_STALE_TIME = 3 * 60 * 1000
 // - params: { start, end } 기간을 기준으로 heatmap 데이터 요청
 // - queryKey에 기간을 포함시켜 캐싱 분리
 export function useHeatmapQuery(params: HeatmapRequestParams) {
+  const accessToken = useAuthStore((state) => state.accessToken)
+  const user = useAuthStore((state) => state.user)
+  const userCacheKey = user?.id ?? user?.nickname ?? 'guest'
+
   return useQuery<HeatmapDetail, AxiosError<ApiErrorResponse>>({
-    // - start/end 값이 바뀌면 다른 쿼리로 인식 (캐시 분리)
-    queryKey: ['heatmap', params.start, params.end],
+    // - user/start/end 값이 바뀌면 다른 쿼리로 인식 (캐시 분리)
+    queryKey: ['heatmap', userCacheKey, params.start, params.end],
     // - 실제 API 호출
     // - res.data.detail만 반환해서 UI에서 바로 사용 가능하게 정리
     queryFn: () => heatmapApi.getHeatmap(params).then((res) => res.data.detail),
+    enabled: Boolean(accessToken && user),
     // - 지정 시간 동안은 데이터 재요청 없이 캐시 사용
     staleTime: HEATMAP_STALE_TIME,
   })


### PR DESCRIPTION
## 📌 관련 이슈

Closes #202

## ✨ 변경 내용

  - 계정 전환 시 이전 유저의 잔디 캐시가 재사용되지 않도록 query key에 유저 식별자를 추가
  - 로그인/회원가입/로그아웃 시 React Query 캐시를 초기화하도록 처리
  - 로그인 유저 정보가 없을 때 잔디 조회가 실행되지 않도록 조건을 추가

## 📸 스크린샷(선택)

## 📚 참고사항
